### PR TITLE
vm/page.c: Improved displaying pages

### DIFF
--- a/src/test/vm.c
+++ b/src/test/vm.c
@@ -62,7 +62,6 @@ void test_vm_alloc(void)
 
 	lib_printf("\n");
 	lib_printf("test: n=%d, dmax=%u, dmin=%u, size=%d:%d\n", n, (u32)dmax, (u32)dmin, minsize, maxsize);
-	lib_printf("test: ");
 	_page_showPages();
 	return;
 }

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -247,7 +247,12 @@ void _page_showSizes(void)
 
 static unsigned int page_digits(unsigned int n, unsigned int base)
 {
-	return (n < base) ? 1 : 1 + page_digits(n / base, base);
+	unsigned int d = 1;
+
+	while (n /= base)
+		d++;
+	
+	return d;
 }
 
 

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -270,9 +270,10 @@ void _page_showPages(void)
 		/* Print markers in case of memory gap */
 		if (p->addr > a) {
 			if ((rep = (p->addr - a) / SIZE_PAGE) >= 4) {
-				if ((w += page_digits(rep, 10) + 3) > 80) {
+				k = page_digits(rep, 10);
+				if ((w += k + 3) > 80) {
 					lib_printf("\nvm: ");
-					w = page_digits(rep, 10) + 7;
+					w = k + 7;
 				}
 				lib_printf("[%dx]", rep);
 			}
@@ -295,9 +296,10 @@ void _page_showPages(void)
 		}
 
 		if (rep >= 4) {
-			if ((w += page_digits(rep + 1, 10) + 3) > 80) {
+			k = page_digits(rep + 1, 10);
+			if ((w += k + 3) > 80) {
 				lib_printf("\nvm: ");
-				w = page_digits(rep + 1, 10) + 7;
+				w = k + 7;
 			}
 			lib_printf("[%d%c]", rep + 1, c);
 		}

--- a/src/vm/page.c
+++ b/src/vm/page.c
@@ -245,24 +245,40 @@ void _page_showSizes(void)
 }
 
 
+static unsigned int page_digits(unsigned int n, unsigned int base)
+{
+	return (n < base) ? 1 : 1 + page_digits(n / base, base);
+}
+
+
 void _page_showPages(void)
 {
 	addr_t a;
 	page_t *p;
-	unsigned int rep, i, k;
+	unsigned int rep, i, k, w = 4;
 	char c;
 
+	lib_printf("vm: ");
 	for (i = 0, a = 0; i < (pages.freesz + pages.allocsz) / SIZE_PAGE; i++) {
-
 		p = &pages.pages[i];
 
 		/* Print markers in case of memory gap */
 		if (p->addr > a) {
-			if ((p->addr - a) / SIZE_PAGE >= 4)
-				lib_printf("[%dx]", (p->addr - a) / SIZE_PAGE);
+			if ((rep = (p->addr - a) / SIZE_PAGE) >= 4) {
+				if ((w += page_digits(rep, 10) + 3) > 80) {
+					lib_printf("\nvm: ");
+					w = page_digits(rep, 10) + 7;
+				}
+				lib_printf("[%dx]", rep);
+			}
 			else {
-				for (k = 0; k < (p->addr - a) / SIZE_PAGE; k++)
-				lib_printf("%c", 'x');
+				for (k = 0; k < rep; k++) {
+					if (++w > 80) {
+						lib_printf("\nvm: ");
+						w = 5;
+					}
+					lib_printf("%c", 'x');
+				}
 			}
 		}
 
@@ -273,11 +289,21 @@ void _page_showPages(void)
 				break;
 		}
 
-		if (rep >= 4)
+		if (rep >= 4) {
+			if ((w += page_digits(rep + 1, 10) + 3) > 80) {
+				lib_printf("\nvm: ");
+				w = page_digits(rep + 1, 10) + 7;
+			}
 			lib_printf("[%d%c]", rep + 1, c);
+		}
 		else {
-			for (k = 0; k <= rep; k++)
+			for (k = 0; k <= rep; k++) {
+				if (++w > 80) {
+					lib_printf("\nvm: ");
+					w = 5;
+				}
 				lib_printf("%c", pmap_marker(p));
+			}
 		}
 
 		a = pages.pages[i + rep ].addr + SIZE_PAGE;
@@ -447,7 +473,6 @@ void _page_init(pmap_t *pmap, void **bss, void **top)
 	lib_printf("vm: Initializing page allocator (%d+%d)/%dKB, page_t=%d\n", (pages.allocsz - pages.bootsz) / 1024,
 		pages.bootsz / 1024, (pages.freesz + pages.allocsz ) / 1024, sizeof(page_t));
 
-	lib_printf("vm: ");
 	_page_showPages();
 
 	/* Create NULL pointer entry */


### PR DESCRIPTION
Each line displaying pages starts with "vm: " prefix. Pages displayed inside [ ] brackets (same page marker repeated more than 3 times) don't get split between lines.