### PR TITLE
arm: Fix object files ordering

### DIFF
--- a/hal/arm/Makefile
+++ b/hal/arm/Makefile
@@ -4,13 +4,11 @@
 # Copyright 2018, 2020 Phoenix Systems
 #
 
-
-OBJS += $(addprefix $(PREFIX_O)hal/arm/, hal.o pmap.o spinlock.o syspage.o cpu.o interrupts.o exceptions.o timer.o)
-
-
 ifneq (, $(findstring imx, $(TARGET)))
 	OBJS += $(PREFIX_O)hal/arm/_init-imx6ull.o $(PREFIX_O)hal/arm/console-imx6ull.o $(PREFIX_O)hal/arm/imx6ull.o
 endif
+
+OBJS += $(addprefix $(PREFIX_O)hal/arm/, hal.o pmap.o spinlock.o syspage.o cpu.o interrupts.o exceptions.o timer.o)
 
 #memtest: _memtest.o memtest.o
 #	@arm-phoenix-ld -o memtest.elf -e _start --section-start .init=0x907000 -z max-page-size=0x1000 _memtest.o memtest.o


### PR DESCRIPTION
Current object files ordering causes wrong order of functions inside .init section of kernel elf, due to which imx6ull won't boot correctly.