### PR TITLE
Fixed waitpid-related races 

### DIFF
--- a/src/posix/posix.c
+++ b/src/posix/posix.c
@@ -366,9 +366,6 @@ int posix_exit(process_t *process)
 	proc_lockDone(&p->lock);
 	vm_kfree(p);
 
-	if (process->parent != NULL)
-		posix_tkill(process->parent->id, NULL, SIGCHLD);
-
 	return 0;
 
 }
@@ -1989,6 +1986,12 @@ int posix_tkill(pid_t pid, int tid, int sig)
 
 		return EOK;
 	}
+}
+
+
+void posix_sigchild(pid_t ppid)
+{
+	posix_tkill(ppid, NULL, SIGCHLD);
 }
 
 

--- a/src/posix/posix.h
+++ b/src/posix/posix.h
@@ -131,6 +131,9 @@ extern int posix_utimes(const char *filename, const struct timeval *times);
 extern int posix_tkill(pid_t pid, int tid, int sig);
 
 
+extern void posix_sigchild(pid_t ppid);
+
+
 extern int posix_setpgid(pid_t pid, pid_t pgid);
 
 

--- a/src/proc/process.c
+++ b/src/proc/process.c
@@ -189,7 +189,6 @@ void proc_kill(process_t *proc)
 	proc_resourcesFree(proc);
 	proc_portsDestroy(proc);
 	posix_exit(proc);
-	proc_zombie(proc);
 
 	if (proc == proc_current()->process)
 		proc_threadDestroy();

--- a/src/proc/process.c
+++ b/src/proc/process.c
@@ -156,12 +156,6 @@ void proc_kill(process_t *proc)
 {
 	process_t *child, *init;
 
-	if (proc->parent != NULL) {
-		proc_lockSet(&proc->parent->lock);
-		LIST_REMOVE(&proc->parent->children, proc);
-		proc_lockClear(&proc->parent->lock);
-	}
-
 	init = proc_find(1);
 
 	proc_lockSet(&proc->lock);

--- a/src/proc/threads.c
+++ b/src/proc/threads.c
@@ -19,6 +19,7 @@
 #include "../../include/signal.h"
 #include "threads.h"
 #include "../lib/lib.h"
+#include "../posix/posix.h"
 #include "resource.h"
 #include "msg.h"
 #include "ports.h"
@@ -565,6 +566,7 @@ void proc_threadsDestroy(process_t *proc)
 void proc_zombie(process_t *proc)
 {
 	process_t *parent = proc->parent;
+	unsigned int ppid = parent->id;
 
 	if (parent != NULL) {
 		hal_spinlockSet(&parent->waitsl);
@@ -576,6 +578,8 @@ void proc_zombie(process_t *proc)
 			proc_threadWakeup(&parent->waitq);
 
 		hal_spinlockClear(&parent->waitsl);
+
+		posix_sigchild(ppid);
 	}
 	else {
 		hal_spinlockSet(&threads_common.spinlock);

--- a/src/proc/threads.c
+++ b/src/proc/threads.c
@@ -559,6 +559,7 @@ void proc_zombie(process_t *proc)
 	if (parent != NULL) {
 		hal_spinlockSet(&parent->waitsl);
 		proc->state = ZOMBIE;
+		LIST_REMOVE(&parent->children, proc);
 		LIST_ADD(&parent->zombies, proc);
 
 		if (parent->waitpid == -1 || (unsigned)parent->waitpid == proc->id)

--- a/src/proc/threads.c
+++ b/src/proc/threads.c
@@ -561,6 +561,9 @@ void proc_threadsDestroy(process_t *proc)
 		LIST_REMOVE_EX(&proc->threads, t, procnext, procprev);
 	}
 	hal_spinlockClear(&threads_common.spinlock);
+
+	if (proc->threads == NULL)
+		proc_zombie(proc);
 }
 
 

--- a/src/proc/threads.c
+++ b/src/proc/threads.c
@@ -510,6 +510,7 @@ void proc_threadDestroy(void)
 	int zombie = 0;
 
 	hal_spinlockSet(&threads_common.spinlock);
+	thr->process = NULL;
 	if (proc != NULL) {
 		LIST_REMOVE_EX(&proc->threads, thr, procnext, procprev);
 		zombie = (proc->threads == NULL);


### PR DESCRIPTION
Fixed:
- Moving process from children to zombie list was not atomic. Calling waitpid during this transition would incorrectly result in ECHILD.
- Process could be zombified and possibly completely cleaned up by waitpid before all it's threads (protected threads in particular) finished.
- SIGCHLD was sent before process was zombified (calling waitpid could possibly block even after receiving SIGCHLD).

Additionaly, the last thread is now being detached from it's process, while it is destroyed to avoid the need to perform many actions atomically (notifying parent waiting inside waitpid, sending SIGCHLD, zombifying the process and finally destroying the thread).