### PR TITLE
stm32l4: Fix two race conditions in low power

### DIFF
--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -388,9 +388,6 @@ time_t _stm32_pwrEnterLPStop(time_t us)
 	/* Reset SLEEPDEEP bit of Cortex System Control Register */
 	*(stm32_common.scb + scb_scr) &= ~(1 << 2);
 
-	/* Provoke systick, so we'll be reschuduled asap */
-	*(stm32_common.scb + scb_icsr) |= 1 << 26;
-
 	*(stm32_common.scb + syst_csr) |= 1;
 
 	return 0;


### PR DESCRIPTION
- cmp event could occur before reaching wfi causing wakeup event to be missed and sleep taking much longer (until other wakeup event occured),
- arr event could occur between spinlock set and deep sleep causing timer overflow to be missed (causing ~15 s being lost on system timer).

Remove manual SYSTICK pending flag set, not needed anymore as rescheduling is triggered by timer irqs.

JIRA: ISC-199

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
