### PR TITLE
Add helper macros for managing file permission bits + simplify chmod() + clean up code

### DIFF
--- a/include/posix.h
+++ b/include/posix.h
@@ -44,24 +44,56 @@ struct sockaddr {
 };
 
 
-#define S_IFMT   0170000
-#define S_IFIFO  0010000
-#define S_IFCHR  0020000
-#define S_IFDIR  0040000
-#define S_IFBLK  0060000
-#define S_IFREG  0100000
-#define S_IFLNK  0120000
-#define S_IFSOCK 0140000
+/* File type */
+#define S_IFMT   0xf000 /* File type mask */
+#define S_IFSOCK 0xc000 /* Socket */
+#define S_IFLNK  0xa000 /* Symbolic link */
+#define S_IFREG  0x8000 /* Regular file */
+#define S_IFBLK  0x6000 /* Block device */
+#define S_IFDIR  0x4000 /* Directory */
+#define S_IFCHR  0x2000 /* Character device */
+#define S_IFIFO  0x1000 /* FIFO */
 
-#define S_BLKSIZE 512
+#define S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK) /* Socket */
+#define S_ISLNK(m)  (((m) & S_IFMT) == S_IFLNK)  /* Symbolic link */
+#define S_ISREG(m)  (((m) & S_IFMT) == S_IFREG)  /* Regular file */
+#define S_ISBLK(m)  (((m) & S_IFMT) == S_IFBLK)  /* Block device */
+#define S_ISDIR(m)  (((m) & S_IFMT) == S_IFDIR)  /* Directory */
+#define S_ISCHR(m)  (((m) & S_IFMT) == S_IFCHR)  /* Character device */
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)  /* FIFO */
 
-#define S_ISDIR(m)  (((m) & (0170000)) == 0040000)
-#define S_ISCHR(m)  (((m) & (0170000)) == 0020000)
-#define S_ISBLK(m)  (((m) & (0170000)) == 0060000)
-#define S_ISREG(m)  (((m) & (0170000)) == 0100000)
-#define S_ISFIFO(m) (((m) & (0170000)) == 0010000)
-#define S_ISLNK(m)  (((m) & (0170000)) == 0120000)
-#define S_ISSOCK(m) (((m) & (0170000)) == 0140000)
+/* File permissions */
+#define S_ISUID 0x0800 /* Set user ID on execution */
+#define S_ISGID 0x0400 /* Set group ID on execution */
+#define S_ISVTX 0x0200 /* Sticky bit */
+
+#define S_IRWXU 0x01c0 /* RWX mask for owner */
+#define S_IRUSR 0x0100 /* R for owner */
+#define S_IWUSR 0x0080 /* W for owner */
+#define S_IXUSR 0x0040 /* X for owner */
+
+#define S_IRWXG 0x0038 /* RWX mask for group */
+#define S_IRGRP 0x0020 /* R for group */
+#define S_IWGRP 0x0010 /* W for group */
+#define S_IXGRP 0x0008 /* X for group */
+
+#define S_IRWXO 0x0007 /* RWX mask for other */
+#define S_IROTH 0x0004 /* R for other */
+#define S_IWOTH 0x0002 /* W for other */
+#define S_IXOTH 0x0001 /* X for other */
+
+/* BSD compatibility macros */
+#define S_ISTXT  S_ISVTX
+#define S_IREAD  S_IRUSR
+#define S_IWRITE S_IWUSR
+#define S_IEXEC  S_IXUSR
+
+#define S_BLKSIZE 512 /* Block size (stat.st_blocks unit) */
+
+#define ALLPERMS    (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO) /* 07777 */
+#define ACCESSPERMS (S_IRWXU | S_IRWXG | S_IRWXO)                               /* 0777 */
+#define DEFFILEMODE (S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH) /* 0666 */
+
 
 #define SEEK_SET 0
 #define SEEK_CUR 1

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -901,15 +901,9 @@ int posix_chmod(const char *pathname, mode_t mode)
 	hal_memset(&msg, 0, sizeof(msg));
 	hal_memcpy(&msg.i.attr.oid, &oid, sizeof(oid));
 
-	msg.type = mtGetAttr;
-	msg.i.attr.type = atMode;
-
-	if (((err = proc_send(oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))
-		return err;
-
 	msg.type = mtSetAttr;
 	msg.i.attr.type = atMode;
-	msg.i.attr.val = (msg.o.attr.val & ~0777) | (mode & 0777);
+	msg.i.attr.val = mode & ALLPERMS;
 
 	if (((err = proc_send(oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))
 		return err;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added `ALLPERMS` and `ACCESSPERMS` macros (the names are taken from BSD: [link](https://github.com/openbsd/src/blob/4cd1828ed9eeebb6486d183eb7e4a99fc9464b70/sys/sys/stat.h#L151-L153))
Cleaned up file type and permission bits macros (removed octal notation in favour of hexedecimal).
Simplified `posix_chmod()` implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Code that manages file permissions should use provided macros instead of 'magic values', e.g. `0777`.
[JIRA: RTOS-148](https://jira.phoenix-rtos.com/browse/RTOS-148)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/libphoenix/pull/160
https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/59
- [ ] I will merge this PR by myself when appropriate.
