### PR TITLE
ia32: Fix CPU load calculation

### DIFF
--- a/src/proc/threads.h
+++ b/src/proc/threads.h
@@ -33,14 +33,6 @@ enum { OWNSTACK = 0, PARENTSTACK };
 
 enum { READY = 0, SLEEP };
 
-typedef struct {
-	cycles_t cycl[10];
-	cycles_t cyclPrev;
-	int cyclptr;
-	time_t jiffiesptr;
-	time_t total;
-} cpu_load_t;
-
 
 typedef struct _thread_t {
 	struct _thread_t *next;
@@ -83,9 +75,9 @@ typedef struct _thread_t {
 	time_t readyTime;
 	time_t maxWait;
 
-#ifndef CPU_STM32
-	cpu_load_t load;
-#endif
+	time_t startTime;
+	time_t cpuTime;
+	time_t lastTime;
 
 	cpu_context_t *context;
 } thread_t;


### PR DESCRIPTION
Instead of calculating CPU load in a time window using TSC, which
turned out to be buggy on a multiprocessor environment, compute CPU load
as a ratio of task's CPU time and time since a task was created in
kernel's jiffies.