### PR TITLE
armv7m: unnecessary 'it' statements removed

### DIFF
--- a/hal/armv7m/imxrt/_init.S
+++ b/hal/armv7m/imxrt/_init.S
@@ -119,7 +119,6 @@ _syscall_dispatch0:
 	ldr r6, [r0, r5]
 	str r6, [sp, r5]
 	subs r5, r5, #4
-	it pl
 	bpl _syscall_dispatch0
 
 	ldr r6, =0xe000ef38
@@ -254,7 +253,6 @@ hal_cpuReschedule:
 	bl _hal_invokePendSV
 	pop {r1-r3, lr}
 	cmp r1, #NULL
-	it eq
 	beq hal_cpuReschedule0
 	push {r3-r4}
 	add r1, r1, #12

--- a/hal/armv7m/stm32/_init.S
+++ b/hal/armv7m/stm32/_init.S
@@ -229,7 +229,6 @@ hal_cpuReschedule:
 	bl _hal_invokePendSV
 	pop {r1-r3, lr}
 	cmp r1, #NULL
-	it eq
 	beq hal_cpuReschedule0
 	push {r3-r4}
 	add r1, r1, #12


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There is only a branch instruction in the `it` block.
I think `it` instruction may be removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
