### PR TITLE
threads: fix proc_join

### DIFF
--- a/proc/threads.h
+++ b/proc/threads.h
@@ -134,7 +134,7 @@ extern void proc_threadsDestroy(thread_t **threads);
 extern int proc_waitpid(int pid, int *stat, int options);
 
 
-extern int proc_join(time_t timeout);
+extern int proc_join(int tid, time_t timeout);
 
 
 extern void proc_changeMap(process_t *proc, vm_map_t *map, pmap_t *pmap);

--- a/syscalls.c
+++ b/syscalls.c
@@ -192,11 +192,13 @@ int syscalls_sys_waitpid(void *ustack)
 
 int syscalls_threadJoin(void *ustack)
 {
+	int tid;
 	time_t timeout;
 
-	GETFROMSTACK(ustack, time_t, timeout, 0);
+	GETFROMSTACK(ustack, int, tid, 0);
+	GETFROMSTACK(ustack, time_t, timeout, 1);
 
-	return proc_join(timeout);
+	return proc_join(tid, timeout);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes bad proc_join approach

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- JIRA: RTOS-226

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
`threadJoin` syscall takes now 2 arguments - timeout and thread id. Existing threadJoin calls which do not specify thread id shall be called with `tid = -1`, which keeps original threadJoin behaviour.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/libphoenix/pull/200, https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/130, https://github.com/phoenix-rtos/phoenix-rtos-corelibs/pull/24, https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/285, https://github.com/phoenix-rtos/phoenix-rtos-lwip/pull/73, https://github.com/phoenix-rtos/phoenix-rtos-utils/pull/149.
- [ ] I will merge this PR by myself when appropriate.
