### PR TITLE
posix/waitpid: Fixed waitpid with WNOHANG when there's a zombie,

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2375,7 +2375,7 @@ int posix_waitpid(pid_t child, int *status, int options)
 		}
 		while (!found && (c = c->next) != pinfo->zombies);
 	}
-	while (!found);
+	while (!found && !(options & 1));
 	proc_lockClear(&pinfo->lock);
 
 	if (found) {


### PR DESCRIPTION
but of a process we don't wait for

JIRA: RTOS-155

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Case when there is a zombie, but of a different process than the one we're waiting for wasn't handled at all - caused tight loop in waitpid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes problem found in waitpid test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
