### PR TITLE
hal/syspage: move syspage_hal_t field on top of syspage_t struct

### DIFF
--- a/hal/armv7m/imxrt/syspage.h
+++ b/hal/armv7m/imxrt/syspage.h
@@ -30,6 +30,19 @@ enum { mAttrRead = 0x01, mAttrWrite = 0x02, maAtrrExec = 0x04, mAttrShareable = 
 	   mAttrCacheable = 0x10, mAttrBufferable = 0x20, /* TODO: */ };
 
 
+typedef struct {
+	struct {
+		u32 type;
+		u32 allocCnt;
+		struct {
+			u32 rbar;
+			u32 rasr;
+		} table[16] __attribute__((aligned(8)));
+		u32 map[16]; /* ((u32)-1) = map is not assigned */
+	} mpu;
+} syspage_hal_t;
+
+
 typedef struct _syspage_map_t {
 	addr_t start;
 	addr_t end;
@@ -52,6 +65,8 @@ typedef struct syspage_program_t {
 
 
 typedef struct _syspage_t {
+	syspage_hal_t hal;
+
 	struct {
 		addr_t text;
 		size_t textsz;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added syspage_hal_t field at start of syspage_t struct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Syspage unification.
[JIRA: PD-153](https://jira.phoenix-rtos.com/browse/PD-153)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
