### PR TITLE
stm32l1.c: compiler warning removed

### DIFF
--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -760,8 +760,10 @@ int _stm32_systickInit(u32 interval)
 
 void _stm32_systickSet(u8 state)
 {
-	*(stm32_common.stk + stk_ctrl) &= ~(!state);
-	*(stm32_common.stk + stk_ctrl) |= !!state;
+	if (state > 0)
+		*(stm32_common.stk + stk_ctrl) |= 1;
+	else
+		*(stm32_common.stk + stk_ctrl) &= ~1;
 }
 
 


### PR DESCRIPTION
This version takes less bytes an is faster.
