### PR TITLE
stm32: Do not clean console and change newline mode on start

### DIFF
--- a/src/hal/armv7/console-stm32l1.c
+++ b/src/hal/armv7/console-stm32l1.c
@@ -114,9 +114,8 @@ void _hal_consoleInit(void)
 	*(console_common.base + brr) = console_common.cpufreq / 9600; /* 9600 baud rate */
 	*(console_common.base + cr1) |= 0x2000;
 
-	_hal_consolePrint("\033c");
 	_hal_consolePrint("\033[2J");
-	_hal_consolePrint("\033[20h");
+	_hal_consolePrint("\033[f");
 
 	return;
 }

--- a/src/hal/armv7/console-stm32l4.c
+++ b/src/hal/armv7/console-stm32l4.c
@@ -107,9 +107,8 @@ void _hal_consoleInit(void)
 	*(console_common.base + cr1) |= 1;
 	hal_cpuDataBarrier();
 
-	_hal_consolePrint("\033c");
 	_hal_consolePrint("\033[2J");
-	_hal_consolePrint("\033[20h");
+	_hal_consolePrint("\033[f");
 
 	return;
 }


### PR DESCRIPTION
"\033c" – reset console 
"\033[2J" – clear screen
"\033[20h" – change \r to \r\n
"\033[f" – Set cursor to 0,0

I remove console resetting and changing newline mode which should not be needed.

Now it's aligned to imx6ull console.
@Maxez Please confirm if I wrote correctly :)