### PR TITLE
Enable jtag/debuger

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -1812,7 +1812,7 @@ void _imxrt_nvicSystemReset(void)
 {
 	*(imxrt_common.scb + scb_aircr) = ((0x5fa << 16) | (*(imxrt_common.scb + scb_aircr) & (0x700)) | (1 << 0x02));
 
-	__asm__ volatile ("dsb");
+	hal_cpuDataSyncBarrier();
 
 	for(;;);
 }

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2163,9 +2163,9 @@ void _imxrt_init(void)
 
 	/* Disable unused clocks */
 	*(imxrt_common.ccm + ccm_ccgr0) = 0x00c0ffff;
-	*(imxrt_common.ccm + ccm_ccgr1) = 0x30000000;
+	*(imxrt_common.ccm + ccm_ccgr1) = 0x300c0000;
 	*(imxrt_common.ccm + ccm_ccgr2) = 0xfffff03f;
-	*(imxrt_common.ccm + ccm_ccgr3) = 0xf00c3fff;
+	*(imxrt_common.ccm + ccm_ccgr3) = 0xf00c3fcf;
 	*(imxrt_common.ccm + ccm_ccgr4) = 0x0000ff3c;
 	*(imxrt_common.ccm + ccm_ccgr5) = 0xf00f330f;
 	*(imxrt_common.ccm + ccm_ccgr6) = 0x00fc0f0f;

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2157,7 +2157,7 @@ void _imxrt_init(void)
 	_imxrt_ccmSetDiv(clk_div_ahb, 0x0);
 	_imxrt_ccmSetDiv(clk_div_ipg, 0x3);
 
-	/* Now CPU runs again on ARM PLL at 600M (with divider 2) */
+	/* Now CPU runs again on ARM PLL at 528M (with divider 2) */
 	_imxrt_ccmSetMux(clk_mux_prePeriph, 0x3);
 	_imxrt_ccmSetMux(clk_mux_periph, 0x0);
 

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2170,6 +2170,9 @@ void _imxrt_init(void)
 	*(imxrt_common.ccm + ccm_ccgr5) = 0xf00f330f;
 	*(imxrt_common.ccm + ccm_ccgr6) = 0x00fc0f0f;
 
+	hal_cpuDataSyncBarrier();
+	hal_cpuInstrBarrier();
+
 	/* Remain in run mode on wfi */
 	_imxrt_ccmSetMode(0);
 
@@ -2177,6 +2180,9 @@ void _imxrt_init(void)
 	_imxrt_ccmDeinitAudioPll();
 	_imxrt_ccmDeinitEnetPll();
 	_imxrt_ccmDeinitUsb2Pll();
+
+	/* Wait for any pending CCM div/mux handshake process to complete */
+	while (*(imxrt_common.ccm + ccm_cdhipr) & 0x1002b);
 
 	/* Allow userspace applications to access hardware registers */
 	for (i = 0; i < sizeof(imxrt_common.aips) / sizeof(imxrt_common.aips[0]); ++i) {


### PR DESCRIPTION
This commit is analogous to https://github.com/phoenix-rtos/plo/pull/26 because of the same procedure.

* The debugger functionality has been checked against to use J-Link (jtag / swd) and [pyOCD](https://github.com/pyocd/pyOCD) (using CMSIS-DAP available on the mimixrt1064-evk board).
* Also a minor update in the comment about clock freq.