### PR TITLE
imxrt117x: fixed name of included file

### DIFF
--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -15,7 +15,7 @@
 
 #include "cpu.h"
 #include "console.h"
-#include "imxrt1170.h"
+#include "imxrt117x.h"
 #include "../../include/errno.h"
 #include "../../include/arch/imxrt1170.h"
 

--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -13,7 +13,7 @@
  * %LICENSE%
  */
 
-#include "imxrt1170.h"
+#include "imxrt117x.h"
 #include "interrupts.h"
 #include "pmap.h"
 #include "../../../include/errno.h"
@@ -581,8 +581,6 @@ void _imxrt_platformInit(void)
 
 void _imxrt_init(void)
 {
-	int i;
-
 	imxrt_common.aips[0] = (void *)0x40000000;
 	imxrt_common.aips[1] = (void *)0x40400000;
 	imxrt_common.aips[2] = (void *)0x40800000;

--- a/hal/armv7m/imxrt/117x/imxrt117x.h
+++ b/hal/armv7m/imxrt/117x/imxrt117x.h
@@ -57,4 +57,19 @@ extern void _imxrt_platformInit(void);
 extern void _imxrt_init(void);
 
 
+extern int _imxrt_systickInit(u32 interval);
+
+
+extern void _imxrt_systickSet(u8 state);
+
+
+extern u32 _imxrt_systickGet(void);
+
+
+extern void _imxrt_nvicSetIRQ(s8 irqn, u8 state);
+
+
+extern void _imxrt_nvicSystemReset(void);
+
+
 #endif


### PR DESCRIPTION
I corrected name of included file to imxrt117x.
I also removed some compiler warnings.
