### PR TITLE
proc: change process map under threads_common.spinlock

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1003,6 +1003,17 @@ void proc_reap(void)
 }
 
 
+void proc_changeMap(process_t *proc, vm_map_t *map, pmap_t *pmap)
+{
+	spinlock_ctx_t sc;
+
+	hal_spinlockSet(&threads_common.spinlock, &sc);
+	proc->mapp = map;
+	proc->pmapp = pmap;
+	hal_spinlockClear(&threads_common.spinlock, &sc);
+}
+
+
 /*
  * Sleeping and waiting
  */

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -137,6 +137,9 @@ extern int proc_waitpid(int pid, int *stat, int options);
 extern int proc_join(time_t timeout);
 
 
+extern void proc_changeMap(process_t *proc, vm_map_t *map, pmap_t *pmap);
+
+
 extern int proc_threadsList(int n, threadinfo_t *info);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Process map is changed under threads_common.spinlock to prevent scheduling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

PD-250

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zynq7000, ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
