### PR TITLE
programs.c: added conversion error check

### DIFF
--- a/src/programs.c
+++ b/src/programs.c
@@ -83,7 +83,15 @@ int programs_decode(vm_map_t *kmap, vm_object_t *kernel)
 		hal_strncpy(pr->cmdline, (char *)cpio->name + k, sizeof(pr->cmdline) - 1);
 
 		fs = programs_a2i(cpio->c_filesize);
+		if (fs == -EINVAL) {
+			lib_printf("programs: invalid filesize");
+			continue;
+		}
 		ns = programs_a2i(cpio->c_namesize);
+		if (ns == -EINVAL) {
+			lib_printf("programs: invalid namesize");
+			continue;
+		}
 
 		cpio = (void *)(((ptr_t)cpio + sizeof(cpio_newc_t) + ns + CPIO_PAD) & ~CPIO_PAD);
 


### PR DESCRIPTION
Comparing unsigned int with negative value looks not very good but `programs_a2i()` returns this value.
I don't know if it will be better in this case `continue` or `return -EINVAL`
In addition, the value returned by `programs_decode()` is not checked in `main_initthr()`.
