### PR TITLE
Support for switching to serial mode with variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 
 VERSION="2.97 rev: "`git rev-parse --short HEAD`
-CONSOLE=vga
+CONSOLE?=vga
 KERNEL=1
 
 SIL ?= @


### PR DESCRIPTION
Change is supposed to make possible building kernel in serial mode by setting variable explicitly:

TARGET=ia32-generic CONSOLE=serial phoenix-rtos-build/build.sh ...


Referenced by:
https://github.com/phoenix-rtos/plo/pull/25
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/46