### PR TITLE
armv7a/imx6ull: remove persistent bits clearing in init

### DIFF
--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -348,12 +348,6 @@ _start:
 
 	/* WARNING: R7 - can't touch this until MMU enable */
 
-	/* Clear PERSIST_SECONDARY_BOOT bit */
-	ldr r0, =0x020d8044
-	ldr r1, [r0]
-	bic r1, r1, #(1 << 30)
-	str r1, [r0]
-
 	/* Enable PMU cycle counter */
 	mrc p15, 0, r0, c9, c12, 0
 	orr r0, #0x7


### PR DESCRIPTION
## Description
Remove persistent bit clearing at bootup to be read out later in userspace. Using psh `reboot` or disconnecting power will reset this bit anyway.

## Motivation and Context
JIRA: DTR-181

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
