### PR TITLE
vm: set page mapsz to -1 on non-mmu targets

### DIFF
--- a/vm/page-nommu.c
+++ b/vm/page-nommu.c
@@ -159,6 +159,7 @@ void vm_pageinfo(meminfo_t *info)
 	info->page.free = pages.freesz;
 	info->page.boot = pages.bootsz;
 	info->page.sz = sizeof(page_t);
+	info->page.mapsz = -1;
 
 	proc_lockClear(&pages.lock);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- Set `page.mapsz` to `-1` on non-mmu targets.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When calling `vm_pageinfo` on non-mmu targets `page.mapsz` and `page.map` values remain uninitialized. For clarity, `page.map` isn't initialized the suggestion is to set `page.mapsz` to `-1`.
Related to:
https://github.com/phoenix-rtos/phoenix-rtos-project/issues/281
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m7-imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
