### PR TITLE
vm: Added shared memory maps info to vm_mapinfo

### DIFF
--- a/include/sysinfo.h
+++ b/include/sysinfo.h
@@ -61,6 +61,17 @@ typedef struct _pageinfo_t {
 } pageinfo_t;
 
 
+typedef struct {
+	int id;
+	addr_t pstart;
+	addr_t pend;
+	addr_t vstart;
+	addr_t vend;
+	size_t alloc;
+	size_t free;
+} mapinfo_t;
+
+
 typedef struct _meminfo_t {
 	struct {
 		unsigned int alloc, free, boot, sz;
@@ -73,6 +84,13 @@ typedef struct _meminfo_t {
 		int mapsz, kmapsz;
 		entryinfo_t *kmap, *map;
 	} entry;
+
+	struct {
+		size_t total;
+		size_t free;
+		int mapsz;
+		mapinfo_t *map;
+	} maps;
 } meminfo_t;
 
 


### PR DESCRIPTION
JIRA: ISC-163

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently there is a problem with estimation of allocated/available memory on NOMMU targets. Shared maps parameters provide adequate information about total system memory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4, ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/129).
- [ ] I will merge this PR by myself when appropriate.
