### PR TITLE
lib/printf.h: fixed missing lib_putch()

### DIFF
--- a/src/lib/printf.h
+++ b/src/lib/printf.h
@@ -26,7 +26,7 @@ extern int lib_vsprintf(char *out, const char *format, va_list args);
 extern int lib_printf(const char *fmt, ...);
 
 
-extern void putch(char c);
+extern void lib_putch(char c);
 
 
 #endif


### PR DESCRIPTION
`putch()` does not exists

### My suggestion:
add `lib_puts()` to `lib/printf.c` and use it instead of `lib_printf()` where there is a string without formatting.
```
int lib_puts(const char *s)
{
	hal_consolePrint(ATTR_NORMAL, s);
	return 0;
}
```
or in `lib/printf.h`:
```
static inline int lib_puts(const char *s)
{
	hal_consolePrint(ATTR_NORMAL, s);
	return 0;
}
```
