### PR TITLE
hal/armv7a/imx6ull: set ENFC_CLK_ROOT (GPMI NAND root clock) to 198 MHz

### DIFF
--- a/hal/armv7a/imx6ull/imx6ull.c
+++ b/hal/armv7a/imx6ull/imx6ull.c
@@ -413,6 +413,8 @@ int hal_platformctl(void *ptr)
 
 void _hal_platformInit(void)
 {
+	unsigned int reg, tmp;
+
 	hal_spinlockCreate(&imx6ull_common.pltctlSp, "pltctl");
 	imx6ull_common.ccm = (void *)(((u32)&_end + (11 * SIZE_PAGE) - 1) & ~(SIZE_PAGE - 1));
 	imx6ull_common.ccm_analog = (void *)(((u32)&_end + (12 * SIZE_PAGE) - 1) & ~(SIZE_PAGE - 1));
@@ -431,4 +433,21 @@ void _hal_platformInit(void)
 	/* copy watchdog Reset Status Register to bootreason[23:16] */
 	imx6ull_bootReason &= 0xff00ffffu;
 	imx6ull_bootReason |= *(imx6ull_common.wdog + wdog_wrsr) << 16;
+
+	/* Set ENFC clock to 198 MHz */
+	/* First disable all output clocks */
+	reg = *(imx6ull_common.ccm + ccm_ccgr4);
+	tmp = reg;
+	reg &= ~((3 << 30) | (3 << 28) | (3 << 26) | (3 << 24) | (3 << 12));
+	*(imx6ull_common.ccm + ccm_ccgr4) = reg;
+
+	/* Configure ENFC clock */
+	reg = *(imx6ull_common.ccm + ccm_cs2cdr);
+	reg &= ~((63 << 21) | (7 << 18) | (7 << 15)); /* Clear ENFC clock selector and dividers */
+	reg |= (3 << 15);                             /* Set ENFC_CLK_SEL to PLL2 PFD2 (396 MHz) */
+	reg |= (1 << 18);                             /* Set ENFC_PRED divider to 2 */
+	*(imx6ull_common.ccm + ccm_cs2cdr) = reg;
+
+	/* Restore output clocks state */
+	*(imx6ull_common.ccm + ccm_ccgr4) = tmp;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added ENFC clock configuration. Boot ROM sets it to 24 MHz (it has a bug that causes timings specified in TMSpeed field in FCB to not be correctly applied) so that the following description from imx6ull reference manual doesn't really work (I've tested the TMSpeed field in FCB settings and it takes no effect).

![fcb_tmspeed](https://user-images.githubusercontent.com/8835317/163383020-9784d692-c5ee-4d5e-8cd8-d57cc6302d55.png)

### **Please note that this change effectively sets GPMI NAND IO clock to 198 MHz.**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: DTR-169](https://jira.phoenix-rtos.com/browse/DTR-169)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.