### PR TITLE
Fixed freeing objects marked as OID_CONTIGUOUS + moved predefined oids from libphoenix

### DIFF
--- a/include/mman.h
+++ b/include/mman.h
@@ -24,4 +24,10 @@ enum { MAP_NONE = 0x0, MAP_NEEDSCOPY = 0x1, MAP_UNCACHED = 0x2, MAP_DEVICE = 0x4
 enum { PROT_NONE = 0x0, PROT_READ = 0x1, PROT_WRITE = 0x2, PROT_EXEC = 0x4, PROT_USER = 0x8 };
 
 
+/* Predefined oids */
+#define OID_NULL       NULL
+#define OID_PHYSMEM    (void *)-1
+#define OID_CONTIGUOUS (void *)-2
+
+
 #endif

--- a/syscalls.c
+++ b/syscalls.c
@@ -63,13 +63,13 @@ void *syscalls_mmap(void *ustack)
 	GETFROMSTACK(ustack, oid_t *, oid, 4);
 	GETFROMSTACK(ustack, offs_t, offs, 5);
 
-	if (oid == (void *)-1) {
-		o = (void *)-1;
-	}
-	else if (oid == NULL) {
+	if (oid == OID_NULL) {
 		o = NULL;
 	}
-	else if (oid == (void *)-2) {
+	else if (oid == OID_PHYSMEM) {
+		o = (void *)-1;
+	}
+	else if (oid == OID_CONTIGUOUS) {
 		if ((o = vm_objectContiguous(size)) == NULL)
 			return (void *)-1;
 	}


### PR DESCRIPTION
PR with changes on libphoenix side: [link](https://github.com/phoenix-rtos/libphoenix/pull/74)