### PR TITLE
hal/ia32/string.h: hal_i2s() - use static const char[] instead char[]

### DIFF
--- a/src/hal/ia32/string.h
+++ b/src/hal/ia32/string.h
@@ -159,7 +159,7 @@ static inline char *hal_strncpy(char *dest, const char *src, size_t n)
 
 static inline unsigned int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
-	char digits[] = "0123456789abcdef";
+	static const char digits[] = "0123456789abcdef";
 	char c;
 	unsigned int l, k, m;
 


### PR DESCRIPTION
I don't know if it's about such a modification or using `hal_i2s ()` as a normal function.
