### PR TITLE
hal/imxrt10xx: Enable USB2 PLL

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2183,6 +2183,7 @@ void _imxrt_init(void)
 	_imxrt_ccmInitArmPll(88);
 	_imxrt_ccmInitSysPll(1);
 	_imxrt_ccmInitUsb1Pll(0);
+	_imxrt_ccmInitUsb2Pll(0);
 
 	_imxrt_ccmSetDiv(clk_div_arm, 0x1);
 	_imxrt_ccmSetDiv(clk_div_ahb, 0x0);
@@ -2210,7 +2211,6 @@ void _imxrt_init(void)
 	/* Power down all unused PLL */
 	_imxrt_ccmDeinitAudioPll();
 	_imxrt_ccmDeinitEnetPll();
-	_imxrt_ccmDeinitUsb2Pll();
 
 	/* Wait for any pending CCM div/mux handshake process to complete */
 	while (*(imxrt_common.ccm + ccm_cdhipr) & 0x1002b);


### PR DESCRIPTION
JIRA: RTOS-21

<!--- Provide a general summary of your changes in the Title above -->
## Description
This change enables USB2PLL on imxrt10xx MCUs.

## Motivation and Context
This change is required in order to use USB2 in host mode on imxrt1064.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
It was HW tested on imxrt1064.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
