### PR TITLE
proc/name.c: fixed memory leak in proc_portRegister()

### DIFF
--- a/proc/name.c
+++ b/proc/name.c
@@ -74,6 +74,14 @@ int proc_portRegister(unsigned int port, const char *name, oid_t *oid)
 	}
 	proc_lockClear(&name_common.dcache_lock);
 
+	if (name[0] == '/' && name[1] == 0) {
+		name_common.root_oid.port = port;
+		if (oid != NULL)
+			name_common.root_oid.id = oid->id;
+		name_common.root_registered = 1;
+		return EOK;
+	}
+
 	if ((entry = vm_kmalloc(sizeof(dcache_entry_t) + hal_strlen(name) + 1)) == NULL)
 		return -ENOMEM;
 
@@ -81,12 +89,6 @@ int proc_portRegister(unsigned int port, const char *name, oid_t *oid)
 	if (oid != NULL)
 		entry->oid.id = oid->id;
 	hal_strcpy(entry->name, name);
-
-	if (name[0] == '/' && name[1] == 0) {
-		name_common.root_oid = entry->oid;
-		name_common.root_registered = 1;
-		return EOK;
-	}
 
 	proc_lockSet(&name_common.dcache_lock);
 	entry->next = name_common.dcache[hash];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
I moved root directory check before allocating memory for the variable `entry`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
