### PR TITLE
vm/map: Fix syspage progs being executed in place

### DIFF
--- a/vm/map.c
+++ b/vm/map.c
@@ -622,7 +622,7 @@ static int _map_force(vm_map_t *map, map_entry_t *e, void *paddr, int prot)
 
 	if (e->amap == NULL)
 		p = vm_objectPage(map, NULL, e->object, paddr, (e->offs < 0) ? e->offs : e->offs + offs);
-	else if (e->object != (void *)-1)
+	else /* if (e->object != (void *)-1) FIXME disabled until memory objects are created for syspage progs */
 		p = amap_page(map, e->amap, e->object, paddr, e->aoffs + offs, (e->offs < 0) ? e->offs : e->offs + offs, prot);
 
 	if (prot & PROT_WRITE)


### PR DESCRIPTION
This causes original elf file residint in the memory to be modified by it's execution. Regresion: forking process with mapped physical memory will cause bad behaviour - pages with physical memory will be copied insted of being shared.

JIRA: RTOS-177

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
