### PR TITLE
posix/unix: replace SOCK_LARGEBUF flag with SO_RCVBUF option

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -59,6 +59,7 @@
 
 #define ENOTSOCK        88
 #define EPROTOTYPE      91
+#define ENOPROTOOPT     92
 #define EPROTONOSUPPORT 93
 #define EOPNOTSUPP      95
 #define EAFNOSUPPORT    97

--- a/include/posix.h
+++ b/include/posix.h
@@ -126,6 +126,8 @@ struct timeval {
 
 #define SOL_SOCKET 0xFFF
 
+#define SO_RCVBUF 0x1002
+
 #define MSG_PEEK     0x01
 #define MSG_WAITALL  0x02
 #define MSG_OOB      0x04


### PR DESCRIPTION
Socket receive buffer reallocation is not supported yet.

DONE: DTR-209

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
