### PR TITLE
armv7a/spinlock: fix inconsistency in the use of instructions with exclusive access to the memory

### DIFF
--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -792,10 +792,13 @@ hal_cpuReschedule:
 	add r0, #12
 
 	/* Spinlock clear */
+spinlock:
 	ldrexb r1, [r0]
 	add r1, r1, #1
 	dmb
 	strexb r2, r1, [r0]
+	cmp r2, #0
+	bne spinlock
 	ldrb r1, [r3]
 
 	bic r4, #0xff

--- a/hal/armv7a/spinlock.h
+++ b/hal/armv7a/spinlock.h
@@ -57,15 +57,18 @@ static inline void hal_spinlockSet(spinlock_t *spinlock, spinlock_ctx_t *sc)
 static inline void hal_spinlockClear(spinlock_t *spinlock, spinlock_ctx_t *sc)
 {
 	__asm__ volatile (" \
+	1 : \
 		ldrexb r1, [%0]; \
 		add r1, r1, #1; \
 		dmb; \
-		strb r1, [%0]; \
+		strexb r2, r1, [%0]; \
+		cmp r2, #0; \
+		bne 1b; \
 		ldrb r1, [%1]; \
 		msr cpsr_c, r1;"
 	:
 	: "r" (&spinlock->lock), "r" (sc)
-	: "r1", "memory");
+	: "r1", "r2", "memory");
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In the code alternately has been used strb or strexb, it was wrong approach. Unifed to use only strexb in spinlocks.
After usage of strexb, the status has to be checked. If the operation has failed, it has to be repeated

JIRA: PD-193

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
System has tendency to hang  on Zynq-7000. It was related to wrong spinlock implementation. The same behaviour can be observed on imx6ull.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull, zynq-7000).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
