### PR TITLE
proc: try to print exception without taking any locks

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -313,8 +313,8 @@ void proc_kill(process_t *proc)
 
 void process_dumpException(unsigned int n, exc_context_t *ctx)
 {
-	thread_t *thread = proc_current();
-	process_t *process = thread->process;
+	thread_t *thread;
+	process_t *process;
 	userintr_t *intr;
 	char buff[SIZE_CTXDUMP];
 
@@ -324,12 +324,16 @@ void process_dumpException(unsigned int n, exc_context_t *ctx)
 	posix_write(2, buff, hal_strlen(buff));
 	posix_write(2, "\n", 1);
 
+	/* use proc_current() as late as possible - to be able to print exceptions in scheduler */
+	thread = proc_current();
+	process = thread->process;
+
 	if ((intr = userintr_active()) != NULL)
-		lib_printf("in interrupt (%d) handler of process \"%s\" (%x)\n", intr->handler.n, intr->process->path, intr->process->id);
+		lib_printf("in interrupt (%u) handler of process \"%s\" (PID: %u)\n", intr->handler.n, intr->process->path, intr->process->id);
 	else if (process == NULL)
-		lib_printf("in kernel thread %x\n", thread->id);
+		lib_printf("in kernel thread %lu\n", thread->id);
 	else
-		lib_printf("in thread %d, process \"%s\" (%x)\n", thread->id, process->path, process->id);
+		lib_printf("in thread %lu, process \"%s\" (PID: %u)\n", thread->id, process->path, process->id);
 }
 
 


### PR DESCRIPTION
## Description

Currently if exception happens in scheduler - system deadlocks without
any message. Try to output at least some info before taking any
spinlock.

## Motivation and Context

Connected to phoenix-rtos/phoenix-rtos-project#138
Connected to JIRA: RTOS-69

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.
