### PR TITLE
Makefile.riscv64: CROSS variable fix

### DIFF
--- a/src/Makefile.riscv64
+++ b/src/Makefile.riscv64
@@ -8,7 +8,7 @@
 # %LICENSE%
 #
 
-CROSS ?= riscv64-unknown-elf-
+CROSS ?= riscv64-phoenix-elf-
 SUBDIRS = hal/riscv64 $(SUBSYSTEMS)
 
 VADDR = 0000003fc0000000


### PR DESCRIPTION
As described in the README.md file:
Targets supported currently by the script:
- i386-pc-phoenix
- arm-phoenix
- riscv64-phoenix-elf

Change needed in other repositories.