### PR TITLE
hal/ia32/_init.S: removed assembler warnings

### DIFF
--- a/src/hal/ia32/_init.S
+++ b/src/hal/ia32/_init.S
@@ -158,7 +158,7 @@ _start_initap:
 	movl %eax, (0xfff0)
 	movl 4(%esi), %eax
 	movl %eax, (0xfff4)
-	subl $VADDR_KERNEL, (0xfff2) 		
+	subl $VADDR_KERNEL, (0xfff2)
 	movl %esi, (0xfff8)
 
 	movl $0x11000, %edi
@@ -246,7 +246,7 @@ _init_core:
 
 	/* mov ax, #0 */
 	.byte 0xb8, 0x00, 0x00
-	
+
 	/* mov ss, ax */
 	.byte 0x8e, 0xd0
 
@@ -267,7 +267,7 @@ _init_core:
 	outb %al, %dx
 
 	/* mov eax, cr0 */
-	.byte 0x0f, 0x20, 0xc0 
+	.byte 0x0f, 0x20, 0xc0
 
 	/* or eax, 1 */
 	.byte 0x66, 0x83, 0xc8, 0x01
@@ -298,18 +298,18 @@ _init_core_prot:
 	/* Set page directory */
 	movl %ecx, %cr3
 
- 	/* Enable big pages */
-        movl %cr4, %eax
-        orl $0x10, %eax
-        movl %eax, %cr4
-	
+	/* Enable big pages */
+	movl %cr4, %eax
+	orl $0x10, %eax
+	movl %eax, %cr4
+
 	movl %cr0, %eax
 	orl $0x80000000, %eax
 	movl %eax, %cr0
 
 	/* Switch to virtual addresses */
 	lea _init_virt, %eax
-	jmp %eax
+	jmp *%eax
 
 _init_virt:
 	/* Reload relocated GDT and IDT */
@@ -337,9 +337,9 @@ _init_core_wait:
 	movl $0x7c00, %esp
 	addl $VADDR_KERNEL, %esp
 	lea _cpu_initCore, %eax
-	call %eax
+	call *%eax
 
-	/* Signal spinlock */	
+	/* Signal spinlock */
 	xorl %eax, %eax
 	xchg (%ebx), %eax
 	hlt


### PR DESCRIPTION
Removed assembler warnings:
```
_init.S:312: Warning: indirect jmp without `*'
_init.S:340: Warning: indirect call without `*'
```
