### PR TITLE
scheduler: Fixed mapp being used as indicator if pmap is present

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -977,17 +977,15 @@ static void process_vforkThread(void *arg)
 	parent = spawn->parent;
 	posix_clone(parent->process->id);
 
-	hal_spinlockSet(&spawn->sl, &sc);
-	while (spawn->state < FORKING)
-		proc_threadWait(&spawn->wq, &spawn->sl, 0, &sc);
-
-	/* in critical section - needs to be done atomically */
 	current->process->mapp = parent->process->mapp;
 	current->process->pmapp = parent->process->pmapp;
 	current->process->sigmask = parent->process->sigmask;
 	current->process->sighandler = parent->process->sighandler;
 	pmap_switch(current->process->pmapp);
 
+	hal_spinlockSet(&spawn->sl, &sc);
+	while (spawn->state < FORKING)
+		proc_threadWait(&spawn->wq, &spawn->sl, 0, &sc);
 	hal_spinlockClear(&spawn->sl, &sc);
 
 	/* Copy parent kernel stack */

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -597,7 +597,7 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 	if (selected != NULL) {
 		threads_common.current[hal_cpuGetID()] = selected;
 
-		if (((proc = selected->process) != NULL) && (proc->mapp != NULL)) {
+		if (((proc = selected->process) != NULL) && (proc->pmapp != NULL)) {
 			/* Switch address space */
 			pmap_switch(proc->pmapp);
 			_hal_cpuSetKernelStack(selected->kstack + selected->kstacksz);


### PR DESCRIPTION
JIRA: RTOS-69

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed pmapp != NULL not being checked in scheduler

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Was causing a crach when mapp != NULL but pmapp == NULL. Caused by introducing pmapp in the first place

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
