### PR TITLE
remove global declaration of enum type from msg.h

### DIFF
--- a/include/msg.h
+++ b/include/msg.h
@@ -32,7 +32,7 @@ enum {
 	mtLookup, mtLink, mtUnlink, mtReaddir,
 
 	mtCount
-} type;
+};
 
 
 #pragma pack(push, 8)


### PR DESCRIPTION
JIRA: RTOS-218
Change-Id: I6db713c06ea8e6aee9585eaf721a981e702541ef

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
This variable is not used anywhere and it results in `type` symbol being defined in multiple object files. We should consider enabling `-fno-common` compilation flag globally (default for gcc >= 10). 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
