### PR TITLE
threads_schedule: fix scheduling

### DIFF
--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -195,6 +195,12 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 }
 
 
+static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
+{
+	return ctx->psr & 0xf;
+}
+
+
 static inline unsigned int hal_cpuGetID(void)
 {
 	return 0;

--- a/hal/armv7m/arch/cpu.h
+++ b/hal/armv7m/arch/cpu.h
@@ -250,6 +250,12 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 }
 
 
+static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
+{
+	return 0;
+}
+
+
 static inline int hal_cpuPushSignal(void *kstack, void (*handler)(void), int sig)
 {
 	return 0;

--- a/hal/armv7m/arch/cpu.h
+++ b/hal/armv7m/arch/cpu.h
@@ -252,7 +252,7 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 
 static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
 {
-	return 0;
+	return ((ctx->irq_ret & (1 << 2)) == 0) ? 1 : 0;
 }
 
 

--- a/hal/cpu.h
+++ b/hal/cpu.h
@@ -88,6 +88,9 @@ extern void *hal_cpuGetSP(cpu_context_t *ctx);
 extern void *hal_cpuGetUserSP(cpu_context_t *ctx);
 
 
+extern int hal_cpuSupervisorMode(cpu_context_t *ctx);
+
+
 extern int hal_cpuPushSignal(void *kstack, void (*handler)(void), int n);
 
 

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -320,6 +320,12 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 }
 
 
+static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
+{
+	return ((ctx->cs & 3) == 0);
+}
+
+
 #endif
 
 #endif

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -208,6 +208,12 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 }
 
 
+static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
+{
+	return (ctx->sscratch == 0);
+}
+
+
 static inline int hal_cpuPushSignal(void *kstack, void (*handler)(void), int n)
 {
 #if 0

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -581,7 +581,7 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 
 		LIST_REMOVE(&threads_common.ready[i], selected);
 
-		if (!selected->exit)
+		if (!selected->exit || hal_cpuSupervisorMode(selected->context))
 			break;
 
 		selected->state = GHOST;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - revert hal code: `hal_cpuSupervisorMode`,
 - update hal_cpuSupervisorMode for `Cortex-M`,
 - thread in ready queue running in a supervisor mode is always allowed to be selected,

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Abort exception occurs when msg is send to the killed thread. 

`msg_send` data are located on stack and shared between threads. If the thread is killed in the middle of message exchange, the abort occurs.

PD--313

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (zturn).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
