### PR TITLE
proc/msg: Unmap memory, when processing kernel messages

### DIFF
--- a/proc/msg.c
+++ b/proc/msg.c
@@ -155,6 +155,7 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 static void msg_release(kmsg_t *kmsg)
 {
 	process_t *process;
+	vm_map_t *map;
 
 	if (kmsg->i.bp != NULL) {
 		vm_pageFree(kmsg->i.bp);
@@ -170,9 +171,13 @@ static void msg_release(kmsg_t *kmsg)
 		kmsg->i.ep = NULL;
 	}
 
+	if ((process = proc_current()->process) != NULL)
+		map = process->mapp;
+	else
+		map = msg_common.kmap;
+
 	if (kmsg->i.w != NULL) {
-		if ((process = proc_current()->process) != NULL)
-			vm_munmap(process->mapp, kmsg->i.w, CEIL((unsigned long)kmsg->msg.i.data + kmsg->msg.i.size) - FLOOR((unsigned long)kmsg->msg.i.data));
+		vm_munmap(map, kmsg->i.w, CEIL((unsigned long)kmsg->msg.i.data + kmsg->msg.i.size) - FLOOR((unsigned long)kmsg->msg.i.data));
 		kmsg->i.w = NULL;
 	}
 
@@ -191,8 +196,7 @@ static void msg_release(kmsg_t *kmsg)
 	}
 
 	if (kmsg->o.w != NULL) {
-		if ((process = proc_current()->process) != NULL)
-			vm_munmap(process->mapp, kmsg->o.w, CEIL((unsigned long)kmsg->msg.o.data + kmsg->msg.o.size) - FLOOR((unsigned long)kmsg->msg.o.data));
+		vm_munmap(map, kmsg->o.w, CEIL((unsigned long)kmsg->msg.o.data + kmsg->msg.o.size) - FLOOR((unsigned long)kmsg->msg.o.data));
 		kmsg->o.w = NULL;
 	}
 }


### PR DESCRIPTION
JIRA: DTR-3

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This fixes memory leak when handling messages processed by kernel threads.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
