### PR TITLE
posix: Allow creating IPv6 sockets

### DIFF
--- a/include/posix.h
+++ b/include/posix.h
@@ -106,6 +106,7 @@ struct timeval {
 
 #define AF_UNIX 1
 #define AF_INET 2
+#define AF_INET6 10
 
 #define SOCK_STREAM 1
 #define SOCK_DGRAM 2

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1478,6 +1478,7 @@ int posix_socket(int domain, int type, int protocol)
 		}
 		break;
 	case AF_INET:
+	case AF_INET6:
 		if ((err = inet_socket(domain, type, protocol)) >= 0) {
 			p->fds[fd].file->type = ftInetSocket;
 			p->fds[fd].file->oid.port = err;


### PR DESCRIPTION
For now, it seems the only change in kernel needed to support IPv6.
Changes in phoenix-rtos-lwip and libphoenix regarding IPv6 will soon get published.