### PR TITLE
ia32/cpu.c: small changes in inline asm

### DIFF
--- a/src/hal/ia32/cpu.c
+++ b/src/hal/ia32/cpu.c
@@ -21,7 +21,6 @@
 #include "syspage.h"
 #include "string.h"
 #include "pmap.h"
-#include "spinlock.h"
 
 
 extern int threads_schedule(unsigned int n, cpu_context_t *context, void *arg);
@@ -171,11 +170,8 @@ u32 cpu_getEFLAGS(void)
 	__asm__ volatile
 	(" \
 		pushf; \
-		popl %%eax; \
-		movl %%eax, %0"
-	:"=g" (eflags)
-	:
-	:"eax");
+		popl %0"
+	: "=a" (eflags));
 
 	return eflags;
 }
@@ -379,11 +375,7 @@ void *_cpu_initCore(void)
 	cpu.tss[hal_cpuGetID()].esp0 = (u32)&cpu.stacks[hal_cpuGetID()][511];
 
 	/* Set task register */
-	__asm__ volatile (" \
-		movl %0, %%eax; \
-		ltr %%ax"
-	:
-	: "r" ((4 + cpu.ncpus) * 8));
+	__asm__ volatile ("ltr %%ax" : : "a" ((4 + cpu.ncpus) * 8));
 
 	return (void *)cpu.tss[hal_cpuGetID()].esp0;
 }


### PR DESCRIPTION
dissassembled code:
 ```objdump -d cpu.o```

#### cpu_getEFLAGS:
current:
```
00000000 <cpu_getEFLAGS>:
   0:   9c                      pushf  
   1:   58                      pop    %eax
   2:   89 c2                   mov    %eax,%edx
   4:   89 d0                   mov    %edx,%eax
   6:   c3                      ret    
```
new:
```
00000000 <cpu_getEFLAGS>:
   0:   9c                      pushf  
   1:   58                      pop    %eax
   2:   c3                      ret    
 ```

#### _cpu_initCore
current:
``` 
3b4:   8d 04 c5 20 00 00 00    lea    0x20(,%eax,8),%eax
3bb:   89 c0                   mov    %eax,%eax
3bd:   0f 00 d8                ltr    %ax
3c0:   a1 20 00 e0 fe          mov    0xfee00020,%eax
```
new:
```
3b4:   8d 04 c5 20 00 00 00    lea    0x20(,%eax,8),%eax
3bb:   0f 00 d8                ltr    %ax
3be:   a1 20 00 e0 fe          mov    0xfee00020,%eax
 ```

removed double 
`#include "spinlock.h"`
