### PR TITLE
armv7m: Change table on stack to static const char

### DIFF
--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -21,7 +21,7 @@
 
 static int exceptions_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
-	char digits[] = "0123456789abcdef";
+	static const char digits[] = "0123456789abcdef";
 	char c;
 	unsigned int l, k, m;
 


### PR DESCRIPTION
JIRA: ISC-124

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Simple change to move array to static storage.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When trying to build with -Os following error occurs:
```
arm-phoenix-ld: /path/to/project/_build/armv7m4-stm32l4x6/phoenix-rtos-kernel/hal/armv7m/exceptions.o: in function `exceptions_i2s':
/path/to/project/phoenix-rtos-kernel/hal/armv7m/exceptions.c:24: undefined reference to `memcpy'
 ```
Attempt to use memcpy seems invalid and this change does not fix it, But I think it's better to have this array in .rodata and it removes compilation error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).
Only build check

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
