### PR TITLE
zynq7000: add platformctl for software reset control

### DIFF
--- a/hal/armv7a/zynq7000/zynq.c
+++ b/hal/armv7a/zynq7000/zynq.c
@@ -348,6 +348,172 @@ static int _zynq_getMIO(unsigned int pin, char *disableRcvr, char *pullup, char 
 }
 
 
+static int _zynq_setDevRst(int dev, unsigned int state)
+{
+	int err = 0;
+
+	_zynq_slcrUnlock();
+	switch (dev) {
+		case pctl_ctrl_pss_rst:
+			*(zynq_common.slcr + slcr_pss_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_ddr_rst:
+			*(zynq_common.slcr + slcr_ddr_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_topsw_rst:
+			*(zynq_common.slcr + slcr_topsw_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_dmac_rst:
+			*(zynq_common.slcr + slcr_dmac_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_usb_rst:
+			*(zynq_common.slcr + slcr_usb_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_gem_rst:
+			*(zynq_common.slcr + slcr_gem_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_sdio_rst:
+			*(zynq_common.slcr + slcr_sdio_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_spi_rst:
+			*(zynq_common.slcr + slcr_spi_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_can_rst:
+			*(zynq_common.slcr + slcr_can_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_i2c_rst:
+			*(zynq_common.slcr + slcr_i2c_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_uart_rst:
+			*(zynq_common.slcr + slcr_uart_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_gpio_rst:
+			*(zynq_common.slcr + slcr_gpio_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_lqspi_rst:
+			*(zynq_common.slcr + slcr_lqspi_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_smc_rst:
+			*(zynq_common.slcr + slcr_smc_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_ocm_rst:
+			*(zynq_common.slcr + slcr_ocm_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_fpga_rst:
+			*(zynq_common.slcr + slcr_fpga_rst_ctrl) = state;
+			break;
+
+		case pctl_ctrl_a9_cpu_rst:
+			*(zynq_common.slcr + slcr_a9_cpu_rst_ctrl) = state;
+			break;
+
+		default:
+			err = -1;
+			break;
+	}
+	_zynq_slcrLock();
+
+	return err;
+}
+
+
+static int _zynq_getDevRst(int dev, unsigned int *state)
+{
+	int err = 0;
+
+	switch (dev) {
+		case pctl_ctrl_pss_rst:
+			*state = *(zynq_common.slcr + slcr_pss_rst_ctrl);
+			break;
+
+		case pctl_ctrl_ddr_rst:
+			*state = *(zynq_common.slcr + slcr_ddr_rst_ctrl);
+			break;
+
+		case pctl_ctrl_topsw_rst:
+			*state = *(zynq_common.slcr + slcr_topsw_rst_ctrl);
+			break;
+
+		case pctl_ctrl_dmac_rst:
+			*state = *(zynq_common.slcr + slcr_dmac_rst_ctrl);
+			break;
+
+		case pctl_ctrl_usb_rst:
+			*state = *(zynq_common.slcr + slcr_usb_rst_ctrl);
+			break;
+
+		case pctl_ctrl_gem_rst:
+			*state = *(zynq_common.slcr + slcr_gem_rst_ctrl);
+			break;
+
+		case pctl_ctrl_sdio_rst:
+			*state = *(zynq_common.slcr + slcr_sdio_rst_ctrl);
+			break;
+
+		case pctl_ctrl_spi_rst:
+			*state = *(zynq_common.slcr + slcr_spi_rst_ctrl);
+			break;
+
+		case pctl_ctrl_can_rst:
+			*state = *(zynq_common.slcr + slcr_can_rst_ctrl);
+			break;
+
+		case pctl_ctrl_i2c_rst:
+			*state = *(zynq_common.slcr + slcr_i2c_rst_ctrl);
+			break;
+
+		case pctl_ctrl_uart_rst:
+			*state = *(zynq_common.slcr + slcr_uart_rst_ctrl);
+			break;
+
+		case pctl_ctrl_gpio_rst:
+			*state = *(zynq_common.slcr + slcr_gpio_rst_ctrl);
+			break;
+
+		case pctl_ctrl_lqspi_rst:
+			*state = *(zynq_common.slcr + slcr_lqspi_rst_ctrl);
+			break;
+
+		case pctl_ctrl_smc_rst:
+			*state = *(zynq_common.slcr + slcr_smc_rst_ctrl);
+			break;
+
+		case pctl_ctrl_ocm_rst:
+			*state = *(zynq_common.slcr + slcr_ocm_rst_ctrl);
+			break;
+
+		case pctl_ctrl_fpga_rst:
+			*state = *(zynq_common.slcr + slcr_fpga_rst_ctrl);
+			break;
+
+		case pctl_ctrl_a9_cpu_rst:
+			*state = *(zynq_common.slcr + slcr_a9_cpu_rst_ctrl);
+			break;
+
+		default:
+			err = -1;
+			break;
+	}
+
+	return err;
+}
+
+
 /* TODO */
 void hal_wdgReload(void)
 {
@@ -399,6 +565,16 @@ int hal_platformctl(void *ptr)
 			else if (data->action == pctl_get)
 				ret = _zynq_getMIO(data->mio.pin, &data->mio.disableRcvr, &data->mio.pullup, &data->mio.ioType, &data->mio.speed, &data->mio.l0,
 					&data->mio.l1, &data->mio.l2, &data->mio.l3, &data->mio.triEnable);
+			break;
+
+		case pctl_devreset:
+			if (data->action == pctl_set) {
+				ret = _zynq_setDevRst(data->devreset.dev, data->devreset.state);
+			}
+			else if (data->action == pctl_get) {
+				ret = _zynq_getDevRst(data->devreset.dev, &t);
+				data->devreset.state = t;
+			}
 			break;
 
 		case pctl_reboot:

--- a/include/arch/zynq7000.h
+++ b/include/arch/zynq7000.h
@@ -32,6 +32,14 @@ enum {
 };
 
 
+/* Devices' reset controllers */
+enum {
+	pctl_ctrl_pss_rst = 0, pctl_ctrl_ddr_rst, pctl_ctrl_topsw_rst, pctl_ctrl_dmac_rst, pctl_ctrl_usb_rst, pctl_ctrl_gem_rst, pctl_ctrl_sdio_rst,
+	pctl_ctrl_spi_rst, pctl_ctrl_can_rst, pctl_ctrl_i2c_rst, pctl_ctrl_uart_rst, pctl_ctrl_gpio_rst, pctl_ctrl_lqspi_rst, pctl_ctrl_smc_rst, pctl_ctrl_ocm_rst,
+	pctl_ctrl_fpga_rst, pctl_ctrl_a9_cpu_rst,
+};
+
+
 enum {
 	pctl_mio_pin_00 = 0, pctl_mio_pin_01, pctl_mio_pin_02, pctl_mio_pin_03, pctl_mio_pin_04, pctl_mio_pin_05, pctl_mio_pin_06, pctl_mio_pin_07, pctl_mio_pin_08,
 	pctl_mio_pin_09, pctl_mio_pin_10, pctl_mio_pin_11, pctl_mio_pin_12, pctl_mio_pin_13, pctl_mio_pin_14, pctl_mio_pin_15, pctl_mio_pin_16, pctl_pctl_mio_pin_17,
@@ -44,7 +52,7 @@ enum {
 
 typedef struct {
 	enum { pctl_set = 0, pctl_get } action;
-	enum { pctl_ambaclock = 0, pctl_devclock, pctl_mioclock, pctl_mio, pctl_reboot } type;
+	enum { pctl_ambaclock = 0, pctl_devclock, pctl_mioclock, pctl_mio, pctl_devreset, pctl_reboot } type;
 
 	union {
 		struct {
@@ -81,6 +89,11 @@ typedef struct {
 			char l3;
 			char triEnable;
 		} mio;
+
+		struct {
+			int dev;
+			unsigned int state;
+		} devreset;
 
 		struct {
 			unsigned int magic;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added device controller reset platformctl. Required for SPI controller initialization.

Usage example:
```c
#include <sys/platform.h>
#include <phoenix/arch/zynq7000.h>


static int spi_reset(unsigned int ndev)
{
	platformctl_t pctl;
	int err;

	pctl.action = pctl_get;
	pctl.type = pctl_devreset;
	pctl.devreset.dev = pctl_ctrl_spi_rst;
	err = platformctl(&pctl);
	if (err < 0) {
		return err;
	}

	pctl.action = pctl_set;
	pctl.devreset.state |= (1 << ndev + 2) | (1 << ndev);
	err = platformctl(&pctl);
	if (err < 0) {
		return err;
	}

	pctl.devreset.state &= ~((1 << ndev + 2) | (1 << ndev));
	err = platformctl(&pctl);

	return err;
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: PP-30](https://jira.phoenix-rtos.com/browse/PP-30)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
