### PR TITLE
armv7m7-imxrt: fix CONTROL register assignment in hal_jmp

### DIFF
--- a/src/hal/armv7/_init-imxrt.S
+++ b/src/hal/armv7/_init-imxrt.S
@@ -502,7 +502,7 @@ hal_jmp_user:
 2:
 	cpsie if
 	msr psp, r6
-	mov r5, #0x3
+	mov r5, USERCONTROL
 	msr control, r5
 	bx r4
 


### PR DESCRIPTION
When using FPU FPCA bit of CONTROL register should be set.
The assignment (value 0x3) in hal_jmp is incorrect, should
be 0x7. There is defined macro USERCONTROL which assigns
correct value when imxrt is in use.