### PR TITLE
proc/name: allow lookup on paths not starting with '/'

### DIFF
--- a/proc/name.c
+++ b/proc/name.c
@@ -165,9 +165,6 @@ int proc_portLookup(const char *name, oid_t *file, oid_t *dev)
 	}
 	proc_lockClear(&name_common.dcache_lock);
 
-	if (name[0] != '/')
-		return -ENOENT;
-
 	srv = name_common.root_oid;
 
 #if 1 /* (MOD) */
@@ -187,7 +184,9 @@ int proc_portLookup(const char *name, oid_t *file, oid_t *dev)
 	hal_strcpy(pptr, name);
 
 	while (i > 1) {
-		while (pptr[--i] != '/');
+		while (i > 0 && pptr[i] != '/') {
+			--i;
+		}
 
 		if (i == 0)
 			break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
PD-266

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`lookup` for files in `devfs` doesn't work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zynq7000).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
