### PR TITLE
stm32l4: Fix sleep, replace wfe with wfi

### DIFF
--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -106,19 +106,20 @@ static inline void hal_cpuEnableInterrupts(void)
 }
 
 
+static inline void hal_cpuHalt(void)
+{
+	__asm__ volatile ("wfi");
+}
+
+
 static inline void hal_cpuLowPower(time_t us)
 {
+	hal_cpuHalt();
 }
 
 
 static inline void hal_cpuSetDevBusy(int s)
 {
-}
-
-
-static inline void hal_cpuHalt(void)
-{
-	__asm__ volatile ("wfi");
 }
 
 

--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -42,8 +42,14 @@ void hal_cpuLowPower(time_t us)
 		/* Don't increment jiffies if sleep was unsuccessful */
 		us = _stm32_pwrEnterLPStop(us);
 		timer_jiffiesAdd(us);
+		hal_spinlockClear(&cpu_common.busySp, &scp);
 	}
-	hal_spinlockClear(&cpu_common.busySp, &scp);
+	else {
+		hal_spinlockClear(&cpu_common.busySp, &scp);
+		hal_cpuHalt();
+	}
+#else
+	hal_cpuHalt();
 #endif
 }
 

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -375,10 +375,6 @@ time_t _stm32_pwrEnterLPStop(time_t us)
 	/* Set SLEEPDEEP bit of Cortex System Control Register */
 	*(stm32_common.scb + scb_scr) |= 1 << 2;
 
-	/* Clear EXTI pending bits */
-	*(stm32_common.exti + exti_pr1) |= 0xffffffff;
-	*(stm32_common.exti + exti_pr2) |= 0xffffffff;
-
 	*(stm32_common.scb + syst_csr) &= ~1;
 
 	timer_setAlarm(us);
@@ -386,7 +382,7 @@ time_t _stm32_pwrEnterLPStop(time_t us)
 	/* Enter Stop mode */
 	__asm__ volatile ("\
 		dmb; \
-		wfe; \
+		wfi; \
 		nop; ");
 
 	/* Reset SLEEPDEEP bit of Cortex System Control Register */

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -204,19 +204,20 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
+static inline void hal_cpuHalt(void)
+{
+	__asm__ volatile ("hlt":);
+}
+
+
 static inline void hal_cpuLowPower(time_t us)
 {
+	hal_cpuHalt();
 }
 
 
 static inline void hal_cpuSetDevBusy(int s)
 {
-}
-
-
-static inline void hal_cpuHalt(void)
-{
-	__asm__ volatile ("hlt":);
 }
 
 

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -139,19 +139,20 @@ static inline void hal_cpuEnableInterrupts(void)
 /* performance */
 
 
+static inline void hal_cpuHalt(void)
+{
+	__asm__ ("wfi");
+}
+
+
 static inline void hal_cpuLowPower(time_t us)
 {
+	hal_cpuHalt();
 }
 
 
 static inline void hal_cpuSetDevBusy(int s)
 {
-}
-
-
-static inline void hal_cpuHalt(void)
-{
-	__asm__ ("wfi");
 }
 
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1700,10 +1700,12 @@ static void threads_idlethr(void *arg)
 	for (;;) {
 		wakeup = proc_nextWakeup();
 
-		if (wakeup > 2000)
+		if (wakeup > (2 * SYSTICK_INTERVAL)) {
 			hal_cpuLowPower(wakeup);
-
-		hal_cpuHalt();
+		}
+		else {
+			hal_cpuHalt();
+		}
 	}
 }
 


### PR DESCRIPTION
DONE: SKAL-576

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removal of sev, wfe caused MCU insomnia, deep sleep was never achieved. Most likely event flag is stuck high for some reason. All our wakeup sources provide IRQ, so WFI should be good replacement.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
