### PR TITLE
armv7a: imx6ull: make memtest compilable again

### DIFF
--- a/hal/armv7a/Makefile
+++ b/hal/armv7a/Makefile
@@ -14,7 +14,14 @@ endif
 
 OBJS += $(addprefix $(PREFIX_O)hal/armv7a/, spinlock.o cpu.o hal.o exceptions.o)
 
-#memtest: _memtest.o memtest.o
-#	@arm-phoenix-ld -o memtest.elf -e _start --section-start .init=0x907000 -z max-page-size=0x1000 _memtest.o memtest.o
-#	@$(OBJCOPY) memtest.elf -Obinary memtest.img
 
+# HACKISH: different OBJS for memtest target
+.PHONY: memtest
+memtest: $(PREFIX_PROG)/memtest.elf $(PREFIX_PROG)/memtest.img
+memtest: OBJS:=$(addprefix $(PREFIX_O)hal/armv7a/, _memtest.o memtest.o)
+
+$(PREFIX_PROG)/memtest.elf: $(PREFIX_O)hal/armv7a/_memtest.o $(PREFIX_O)hal/armv7a/memtest.o
+	$(SIL)$(LD) $(LDFLAGS) -o $@ -e _start --section-start .init=0x907000 -z max-page-size=0x1000 $^
+
+$(PREFIX_PROG)/memtest.img: $(PREFIX_PROG)/memtest.elf
+	$(SIL)$(OBJCOPY) $< -Obinary $@


### PR DESCRIPTION
## Motivation and Context
Needed memtest for `imx6ull` platform.

JIRA: DTR-85

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
