### PR TITLE
vm: Init kernel object refs counter with 0

### DIFF
--- a/vm/object.c
+++ b/vm/object.c
@@ -234,6 +234,7 @@ int _object_init(vm_map_t *kmap, vm_object_t *kernel)
 	proc_lockInit(&object_common.lock);
 	lib_rbInit(&object_common.tree, object_cmp, NULL);
 
+	kernel->refs = 0;
 	kernel->oid.port = 0;
 	kernel->oid.id = 0;
 	lib_rbInsert(&object_common.tree, &kernel->linkage);


### PR DESCRIPTION
Fixes error on imx6ull, when .bss section is not initialized with zeros.