### PR TITLE
added missing cpu_sendIPI()

### DIFF
--- a/src/hal/arm/cpu.h
+++ b/src/hal/arm/cpu.h
@@ -402,6 +402,12 @@ extern void _hal_cpuInit(void);
 extern void _hal_platformInit(void);
 
 
+static inline void cpu_sendIPI(unsigned int cpu, unsigned int intr)
+{
+
+}
+
+
 #endif
 
 #endif

--- a/src/hal/armv7/cpu.h
+++ b/src/hal/armv7/cpu.h
@@ -379,6 +379,13 @@ extern void hal_wdgReload(void);
 
 extern void _hal_cpuInit(void);
 
+
+static inline void cpu_sendIPI(unsigned int cpu, unsigned int intr)
+{
+
+}
+
+
 #endif
 
 #endif

--- a/src/hal/riscv64/cpu.h
+++ b/src/hal/riscv64/cpu.h
@@ -502,6 +502,12 @@ static inline void hal_wdgReload(void)
 extern void _hal_cpuInit(void);
 
 
+static inline void cpu_sendIPI(unsigned int cpu, unsigned int intr)
+{
+
+}
+
+
 #endif
 
 


### PR DESCRIPTION
Fix issue #108 
I added missing cpu_sendIPI() for targets:
```
arm
armv7
riscv64
```
