### PR TITLE
hal/armv7a: cache management in pmap

### DIFF
--- a/hal/armv7a/_armv7a.S
+++ b/hal/armv7a/_armv7a.S
@@ -5,7 +5,7 @@
  *
  * Low-level hal functions for Cortex-A9
  *
- * Copyright 2018, 2020, 2021 Phoenix Systems
+ * Copyright 2018, 2020, 2021-2022 Phoenix Systems
  * Author: Pawel Pisarczyk, Aleksander Kaminski, Maciej Purski, Hubert Buczynski
  *
  * This file is part of Phoenix-RTOS.
@@ -26,111 +26,187 @@ hal_cpuGetCycles:
 	str r1, [r0]
 	bx lr
 .size hal_cpuGetCycles, .-hal_cpuGetCycles
-
-
-.globl hal_cpuInvalDataCache
-.type hal_cpuInvalDataCache, %function
-hal_cpuInvalDataCache:
-	ldr r1, =SIZE_CACHE_LINE - 1
-	bic r0, r0, r1
-	mcr p15, 0, r0, c7, c6, 1
-	bx lr
-.size hal_cpuInvalDataCache, .-hal_cpuInvalDataCache
-
-
-.globl hal_cpuFlushDataCache
-.type hal_cpuFlushDataCache, %function
-hal_cpuFlushDataCache:
-	ldr r1, =SIZE_CACHE_LINE - 1
-	bic r0, r0, r1
-	mcr p15, 0, r0, c7, c14, 1
-	bx lr
-.size hal_cpuFlushDataCache, .-hal_cpuFlushDataCache
-
-
-.globl hal_cpuCleanDataCache
-.type hal_cpuCleanDataCache, %function
-hal_cpuCleanDataCache:
-	ldr r1, =SIZE_CACHE_LINE - 1
-	bic r0, r0, r1
-	mcr p15, 0, r0, c7, c11, 1
-	bx lr
-.size hal_cpuCleanDataCache, .-hal_cpuCleanDataCache
-
-
-.globl hal_cpuInvalASID
-.type hal_cpuInvalASID, %function
-hal_cpuInvalASID:
-	and r0, r0, #0xff
-	mcr p15, 0, r0, c8, c7, 2
-	bx lr
-.size hal_cpuInvalASID, .-hal_cpuInvalASID
-
-
-.globl hal_cpuInvalTLB
-.type hal_cpuInvalTLB, %function
-hal_cpuInvalTLB:
-	mcr p15, 0, r0, c8, c7, 0
-	bx lr
-.size hal_cpuInvalTLB, .-hal_cpuInvalTLB
-
-
-.globl hal_cpuInvalVA
-.type hal_cpuInvalVA, %function
-hal_cpuInvalVA:
-	mcr p15, 0, r0, c8, c7, 1 /* ASID match */
-	bx lr
-.size hal_cpuInvalVA, .-hal_cpuInvalVA
+.ltorg
 
 
 .globl hal_cpuBranchInval
 .type hal_cpuBranchInval, %function
 hal_cpuBranchInval:
+	dsb
 	mov r0, #0
-	mcr p15, 0, r0, c7, c5, 6
+	mcr p15, 0, r0, c7, c5, 6 /* BPIALL */
+	dsb
+	isb
 	bx lr
 .size hal_cpuBranchInval, .-hal_cpuBranchInval
+.ltorg
 
 
 .globl hal_cpuICacheInval
 .type hal_cpuICacheInval, %function
 hal_cpuICacheInval:
+	dsb
 	mov r0, #0
-	mcr p15, 0, r0, c7, c5, 0
+	mcr p15, 0, r0, c7, c5, 0 /* ICIALLU */
+	dsb
+	isb
 	bx lr
 .size hal_cpuICacheInval, .-hal_cpuICacheInval
+.ltorg
 
 
-.globl hal_cpuGetUserTT
-.type hal_cpuGetUserTT, %function
-hal_cpuGetUserTT:
+.globl hal_cpuInvalDataCache
+.type hal_cpuInvalDataCache, %function
+hal_cpuInvalDataCache:
+	dsb
+	mrc p15, 0, r3, c0, c0, 1 /* Read the Cache Type Register */
+	lsr r3, r3, #16           /* DMinLine value */
+	and r3, r3, #0xf
+	mov r2, #4
+	mov r2, r2, lsl r3        /* Cache line size in bytes */
+	sub r3, r2, #1            /* Cache line size mask */
+	bic r0, r0, r3
+inval_line:
+	mcr p15, 0, r0, c7, c6, 1 /* DCIMVAC */
+	add r0, r0, r2
+	cmp r0, r1
+	blo inval_line
+	dsb
+	isb
+	bx lr
+.size hal_cpuInvalDataCache, .-hal_cpuInvalDataCache
+.ltorg
+
+
+.globl hal_cpuCleanDataCache
+.type hal_cpuCleanDataCache, %function
+hal_cpuCleanDataCache:
+	dsb
+	mrc p15, 0, r3, c0, c0, 1  /* Read the Cache Type Register */
+	lsr r3, r3, #16            /* DMinLine value */
+	and r3, r3, #0xf
+	mov r2, #4
+	mov r2, r2, lsl r3         /* Cache line size in bytes */
+	sub r3, r2, #1             /* Cache line size mask */
+	bic r0, r0, r3
+clean_line:
+	mcr p15, 0, r0, c7, c10, 1 /* DCCMVAC */
+	add r0, r0, r2
+	cmp r0, r1
+	blo clean_line
+	dsb
+	isb
+	bx lr
+.size hal_cpuCleanDataCache, .-hal_cpuCleanDataCache
+.ltorg
+
+
+.globl hal_cpuFlushDataCache
+.type hal_cpuFlushDataCache, %function
+hal_cpuFlushDataCache:
+	dsb
+	mrc p15, 0, r3, c0, c0, 1  /* Read the Cache Type Register */
+	lsr r3, r3, #16            /* DMinLine value */
+	and r3, r3, #0xf
+	mov r2, #4
+	mov r2, r2, lsl r3         /* Cache line size in bytes */
+	sub r3, r2, #1             /* Cache line size mask */
+	bic r0, r0, r3
+flush_line:
+	mcr p15, 0, r0, c7, c14, 1 /* DCCIMVAC */
+	add r0, r0, r2
+	cmp r0, r1
+	blo flush_line
+	dsb
+	isb
+	bx lr
+.size hal_cpuFlushDataCache, .-hal_cpuFlushDataCache
+.ltorg
+
+
+.globl hal_cpuInvalASID
+.type hal_cpuInvalASID, %function
+hal_cpuInvalASID:
+	dsb
+	and r0, r0, #0xff
+	mcr p15, 0, r0, c8, c7, 2 /* UTLBIASID */
+	dsb
+	isb
+	bx lr
+.size hal_cpuInvalASID, .-hal_cpuInvalASID
+.ltorg
+
+
+.globl hal_cpuInvalVA
+.type hal_cpuInvalVA, %function
+hal_cpuInvalVA:
+	dsb
+	mcr p15, 0, r0, c8, c7, 1 /* UTLBIMVA */
+	dsb
+	isb
+	bx lr
+.size hal_cpuInvalVA, .-hal_cpuInvalVA
+.ltorg
+
+
+.globl hal_cpuInvalTLB
+.type hal_cpuInvalTLB, %function
+hal_cpuInvalTLB:
+	dsb
+	mcr p15, 0, r0, c8, c7, 0 /* UTLBIALL */
+	dsb
+	isb
+	bx lr
+.size hal_cpuInvalTLB, .-hal_cpuInvalTLB
+.ltorg
+
+
+.globl hal_cpuGetTTBR0
+.type hal_cpuGetTTBR0, %function
+hal_cpuGetTTBR0:
+	dsb
 	mrc p15, 0, r0, c2, c0, 0
+	dsb
+	isb
 	bx lr
-.size hal_cpuGetUserTT, .-hal_cpuGetUserTT
+.size hal_cpuGetTTBR0, .-hal_cpuGetTTBR0
+.ltorg
 
 
-.globl hal_cpuSetUserTT
-.type hal_cpuSetUserTT, %function
-hal_cpuSetUserTT:
+.globl hal_cpuSetTTBR0
+.type hal_cpuSetTTBR0, %function
+hal_cpuSetTTBR0:
+	dsb
 	mcr p15, 0, r0, c2, c0, 0
+	dsb
+	isb
 	bx lr
-.size hal_cpuSetUserTT, .-hal_cpuSetUserTT
+.size hal_cpuSetTTBR0, .-hal_cpuSetTTBR0
+.ltorg
 
 
 .globl hal_cpuSetContextId
 .type hal_cpuSetContextId, %function
 hal_cpuSetContextId:
+	dsb
 	mcr p15, 0, r0, c13, c0, 1
+	dsb
+	isb
 	bx lr
 .size hal_cpuSetContextId, .-hal_cpuSetContextId
+.ltorg
 
 
 .globl hal_cpuGetContextId
 .type hal_cpuGetContextId, %function
 hal_cpuGetContextId:
+	dsb
 	mrc p15, 0, r0, c13, c0, 1
+	dsb
+	isb
 	bx lr
 .size hal_cpuGetContextId, .-hal_cpuGetContextId
+.ltorg
 
 
 .globl hal_cpuGetMIDR
@@ -139,6 +215,7 @@ hal_cpuGetMIDR:
 	mrc p15, 0, r0, c0, c0, 0
 	bx lr
 .size hal_cpuGetMIDR, .-hal_cpuGetMIDR
+.ltorg
 
 
 .globl hal_cpuGetPFR0
@@ -147,6 +224,7 @@ hal_cpuGetPFR0:
 	mrc p15, 0, r0, c0, c1, 0
 	bx lr
 .size hal_cpuGetPFR0, .-hal_cpuGetPFR0
+.ltorg
 
 
 .globl hal_cpuGetPFR1
@@ -155,16 +233,19 @@ hal_cpuGetPFR1:
 	mrc p15, 0, r0, c0, c1, 1
 	bx lr
 .size hal_cpuGetPFR1, .-hal_cpuGetPFR1
+.ltorg
 
 
 .globl _hal_cpuSetKernelStack
 .type _hal_cpuSetKernelStack, %function
 _hal_cpuSetKernelStack:
+	dsb
 	mcr p15, 0, r0, c13, c0, 4
 	dsb
 	isb
 	bx lr
 .size _hal_cpuSetKernelStack, .-_hal_cpuSetKernelStack
+.ltorg
 
 
 .globl hal_longjmp
@@ -174,6 +255,7 @@ hal_longjmp:
 	add sp, r0, #8
 	b _hal_cpuRestoreCtx
 .size hal_longjmp, .-hal_longjmp
+.ltorg
 
 
 .globl hal_jmp
@@ -222,3 +304,4 @@ hal_jmp:
 	push {r4}
 	rfefd sp!
 .size hal_jmp, .-hal_jmp
+.ltorg

--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -20,7 +20,6 @@
 
 #define SIZE_PAGE       0x1000
 #define SIZE_PDIR       0x4000
-#define SIZE_CACHE_LINE 64
 
 #ifndef SIZE_KSTACK
 #define SIZE_KSTACK (8 * 512)

--- a/hal/armv7a/armv7a.h
+++ b/hal/armv7a/armv7a.h
@@ -19,7 +19,7 @@
 #include <arch/types.h>
 
 
-/* barriers */
+/* Barriers */
 
 static inline void hal_cpuDataMemoryBarrier(void)
 {
@@ -39,45 +39,58 @@ static inline void hal_cpuInstrBarrier(void)
 }
 
 
-/* memory management */
-
-extern void hal_cpuFlushDataCache(void *vaddr);
+/* Memory Management */
 
 
-extern void hal_cpuInvalDataCache(void *vaddr);
-
-
-extern void hal_cpuCleanDataCache(void *vaddr);
-
-
-extern void hal_cpuInvalASID(u8 asid);
-
-
-extern void hal_cpuInvalVA(u32 vaddr);
-
-
-extern void hal_cpuInvalTLB(void);
-
-
+/* Invalidate entire branch predictor array */
 extern void hal_cpuBranchInval(void);
 
 
+/* Invalidate all instruction caches to PoU. Also flushes branch target cache */
 extern void hal_cpuICacheInval(void);
 
 
-extern addr_t hal_cpuGetUserTT(void);
+/* Clean Data or Unified cache line by MVA to PoC */
+extern void hal_cpuCleanDataCache(ptr_t vstart, ptr_t vend);
 
 
-extern void hal_cpuSetUserTT(addr_t tt);
+/* Invalidate Data or Unified cache line by MVA to PoC */
+extern void hal_cpuInvalDataCache(ptr_t vstart, ptr_t vend);
 
 
+/* Clean and Invalidate Data or Unified cache line by MVA to PoC */
+extern void hal_cpuFlushDataCache(ptr_t vstart, ptr_t vend);
+
+
+/* Invalidate TLB entries by ASID Match */
+extern void hal_cpuInvalASID(u8 asid);
+
+
+/* Invalidate Unified TLB by MVA */
+extern void hal_cpuInvalVA(ptr_t vaddr);
+
+
+/* Invalidate entire Unified TLB*/
+extern void hal_cpuInvalTLB(void);
+
+
+/* Read Translation Table Base Register 0 with properties */
+extern addr_t hal_cpuGetTTBR0(void);
+
+
+/* Set Translation Table Base Register 0 with properties */
+extern void hal_cpuSetTTBR0(addr_t ttbr0);
+
+
+/* Set ContextID = Process ID (pmap->pdir) and ASID */
 extern void hal_cpuSetContextId(u32 id);
 
 
+/* Get ContextID = Process ID (pmap->pdir) and ASID */
 extern u32 hal_cpuGetContextId(void);
 
 
-/* core management */
+/* Core Management */
 
 extern u32 hal_cpuGetMIDR(void);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Cache management is added to `pmap_enter` and `pmap_remove` to provide data consistency. According to: https://support.xilinx.com/s/article/52035?language=en_US TTL1 and TTL2 entries have to be cleaned and invalidated before update.

Moreover:
1. Barriers have been added to cp15 coprecossor, according to ARM documentation.
2. Added some comments and defines in pmap.

**TODO:**
In current approach TLB is invalidated after each `pmap_switch`, it is unnecessary. ASIDs mechanisms allows to have the same virtual addresses from different processes in TLB. TLB invalidation should be performed in asid alloc/dealloc function when the asids pool is run out.
 
**CHANGES HAVE NOT BEEN TESTED ON DTR PROJECT**
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Executing programs from file system caused abort or prefetch exceptions:
![image](https://user-images.githubusercontent.com/23028094/159699375-8bcf9140-9c53-40b1-973e-6d052921c5df.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zynq7000, qemu-zynq7000, imx6ull-devkit).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
