### PR TITLE
posix/chmod: send atMode messages to filesystem instead of device

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -891,11 +891,11 @@ int posix_chmod(const char *pathname, mode_t mode)
 {
 	TRACE("chmod(%s, %x)", pathname, mode);
 
-	oid_t oid, ln;
+	oid_t oid;
 	msg_t msg;
 	int err;
 
-	if (proc_lookup(pathname, &ln, &oid) < 0)
+	if (proc_lookup(pathname, &oid, NULL) < 0)
 		return -ENOENT;
 
 	hal_memset(&msg, 0, sizeof(msg));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Another bad `lookup()` oid usage. `chmod()` `atMode` messages should always be sent to filesystem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-202](https://jira.phoenix-rtos.com/browse/DTR-202)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
