### PR TITLE
proc: exceptions: better check for being in kernel

### DIFF
--- a/hal/armv7a/exceptions.h
+++ b/hal/armv7a/exceptions.h
@@ -69,6 +69,12 @@ extern int hal_exceptionsFaultType(unsigned int n, exc_context_t *ctx);
 extern void *hal_exceptionsFaultAddr(unsigned int n, exc_context_t *ctx);
 
 
+static inline ptr_t hal_exceptionsPC(exc_context_t *ctx)
+{
+	return ctx->pc;
+}
+
+
 extern void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n);
 
 

--- a/hal/armv7m/exceptions.h
+++ b/hal/armv7m/exceptions.h
@@ -56,6 +56,12 @@ typedef struct _exc_context_t {
 extern void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n);
 
 
+static inline ptr_t hal_exceptionsPC(exc_context_t *ctx)
+{
+	return ctx->pc;
+}
+
+
 static inline int hal_exceptionsSetHandler(unsigned int n, void (*handler)(unsigned int, exc_context_t *))
 {
 	return 0;

--- a/hal/ia32/exceptions.h
+++ b/hal/ia32/exceptions.h
@@ -93,6 +93,12 @@ static inline void *hal_exceptionsFaultAddr(unsigned int n, exc_context_t *ctx)
 }
 
 
+static inline ptr_t hal_exceptionsPC(exc_context_t *ctx)
+{
+	return ctx->eip;
+}
+
+
 extern void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n);
 
 

--- a/hal/riscv64/exceptions.h
+++ b/hal/riscv64/exceptions.h
@@ -40,6 +40,12 @@ static inline void *hal_exceptionsFaultAddr(unsigned int n, exc_context_t *ctx)
 }
 
 
+static inline ptr_t hal_exceptionsPC(exc_context_t *ctx)
+{
+	return ctx->pc;
+}
+
+
 extern void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n);
 
 

--- a/vm/map.c
+++ b/vm/map.c
@@ -665,26 +665,24 @@ static void map_pageFault(unsigned int n, exc_context_t *ctx)
 	vm_map_t *map;
 	void *vaddr, *paddr;
 	int prot;
-	int vaddrInKernel;
 
 	prot = hal_exceptionsFaultType(n, ctx);
 	vaddr = hal_exceptionsFaultAddr(n, ctx);
 	paddr = (void *)((unsigned long)vaddr & ~(SIZE_PAGE - 1));
-	vaddrInKernel = pmap_belongs(&map_common.kmap->pmap, vaddr);
 
 #ifdef PAGEFAULTSTOP
 	process_dumpException(n, ctx);
 	__asm__ volatile ("1: b 1b");
 #endif
 
-	if (vaddrInKernel) /* output exception ASAP to avoid being deadlocked on spinlock */
+	if (hal_exceptionsPC(ctx) >= VADDR_KERNEL) /* output exception ASAP to avoid being deadlocked on spinlock */
 		process_dumpException(n, ctx);
 
 	hal_cpuEnableInterrupts();
 
 	thread = proc_current();
 
-	if (thread->process != NULL && !vaddrInKernel)
+	if (thread->process != NULL && !pmap_belongs(&map_common.kmap->pmap, vaddr))
 		map = thread->process->mapp;
 	else
 		map = map_common.kmap;


### PR DESCRIPTION
## Description
Previous approach too naive (offending address could be NULL). Changed
to checking exception PC address.

## Motivation and Context

Connected to phoenix-rtos/phoenix-rtos-project#138
Connected to JIRA: RTOS-69

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
