### PR TITLE
hal/timer: Implemented high precision timer for STM32L4

### DIFF
--- a/hal/armv7a/cpu.h
+++ b/hal/armv7a/cpu.h
@@ -151,9 +151,8 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
-static inline time_t hal_cpuLowPower(time_t ms)
+static inline void hal_cpuLowPower(time_t us)
 {
-	return 0;
 }
 
 

--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -113,7 +113,7 @@ int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t
 }
 
 
-void hal_cpuLowPower(time_t ms)
+void hal_cpuLowPower(time_t us)
 {
 #ifdef CPU_STM32
 	spinlock_ctx_t scp;
@@ -121,8 +121,8 @@ void hal_cpuLowPower(time_t ms)
 	hal_spinlockSet(&cpu_common.busySp, &scp);
 	if (cpu_common.busy == 0) {
 		/* Don't increment jiffies if sleep was unsuccessful */
-		ms = _stm32_pwrEnterLPStop(ms);
-		timer_jiffiesAdd(1000 * ms);
+		us = _stm32_pwrEnterLPStop(us);
+		timer_jiffiesAdd(us);
 	}
 	hal_spinlockClear(&cpu_common.busySp, &scp);
 #endif

--- a/hal/armv7m/cpu.h
+++ b/hal/armv7m/cpu.h
@@ -190,7 +190,7 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
-extern void hal_cpuLowPower(time_t ms);
+extern void hal_cpuLowPower(time_t us);
 
 
 extern void hal_cpuSetDevBusy(int s);

--- a/hal/armv7m/imxrt/timer.c
+++ b/hal/armv7m/imxrt/timer.c
@@ -40,7 +40,13 @@ void timer_jiffiesAdd(time_t t)
 }
 
 
-int _timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
+void timer_setAlarm(time_t us)
+{
+	(void)us;
+}
+
+
+static int _timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 {
 	(void)n;
 	(void)arg;

--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -456,13 +456,14 @@ void _stm32_pwrEnterLPRun(u32 state)
 }
 
 
-time_t _stm32_pwrEnterLPStop(time_t ms)
+time_t _stm32_pwrEnterLPStop(time_t us)
 {
 #ifdef NDEBUG
 	u8 lprun_state = !!(*(stm32_common.pwr + pwr_cr) & (1 << 14));
 	u8 regulator_state = (*(stm32_common.pwr + pwr_csr) >> 11) & 3;
 	u32 cpuclk_state = (*(stm32_common.rcc + rcc_icscr) >> 13) & 7;
 	int slept = 0, i;
+	time_t ms = (us + 500) / 1000;
 
 	ms = _stm32_rtcSetAlarm(ms);
 

--- a/hal/armv7m/stm32/stm32.h
+++ b/hal/armv7m/stm32/stm32.h
@@ -77,7 +77,7 @@ extern void _stm32_pwrSetCPUVolt(u8 range);
 extern void _stm32_pwrEnterLPRun(u32 state);
 
 
-extern time_t _stm32_pwrEnterLPStop(time_t ms);
+extern time_t _stm32_pwrEnterLPStop(time_t us);
 
 
 extern void _stm32_rtcUnlockRegs(void);

--- a/hal/armv7m/timer.h
+++ b/hal/armv7m/timer.h
@@ -24,6 +24,9 @@
 #define TIMER_CYC2US(x) (x)
 
 
+extern void timer_setAlarm(time_t us);
+
+
 extern void timer_jiffiesAdd(time_t t);
 
 

--- a/hal/ia32/cpu.h
+++ b/hal/ia32/cpu.h
@@ -352,9 +352,8 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
-static inline void hal_cpuLowPower(time_t ms)
+static inline void hal_cpuLowPower(time_t us)
 {
-	return 0;
 }
 
 

--- a/hal/riscv64/cpu.h
+++ b/hal/riscv64/cpu.h
@@ -203,9 +203,8 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
-static inline time_t hal_cpuLowPower(time_t ms)
+static inline void hal_cpuLowPower(time_t us)
 {
-	return 0;
 }
 
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1430,7 +1430,7 @@ static void threads_idlethr(void *arg)
 		wakeup = proc_nextWakeup();
 
 		if (wakeup > TIMER_US2CYC(2000))
-			hal_cpuLowPower((TIMER_CYC2US(wakeup) + TIMER_US2CYC(500)) / TIMER_US2CYC(1000));
+			hal_cpuLowPower(TIMER_CYC2US(wakeup));
 
 		hal_cpuHalt();
 	}


### PR DESCRIPTION
Based on 32KHz crystal source
Changed wakeup timer API to use microseconds

JIRA: RTOS-79

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Use high precision timer for uptime counter

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
High precision time source is needed by ISC project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
