### PR TITLE
hal/armv7a-zynq7000: add software reset

### DIFF
--- a/hal/armv7a/zynq7000/zynq.c
+++ b/hal/armv7a/zynq7000/zynq.c
@@ -514,6 +514,16 @@ static int _zynq_getDevRst(int dev, unsigned int *state)
 }
 
 
+static void zynq_softRst(void)
+{
+	_zynq_slcrUnlock();
+	*(zynq_common.slcr + slcr_pss_rst_ctrl) |= 0x1;
+	_zynq_slcrLock();
+
+	__builtin_unreachable();
+}
+
+
 /* TODO */
 void hal_wdgReload(void)
 {
@@ -578,7 +588,7 @@ int hal_platformctl(void *ptr)
 			break;
 
 		case pctl_reboot:
-			/* TODO */
+			zynq_softRst();
 			break;
 
 		default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Software reset is invoked by the `platformctl`.

Current implementation works by accident. The ABI for `zynq7000` is the same as ABI for `imx6ull`. For this reason `reboot` function in [libphoenix-reboot](https://github.com/phoenix-rtos/libphoenix/blob/master/arch/armv7a/reboot.c) works as expected.

**It will be fixed in the next PR.**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PP-63

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zynq7000-zturn, zynq7000-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
