### PR TITLE
ioctl: add custom packing for SIOCGIFCONF ioctl

### DIFF
--- a/src/posix/posix_private.h
+++ b/src/posix/posix_private.h
@@ -89,6 +89,12 @@ typedef struct {
 } process_info_t;
 
 
+/* SIOCGIFCONF ioctl special case: arg is structure with pointer */
+struct ifconf {
+	int ifc_len;    /* size of buffer */
+	char *ifc_buf;  /* buffer address */
+};
+
 extern void splitname(char *path, char **base, char **dir);
 
 


### PR DESCRIPTION
Argument to this particular ioctl is a structure with pointer to additional buffer inside. It has to be custom-mapped to msg structure to pass all the data to the receiver.