### PR TITLE
Replace usleep with nsleep to allow nanosleep implementation

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -29,7 +29,7 @@
 	ID(gettid) \
 	ID(beginthreadex) \
 	ID(endthread) \
-	ID(usleep) \
+	ID(nsleep) \
 	ID(mutexCreate) \
 	ID(phMutexLock) \
 	ID(mutexTry) \

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2075,7 +2075,7 @@ static int do_poll_iteration(struct pollfd *fds, nfds_t nfds)
 int posix_poll(struct pollfd *fds, nfds_t nfds, int timeout_ms)
 {
 	size_t i, n, ready;
-	time_t timeout, now, unused;
+	time_t timeout, now;
 
 	for (i = n = 0; i < nfds; ++i) {
 		fds[i].revents = 0;
@@ -2090,14 +2090,14 @@ int posix_poll(struct pollfd *fds, nfds_t nfds, int timeout_ms)
 	}
 
 	if (timeout_ms >= 0) {
-		proc_gettime(&timeout, &unused);
+		proc_gettime(&timeout, NULL);
 		timeout += timeout_ms * 1000LL + !timeout_ms;
 	} else
 		timeout = 0;
 
 	while (!(ready = do_poll_iteration(fds, nfds))) {
 		if (timeout) {
-			proc_gettime(&now, &unused);
+			proc_gettime(&now, NULL);
 			if (now > timeout)
 				break;
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1108,7 +1108,7 @@ static int _proc_threadWait(thread_t **queue, time_t timeout, spinlock_ctx_t *sc
 }
 
 
-int proc_threadSleep(unsigned long long us)
+int proc_threadSleep(time_t us)
 {
 	thread_t *current;
 	int err;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1290,8 +1290,12 @@ void proc_gettime(time_t *raw, time_t *offs)
 	spinlock_ctx_t sc;
 
 	hal_spinlockSet(&threads_common.spinlock, &sc);
-	(*raw) = hal_timerGetUs();
-	(*offs) = threads_common.utcoffs;
+	if (raw != NULL) {
+		(*raw) = hal_timerGetUs();
+	}
+	if (offs != NULL) {
+		(*offs) = threads_common.utcoffs;
+	}
 	hal_spinlockClear(&threads_common.spinlock, &sc);
 }
 

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -146,7 +146,7 @@ extern int proc_threadsList(int n, threadinfo_t *info);
 extern void proc_zombie(process_t *proc);
 
 
-extern int proc_threadSleep(unsigned long long us);
+extern int proc_threadSleep(time_t us);
 
 
 extern int proc_threadWait(thread_t **queue, spinlock_t *spinlock, time_t timeout, spinlock_ctx_t *scp);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Replace usleep with nsleep:
- accept greater time resolution (us -> ns)
- allow returning "unsleept" time

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Greater time resolution is needed by `nanosleep()`, returning unsleept time is needed by both `sleep()` and `nanosleep()`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (is dependent on https://github.com/phoenix-rtos/libphoenix/pull/192).
- [ ] I will merge this PR by myself when appropriate.
