### PR TITLE
stm32: Fixed IRQ setting (replaced |= with =)

### DIFF
--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -13,10 +13,9 @@
  * %LICENSE%
  */
 
-#include "stm32.h"
-#include "interrupts.h"
-#include "pmap.h"
-#include "../../include/errno.h"
+#include "../stm32.h"
+#include "../interrupts.h"
+#include "../../../../include/errno.h"
 
 
 struct {
@@ -598,7 +597,10 @@ u32 _stm32_scbGetPriority(s8 excpn)
 void _stm32_nvicSetIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = stm32_common.nvic + ((u8)irqn >> 5) + (state ? nvic_iser: nvic_icer);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
+
+	hal_cpuDataSyncBarrier();
+	hal_cpuInstrBarrier();
 }
 
 
@@ -612,7 +614,7 @@ u32 _stm32_nvicGetPendingIRQ(s8 irqn)
 void _stm32_nvicSetPendingIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = stm32_common.nvic + ((u8)irqn >> 5) + (state ? nvic_ispr: nvic_icpr);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
 }
 
 

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -13,10 +13,9 @@
  * %LICENSE%
  */
 
-#include "stm32.h"
-#include "interrupts.h"
-#include "pmap.h"
-#include "../../include/errno.h"
+#include "../stm32.h"
+#include "../interrupts.h"
+#include "../../../../include/errno.h"
 
 
 struct {
@@ -505,7 +504,10 @@ u32 _stm32_scbGetPriority(s8 excpn)
 void _stm32_nvicSetIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = stm32_common.nvic + ((u8)irqn >> 5) + (state ? nvic_iser: nvic_icer);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
+
+	hal_cpuDataSyncBarrier();
+	hal_cpuInstrBarrier();
 }
 
 
@@ -519,7 +521,7 @@ u32 _stm32_nvicGetPendingIRQ(s8 irqn)
 void _stm32_nvicSetPendingIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = stm32_common.nvic + ((u8)irqn >> 5) + (state ? nvic_ispr: nvic_icpr);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
 }
 
 

--- a/hal/armv7m/stm32/stm32.h
+++ b/hal/armv7m/stm32/stm32.h
@@ -16,9 +16,9 @@
 #ifndef _HAL_STM32_H_
 #define _HAL_STM32_H_
 
-#include "cpu.h"
+#include "../cpu.h"
 #include "pmap.h"
-#include "spinlock.h"
+#include "../spinlock.h"
 
 
 #if defined(CPU_STM32L152XD) || defined(CPU_STM32L152XE)


### PR DESCRIPTION
Fixed IRQ setting on STM32 platform

## Description
|= was used to change bits in register. = should be used

## Motivation and Context
Identical change has been made on imxrt platfrom

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
