### PR TITLE
posix: Fix bad struct stat definition

### DIFF
--- a/include/posix.h
+++ b/include/posix.h
@@ -115,6 +115,12 @@ typedef long long off64_t;
 typedef off64_t off_t;
 
 
+struct timespec {
+	time_t tv_sec;
+	long tv_nsec;
+};
+
+
 struct stat {
 	dev_t st_dev;
 	ino_t st_ino;
@@ -124,17 +130,11 @@ struct stat {
 	gid_t st_gid;
 	dev_t st_rdev;
 	off_t st_size;
-	time_t st_atime;
-	time_t st_mtime;
-	time_t st_ctime;
+	struct timespec st_atim;
+	struct timespec st_mtim;
+	struct timespec st_ctim;
 	blksize_t st_blksize;
 	blkcnt_t st_blocks;
-};
-
-
-struct timespec {
-	time_t tv_sec;
-	long tv_nsec;
 };
 
 

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1087,17 +1087,20 @@ int posix_fstat(int fd, struct stat *buf)
 			msg.i.attr.type = atMTime;
 			if (((err = proc_send(f->oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))
 				break;
-			buf->st_mtime = msg.o.attr.val;
+			buf->st_mtim.tv_sec = msg.o.attr.val;
+			buf->st_mtim.tv_nsec = 0;
 
 			msg.i.attr.type = atATime;
 			if (((err = proc_send(f->oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))
 				break;
-			buf->st_atime = msg.o.attr.val;
+			buf->st_atim.tv_sec = msg.o.attr.val;
+			buf->st_atim.tv_nsec = 0;
 
 			msg.i.attr.type = atCTime;
 			if (((err = proc_send(f->oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))
 				break;
-			buf->st_ctime = msg.o.attr.val;
+			buf->st_ctim.tv_sec = msg.o.attr.val;
+			buf->st_ctim.tv_nsec = 0;
 
 			msg.i.attr.type = atLinks;
 			if (((err = proc_send(f->oid.port, &msg)) < 0) || ((err = msg.o.attr.err) < 0))


### PR DESCRIPTION
JIRA: RTOS-227

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Made struct stat in kernel identical to libphoenix version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Caused fstat to return gibberish

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
