### PR TITLE
programs.c: other check of HAL name

### DIFF
--- a/programs.c
+++ b/programs.c
@@ -60,7 +60,7 @@ int programs_decode(vm_map_t *kmap, vm_object_t *kernel)
 	if (hal_strncmp(cpio->c_magic, "070701", 6)) {
 
 		/* Happens in QEMU when programs are not page aligned. What the hell? */
-		if (!hal_strcmp(HAL, "hal/ia32/hal.h"))
+		if (!__builtin_strcmp(HAL, "hal/ia32/hal.h"))
 			cpio = (void *)(programs - 0x1000);
 
 		if (hal_strncmp(cpio->c_magic, "070701", 6)) {


### PR DESCRIPTION
The `HAL` value is known at compile time and instead of `hal_strcmp()` use `__builtin_strcmp()`.

### Other solutions
- **define variable in `Makefile`**

`Makefile`
```
ifeq ($(TARGET_SUFF), ia32)
CFLAGS += -DIA32_QEMU
endif
```
`programs.c`
```
#if defined(IA32_QEMU)
        cpio = (void *)(programs - 0x1000);
#endif
```
- **use predefined `__i386__`**

`programs.c`
```
#if defined(__ i386__)
        cpio = (void *)(programs - 0x1000);
#endif
```

