### PR TITLE
proc: Fix cpu time calculation, if current is NULL

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -542,7 +542,7 @@ static void threads_cpuTimeCalc(thread_t *current, thread_t *selected)
 		current->lastTime = now;
 	}
 
-	if (current != NULL && selected != NULL && current != selected)
+	if (selected != NULL && current != selected)
 		selected->lastTime = now;
 }
 


### PR DESCRIPTION
This should fix the abnormal cpu time rise of `init` process, when another process exits.