### PR TITLE
hal/ia32/console-serial.c: change default baudrate to 115200bps

### DIFF
--- a/hal/ia32/console-serial.c
+++ b/hal/ia32/console-serial.c
@@ -104,9 +104,9 @@ __attribute__ ((section (".init"))) void _hal_consoleInit(void)
 	}
 
 	/* 115200 8n1 */
-	_console_uartWrite(lcr, 0x83);
-	_console_uartWrite(dlh, 0x01);
-	_console_uartWrite(dll, 0x20);
+	_console_uartWrite(lcr, 0x80);
+	_console_uartWrite(dll, 0x01);
+	_console_uartWrite(dlh, 0x00);
 	_console_uartWrite(lcr, 0x03);
 
 	/* disable IRQ */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed default serial console speed on ia32-generic target to 115200bps.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix uart-16550 on real PC hardware.
[JIRA: PD-86](https://jira.phoenix-rtos.com/browse/PD-86)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
