### PR TITLE
Implement thread local storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 CMakeLists.txt
 .idea/
 cmake-build-debug/
+.vscode/*

--- a/hal/armv7a/cpu.c
+++ b/hal/armv7a/cpu.c
@@ -19,6 +19,7 @@
 #include "../cpu.h"
 #include "../string.h"
 #include "../spinlock.h"
+#include "../hal.h"
 
 
 /* Function creates new cpu context on top of given thread kernel stack */
@@ -198,6 +199,16 @@ char *hal_cpuFeatures(char *features, unsigned int len)
 		features[0] = '\0';
 
 	return features;
+}
+
+
+void hal_cpuTlsSet(hal_tls_t *tls, cpu_context_t *ctx)
+{
+	/* In theory there should be 8-byte thread control block but
+	 * it's stored elsewhere so we need to subtract 8 from the pointer
+	 */
+	ptr_t ptr = tls->tls_base - 8;
+	__asm__ volatile("mcr p15, 0, %[value], cr13, cr0, 3;" ::[value] "r"(ptr));
 }
 
 

--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -17,6 +17,7 @@
 #include "../interrupts.h"
 #include "../spinlock.h"
 #include "../string.h"
+#include "../hal.h"
 #include "../timer.h"
 
 #include "config.h"
@@ -285,4 +286,10 @@ void _hal_cpuInit(void)
 #elif defined(CPU_IMXRT)
 	_imxrt_platformInit();
 #endif
+}
+
+
+void hal_cpuTlsSet(hal_tls_t *tls, cpu_context_t *ctx)
+{
+	*(ptr_t *)tls->arm_m_tls = tls->tls_base - 8;
 }

--- a/hal/cpu.h
+++ b/hal/cpu.h
@@ -20,6 +20,9 @@
 #include "spinlock.h"
 
 
+struct _hal_tls_t;
+
+
 /* interrupts */
 
 
@@ -116,6 +119,12 @@ extern char *hal_cpuFeatures(char *features, unsigned int len);
 
 
 extern void cpu_sendIPI(unsigned int cpu, unsigned int intr);
+
+
+/* thread local storage */
+
+
+extern void hal_cpuTlsSet(struct _hal_tls_t *tls, cpu_context_t *ctx);
 
 
 /* cache management */

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -14,6 +14,7 @@
  */
 
 #ifndef _HAL_HAL_H_
+#define _HAL_HAL_H_
 
 #include "cpu.h"
 /* TODO: remove config file after cleaning up 'includes' directory */
@@ -25,6 +26,15 @@
 #include "interrupts.h"
 #include "exceptions.h"
 #include "timer.h"
+
+
+typedef struct _hal_tls_t {
+	ptr_t tls_base;
+	ptr_t arm_m_tls;
+	size_t tdata_sz;
+	size_t tbss_sz;
+	size_t tls_sz;
+} hal_tls_t;
 
 
 extern void *hal_syspageRelocate(void *data);
@@ -46,5 +56,6 @@ extern void _hal_start(void);
 
 
 extern void _hal_init(void);
+
 
 #endif

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -90,12 +90,18 @@
 /* Descriptor of user task data segment */
 #define DESCR_KDATA (DBITS_4KB | DBITS_PRESENT | DBITS_DPL0 | DBITS_APP | DBITS_DATA | DBITS_WRT)
 
+/* Descriptor of Thread Local Storage segment */
+#define DESCR_TLS (DBITS_4KB | DBITS_CODE32 | DBITS_PRESENT | DBITS_DPL3 | DBITS_APP | DBITS_DATA | DBITS_WRT)
+
 
 /* Segment selectors */
 #define SEL_KCODE 8
 #define SEL_KDATA 16
 #define SEL_UCODE 27
 #define SEL_UDATA 35
+#define SEL_TLS   43
+
+#define TLS_DESC_IDX 5
 
 
 #ifndef __ASSEMBLY__

--- a/hal/riscv64/cpu.c
+++ b/hal/riscv64/cpu.c
@@ -14,12 +14,14 @@
  */
 
 #include "../../include/errno.h"
+#include "../hal.h"
 #include "../cpu.h"
 #include "../spinlock.h"
 #include "../string.h"
 #include "../pmap.h"
 #include "riscv64.h"
 #include "dtb.h"
+#include "arch/types.h"
 
 
 extern int threads_schedule(unsigned int n, cpu_context_t *context, void *arg);
@@ -276,4 +278,10 @@ void hal_cleanDCache(ptr_t start, size_t len)
 void _hal_cpuInit(void)
 {
 	_hal_cpuInitCores();
+}
+
+
+void hal_cpuTlsSet(hal_tls_t *tls, cpu_context_t *ctx)
+{
+	ctx->tp = tls->tls_base;
 }

--- a/proc/elf.h
+++ b/proc/elf.h
@@ -150,6 +150,20 @@ typedef struct {
 } Elf64_Phdr;
 
 
+typedef struct {
+	Elf64_Word sh_name;
+	Elf64_Word sh_type;
+	Elf64_Xword sh_flags;
+	Elf64_Addr sh_addr;
+	Elf64_Off sh_offset;
+	Elf64_Xword sh_size;
+	Elf64_Word sh_link;
+	Elf64_Word sh_info;
+	Elf64_Xword sh_addralign;
+	Elf64_Xword sh_entsize;
+} Elf64_Shdr;
+
+
 #pragma pack(pop)
 
 

--- a/proc/process.h
+++ b/proc/process.h
@@ -22,6 +22,7 @@
 #include "lock.h"
 #include "../vm/amap.h"
 #include "../syspage.h"
+#include "arch/types.h"
 
 #define MAX_PID ((1LL << (__CHAR_BIT__ * (sizeof(unsigned)) - 1)) - 1)
 
@@ -70,6 +71,7 @@ typedef struct _process_t {
 	void *sighandler;
 
 	void *got;
+	hal_tls_t tls;
 } process_t;
 
 
@@ -122,5 +124,12 @@ extern int _process_init(vm_map_t *kmap, vm_object_t *kernel);
 
 
 extern void process_dumpException(unsigned int n, exc_context_t *exc);
+
+
+extern int process_tlsInit(hal_tls_t *dest, hal_tls_t *source, vm_map_t *map);
+
+
+extern int process_tlsDestroy(hal_tls_t *tls, vm_map_t *map);
+
 
 #endif

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -71,6 +71,8 @@ typedef struct _thread_t {
 	size_t kstacksz;
 	char *ustack;
 
+	hal_tls_t tls;
+
 	/* for vfork/exec */
 	void *parentkstack, *execkstack;
 	void *execdata;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- Implements thread local storage on all supported architectures.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: RTOS-209
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/125.
- [x] Tested by hand on: `ia32-generic-qemu`, `armv7m7-imxrt106x-evk`, `riscv64-generic-qemu`, `armv7a9-zynq7000-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/340, https://github.com/phoenix-rtos/phoenix-rtos-build/pull/127, https://github.com/phoenix-rtos/libphoenix/pull/195.
- [ ] I will merge this PR by myself when appropriate.
