### PR TITLE
hal/ia32/string.h: code optimization

### DIFF
--- a/src/hal/ia32/string.h
+++ b/src/hal/ia32/string.h
@@ -163,8 +163,11 @@ static inline unsigned int hal_i2s(char *prefix, char *s, unsigned int i, unsign
 	char c;
 	unsigned int l, k, m;
 
-	m = hal_strlen(prefix);
-	hal_memcpy(s, prefix, m);
+	m = 0;
+	while (*prefix) {
+		s[m] = *prefix++;
+		m++;
+	}
 
 	for (k = m, l = (unsigned int)-1; l; i /= b, l /= b) {
 		if (!zero && !i)


### PR DESCRIPTION
`hal_i2s()` - replace `hal_strlen()` and `hal_memcpy()` with simple code

Improved function code 
`hal_memcpy, hal_memset, hal_memsetw., hal_in, hal_out`
is in `plo/efi`.
Question: why is it not used in this kernel?
