### PR TITLE
exceptions.c: added array index corection

### DIFF
--- a/hal/arm/exceptions.c
+++ b/hal/arm/exceptions.c
@@ -86,6 +86,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	};
 	size_t i = 0;
 
+	n &= 0x7;
+
 	hal_strcpy(buff, "\nException: ");
 	hal_strcpy(buff += hal_strlen(buff), mnemonics[n]);
 	hal_strcpy(buff += hal_strlen(buff), "\n");

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -56,6 +56,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	};
 	size_t i = 0;
 
+	n &= 0xf;
+
 	hal_strcpy(buff, "\nException: ");
 	hal_strcpy(buff += hal_strlen(buff), mnemonics[n]);
 	hal_strcpy(buff += hal_strlen(buff), "\n");

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -80,6 +80,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	size_t i = 0;
 	u32 ss;
 
+	n &= 0x1f;
+
 	__asm__ volatile
 	(" \
 		xorl %%eax, %%eax; \


### PR DESCRIPTION
Such corection is in `riscv64`, in the others there is no.
