### PR TITLE
imxrt: fix platformctl reboot

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -464,12 +464,6 @@ static int _imxrt_getIOisel(int isel, char *daisy)
 }
 
 
-static void _imxrt_reboot(void)
-{
-	/* TODO */
-}
-
-
 int hal_platformctl(void *ptr)
 {
 	platformctl_t *data = ptr;
@@ -526,7 +520,7 @@ int hal_platformctl(void *ptr)
 	case pctl_reboot:
 		if (data->action == pctl_set) {
 			if (data->reboot.magic == PCTL_REBOOT_MAGIC)
-				_imxrt_reboot();
+				_imxrt_nvicSystemReset();
 		}
 		else if (data->action == pctl_get) {
 			data->reboot.reason = imxrt_common.resetFlags;

--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -600,13 +600,6 @@ int _imxrt_getDevClock(int clock, int *div, int *mux, int *mfd, int *mfn, int *s
 }
 
 
-static void _imxrt_reboot(void)
-{
-	/* TODO */
-}
-
-
-
 int hal_platformctl(void *ptr)
 {
 	platformctl_t *data = ptr;
@@ -667,7 +660,7 @@ int hal_platformctl(void *ptr)
 	case pctl_reboot:
 		if (data->action == pctl_set) {
 			if (data->reboot.magic == PCTL_REBOOT_MAGIC)
-				_imxrt_reboot();
+				_imxrt_nvicSystemReset();
 		}
 		else if (data->action == pctl_get) {
 			data->reboot.reason = imxrt_common.resetFlags;


### PR DESCRIPTION
This fix enables to work the below snippet of code (as example), which is failing (`platformctl`) with `-EINVAL` on imxrt targets without the fix. Additionaly to enable `psh` to act on `reboot` command libphoenix fix is in another PR (https://github.com/phoenix-rtos/libphoenix/pull/82)

```C
platformctl_t pctl = {
       .action = pctl_set,
       .type = pctl_reboot,
       .reboot = {
              .magic = PHOENIX_REBOOT_MAGIC
        }
};
platformctl(&pctl);  
```

JIRA: RTOS-14