### PR TITLE
hal/armv7m7-imxrt106x: Allow kernel console on UART5 with different bauds

### DIFF
--- a/hal/armv7m/imxrt/10xx/console.c
+++ b/hal/armv7m/imxrt/10xx/console.c
@@ -17,12 +17,17 @@
 #define UART_CONSOLE 1
 #endif
 
+#ifndef CONSOLE_BAUDRATE
+#define CONSOLE_BAUDRATE 115200
+#endif
+
 #include "cpu.h"
 #include "console.h"
 #include "imxrt10xx.h"
 #include "../../../../include/errno.h"
 #include "../../../../include/arch/imxrt.h"
 
+#define UART_CLK 80000000
 
 struct {
 	volatile u32 *uart;
@@ -31,6 +36,40 @@ struct {
 
 enum { uart_verid = 0, uart_param, uart_global, uart_pincfg, uart_baud, uart_stat, uart_ctrl,
 	uart_data, uart_match, uart_modir, uart_fifo, uart_water };
+
+
+static u32 calculate_baudrate(int baud)
+{
+	u32 osr, sbr, t, tDiff;
+	u32 bestOsr = 0, bestSbr = 0, bestDiff = (u32)baud;
+
+	if (baud <= 0)
+		return 0;
+
+	for (osr = 4; osr <= 32; ++osr) {
+		/* find sbr value in range between 1 and 8191 */
+		sbr = (UART_CLK / ((u32)baud * osr)) & 0x1fff;
+		sbr = (sbr == 0) ? 1 : sbr;
+
+		/* baud rate difference based on temporary osr and sbr */
+		tDiff = UART_CLK / (osr * sbr) - (u32)baud;
+		t = UART_CLK / (osr * (sbr + 1));
+
+		/* select best values between sbr and sbr+1 */
+		if (tDiff > (u32)baud - t) {
+			tDiff = (u32)baud - t;
+			sbr += (sbr < 0x1fff);
+		}
+
+		if (tDiff <= bestDiff) {
+			bestDiff = tDiff;
+			bestOsr = osr - 1;
+			bestSbr = sbr;
+		}
+	}
+
+	return (bestOsr << 24) | ((bestOsr <= 6) << 17) | (bestSbr & 0x1fff);
+}
 
 
 void _hal_consolePrint(const char *s)
@@ -70,6 +109,20 @@ void _hal_consoleInit(void)
 
 	_imxrt_setIOpad(pctl_pad_gpio_emc_13, 0, 0, 0, 1, 0, 2, 6, 0);
 	_imxrt_setIOpad(pctl_pad_gpio_emc_14, 0, 0, 0, 1, 0, 2, 6, 0);
+#elif UART_CONSOLE == 5
+	console_common.uart = (void *)0x40194000;
+
+	_imxrt_ccmControlGate(pctl_clk_lpuart5, clk_state_run_wait);
+
+	_imxrt_setIOmux(pctl_mux_gpio_emc_23, 0, 2);
+	_imxrt_setIOmux(pctl_mux_gpio_emc_24, 0, 2);
+
+	_imxrt_setIOisel(pctl_isel_lpuart5_tx, 0);
+	_imxrt_setIOisel(pctl_isel_lpuart5_rx, 0);
+
+	_imxrt_setIOpad(pctl_pad_gpio_emc_23, 0, 0, 0, 1, 0, 2, 6, 0);
+	_imxrt_setIOpad(pctl_pad_gpio_emc_24, 0, 0, 0, 1, 0, 2, 6, 0);
+
 #else
 	console_common.uart = (void *)0x40184000;
 
@@ -90,11 +143,8 @@ void _hal_consoleInit(void)
 	*(console_common.uart + uart_global) &= ~(1 << 1);
 	hal_cpuDataBarrier();
 
-	/* Set 115200 baudrate */
-	t = *(console_common.uart + uart_baud);
-	t = (t & ~(0x1f << 24)) | (0x4 << 24);
-	*(console_common.uart + uart_baud) = (t & ~0x1fff) | 0x8b;
-	*(console_common.uart + uart_baud) &= ~(1 << 29);
+	t = *(console_common.uart + uart_baud) & ~((0x1f << 24) | (1 << 17) | 0x1fff);
+	*(console_common.uart + uart_baud) = t | calculate_baudrate(CONSOLE_BAUDRATE);
 
 	/* Set 8 bit and no parity mode */
 	*(console_common.uart + uart_ctrl) &= ~0x117;


### PR DESCRIPTION
JIRA: BES-188

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change allows setting kernel console to UART5 and setting different baudrates using `CONSOLE_BAUDRATE` define.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed in projects, which use UART5 with baudrates other than 115200.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
