### PR TITLE
arm/string.h: code optimization

### DIFF
--- a/src/hal/arm/string.h
+++ b/src/hal/arm/string.h
@@ -23,29 +23,26 @@ static inline void hal_memcpy(void *dst, const void *src, unsigned int l)
 {
 	__asm__ volatile
 	(" \
-		mov r1, %2; \
-		mov r3, %1; \
-		mov r4, %0; \
-		orr r2, r3, r4; \
-		ands r2, #3; \
+		orr r3, %0, %1; \
+		lsls r3, r3, #30; \
 		bne 2f; \
 	1: \
-		cmp r1, #4; \
+		cmp %2, #4; \
 		ittt hs; \
-		ldrhs r2, [r3], #4; \
-		strhs r2, [r4], #4; \
-		subshs r1, #4; \
+		ldrhs r3, [%1], #4; \
+		strhs r3, [%0], #4; \
+		subshs %2, #4; \
 		bhs 1b; \
 	2: \
-		cmp r1, #0; \
+		cmp %2, #0; \
 		ittt ne; \
-		ldrbne r2, [r3], #1; \
-		strbne r2, [r4], #1; \
-		subsne r1, #1; \
+		ldrbne r3, [%1], #1; \
+		strbne r3, [%0], #1; \
+		subsne %2, #1; \
 		bne 2b"
+	: "+r" (dst), "+r" (src), "+r" (l)
 	:
-	: "r" (dst), "r" (src), "r" (l)
-	: "r1", "r2", "r3", "r4", "memory", "cc");
+	: "r3", "memory", "cc");
 }
 
 
@@ -55,16 +52,13 @@ static inline int hal_memcmp(const void *ptr1, const void *ptr2, size_t num)
 
 	__asm__ volatile
 	(" \
-		mov r1, %1; \
-		mov r2, %2; \
-		mov r3, %3; \
 	1: \
-		cmp r3, #0; \
+		cmp %3, #0; \
 		beq 3f; \
-		sub r3, #1; \
-		ldrb r4, [r1], #1; \
-		ldrb r5, [r2], #1; \
-		cmp r4, r5; \
+		sub %3, #1; \
+		ldrb r3, [%1], #1; \
+		ldrb r4, [%2], #1; \
+		cmp r3, r4; \
 		beq 1b; \
 		blo 2f; \
 		mov %0, #1; \
@@ -72,9 +66,9 @@ static inline int hal_memcmp(const void *ptr1, const void *ptr2, size_t num)
 	2: \
 		mov %0, #-1; \
 	3: "
-	: "+r" (res)
-	: "r" (ptr1), "r" (ptr2), "r" (num)
-	: "r1", "r2", "r3", "r4", "r5", "cc");
+	: "+r" (res), "+r" (ptr1), "+r" (ptr2), "+r" (num)
+	:
+	: "r3", "r4", "memory", "cc");
 
 	return res;
 }
@@ -82,30 +76,29 @@ static inline int hal_memcmp(const void *ptr1, const void *ptr2, size_t num)
 
 static inline void hal_memset(void *dst, int v, unsigned int l)
 {
+	int v1 = v & 0xff;
+
 	__asm__ volatile
 	(" \
-		mov r1, %2; \
-		mov r3, %1; \
-		orr r3, r3, r3, lsl #8; \
-		orr r3, r3, r3, lsl #16; \
-		mov r4, %0; \
-		ands r2, r4, #3; \
+		orr %1, %1, %1, lsl #8; \
+		orr %1, %1, %1, lsl #16; \
+		lsls r3, %0, #30; \
 		bne 2f; \
 	1: \
-		cmp r1, #4; \
+		cmp %2, #4; \
 		itt hs; \
-		strhs r3, [r4], #4; \
-		subshs r1, #4; \
+		strhs %1, [%0], #4; \
+		subshs %2, #4; \
 		bhs 1b; \
 	2: \
-		cmp r1, #0; \
+		cmp %2, #0; \
 		itt ne; \
-		strbne r3, [r4], #1; \
-		subsne r1, #1; \
+		strbne %1, [%0], #1; \
+		subsne %2, #1; \
 		bne 2b"
+	: "+r"(dst), "+r" (v1), "+r" (l)
 	:
-	: "r" (dst), "r" (v & 0xff), "r" (l)
-	: "r1", "r2", "r3", "r4", "memory", "cc");
+	: "r3", "memory", "cc");
 }
 
 
@@ -117,12 +110,12 @@ static inline unsigned int hal_strlen(const char *s)
 	(" \
 	1: \
 		ldrb r1, [%1, %0]; \
+		cbz r1, 2f; \
 		add %0, #1; \
-		cmp r1, #0; \
-		bne 1b; \
-		sub %0, #1;"
-	: "+r" (k)
-	: "r" (s)
+		b 1b; \
+	2:"
+	: "+r" (k), "+r" (s)
+	:
 	: "r1", "cc");
 
 	return k;
@@ -135,27 +128,24 @@ static inline int hal_strcmp(const char *s1, const char *s2)
 
 	__asm__ volatile
 	(" \
-		mov r1, %1; \
-		mov r2, %2; \
 	1: \
-		ldrb r3, [r1], #1; \
-		ldrb r4, [r2], #1; \
-		cmp r3, #0; \
-		beq 2f; \
-		cmp r3, r4; \
+		ldrb r2, [%1], #1; \
+		ldrb r3, [%2], #1; \
+		cbz r2, 2f; \
+		cmp r2, r3; \
 		beq 1b; \
 		blo 3f; \
 		mov %0, #1; \
 		b 4f; \
 	2: \
-		cmp r4, #0; \
+		cmp r3, #0; \
 		beq 4f; \
 	3: \
 		mov %0, #-1; \
 	4: "
-	: "+r" (res)
-	: "r" (s1), "r" (s2)
-	: "r1", "r2", "r3", "r4", "cc");
+	: "+r" (res), "+r" (s1), "+r" (s2)
+	:
+	: "r2", "r3", "memory", "cc");
 
 	return res;
 }
@@ -167,17 +157,13 @@ static inline int hal_strncmp(const char *s1, const char *s2, unsigned int count
 
 	__asm__ volatile
 	(" \
-		mov r1, %1; \
-		mov r2, %2; \
-		mov r5, %3; \
 	1: \
-		cmp r5, #0; \
+		cmp %3, #0; \
 		beq 4f; \
-		sub r5, #1; \
-		ldrb r3, [r1], #1; \
-		ldrb r4, [r2], #1; \
-		cmp r3, #0; \
-		beq 2f; \
+		sub %3, #1; \
+		ldrb r3, [%1], #1; \
+		ldrb r4, [%2], #1; \
+		cbz r3, 2f; \
 		cmp r3, r4; \
 		beq 1b; \
 		blo 3f; \
@@ -189,9 +175,9 @@ static inline int hal_strncmp(const char *s1, const char *s2, unsigned int count
 	3: \
 		mov %0, #-1; \
 	4: "
-	: "+r" (res)
-	: "r" (s1), "r" (s2), "r" (count)
-	: "r1", "r2", "r3", "r4", "r5", "cc");
+	: "+r" (res), "+r" (s1), "+r" (s2), "+r" (count)
+	:
+	: "r3", "r4", "memory", "cc");
 
 	return res;
 }
@@ -199,20 +185,18 @@ static inline int hal_strncmp(const char *s1, const char *s2, unsigned int count
 
 static inline char *hal_strcpy(char *dest, const char *src)
 {
+	char *p = dest;
+
 	__asm__ volatile
 	(" \
-		mov r2, %0; \
-		mov r3, %1; \
-		ldrb r1, [r3], #1; \
 	1: \
-		strb r1, [r2], #1; \
-		cmp r1, #0; \
-		itt ne; \
-		ldrbne r1, [r3], #1; \
+		ldrb r3, [%1], #1; \
+		strb r3, [%0], #1; \
+		cmp r3, #0; \
 		bne 1b"
+	: "+r" (p), "+r" (src)
 	:
-	: "r" (dest), "r" (src)
-	: "r1", "r2", "r3", "memory", "cc");
+	: "r3", "memory", "cc");
 
 	return dest;
 }
@@ -220,25 +204,22 @@ static inline char *hal_strcpy(char *dest, const char *src)
 
 static inline char *hal_strncpy(char *dest, const char *src, size_t n)
 {
+	char *p = dest;
+
 	__asm__ volatile
 	(" \
-		mov r2, %2; \
-		mov r3, %0; \
-		mov r4, %1; \
-		ldrb r1, [r4], #1; \
-	1: \
-		cmp r2, #0; \
+		cmp %2, #0; \
 		beq 2f; \
-		sub r2, #1; \
-		strb r1, [r3], #1; \
-		cmp r1, #0; \
-		itt ne; \
-		ldrbne r1, [r4], #1; \
+	1: \
+		ldrb r3, [%1], #1; \
+		strb r3, [%0], #1; \
+		cbz r3, 2f; \
+		subs %2, #1; \
 		bne 1b; \
 	2:"
+	: "+r" (p), "+r" (src), "+r" (n)
 	:
-	: "r" (dest), "r" (src), "r" (n)
-	: "r1", "r2", "r3", "r4", "memory", "cc");
+	: "r3", "memory", "cc");
 
 	return dest;
 }


### PR DESCRIPTION
My suggestion for changes to the function code written in assembler

Major changes:
1. other use of registers,
2. use of other instructions

`mem*` - I changed the code size without changing the loop algorithm.
`str*` - practically same as generated by a compiler with the `-Os` option for functions in `c`.

Result:
* Difference in `*.img` file size

`armv7a7-imx6ull` - about `1.6kb (-Og)`
`armv7m7-stm32l152xd` - about `400b (-Os)`

`memcpy and memset` - for better performance, we can use a different algorithm in loops
