### PR TITLE
imx6ull: fix indentation in memory test makefile

### DIFF
--- a/hal/armv7a/imx6ull/Makefile
+++ b/hal/armv7a/imx6ull/Makefile
@@ -9,7 +9,7 @@ OBJS += $(addprefix $(PREFIX_O)hal/armv7a/imx6ull/, _init.o console.o imx6ull.o 
 $(PREFIX_O)hal/armv7a/imx6ull/_init.o: hal/armv7a/_armv7a.S hal/armv7a/_interrupts.S
 
 ifdef MEMTEST_SHORT
-	CFLAGS += -DMEMTEST_SHORT
+  CFLAGS += -DMEMTEST_SHORT
 endif
 
 # TODO: remove after introducing plo

--- a/hal/armv7a/imx6ull/memtest.c
+++ b/hal/armv7a/imx6ull/memtest.c
@@ -273,6 +273,7 @@ int test_ddrAll(void)
 }
 
 
+#ifdef MEMTEST_SHORT
 static void test_ddrShort(void)
 {
 	int errors;
@@ -283,6 +284,7 @@ static void test_ddrShort(void)
 	test_ddrPrintUint(errors);
 	test_ddrPutch('\n');
 }
+#endif
 
 
 void test_ddr(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As the title says, change tab to two spaces. Also do not define short ddr test if `MEMTEST_SHORT` is not defined

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
