### PR TITLE
exceptions.c: changed printing new line

### DIFF
--- a/hal/arm/exceptions.c
+++ b/hal/arm/exceptions.c
@@ -118,6 +118,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 
 	i += exceptions_i2s("\nifa=", &buff[i], ctx->ifar, 16, 1);
 
+	buff[i++] = '\n';
+
 	buff[i] = 0;
 }
 
@@ -130,7 +132,6 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
-	hal_consolePrint(ATTR_BOLD, "\n");
 
 	for (;;)
 		hal_cpuHalt();

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -88,6 +88,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 
 	i += exceptions_i2s("\ncfs=", &buff[i], *(u32*)0xe000ed28, 16, 1);
 
+	buff[i++] = '\n';
+
 	buff[i] = 0;
 }
 
@@ -98,7 +100,6 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
-	hal_consolePrint(ATTR_BOLD, "\n");
 
 #ifdef NDEBUG
 	hal_cpuRestart();

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -133,6 +133,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	i += hal_i2s(" cr2=", &buff[i], ss, 16, 1);
 	/* i += hal_i2s(" thr=", &buff[i], _proc_current(), 16, 1); */
 
+	buff[i++] = '\n';
+
 	buff[i] = 0;
 
 	return;
@@ -145,7 +147,6 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
-	hal_consolePrint(ATTR_BOLD, "\n");
 	hal_cpuHalt();
 
 	return;

--- a/hal/riscv64/exceptions.c
+++ b/hal/riscv64/exceptions.c
@@ -120,7 +120,6 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
-	hal_consolePrint(ATTR_BOLD, "\n");
 
 	for (;;)
 		hal_cpuHalt();


### PR DESCRIPTION
Printing a newline with the bold attribute is probably unnecessary.
In `riscv64` line
```
buff[i++] = '\n';
```
already exists.

