### PR TITLE
posix: fix setsid() return value

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2334,8 +2334,9 @@ pid_t posix_setsid(void)
 
 	pid = proc_current()->process->id;
 
-	if ((pinfo = pinfo_find(pid)) == NULL)
-		return -EINVAL;
+	if ((pinfo = pinfo_find(pid)) == NULL) {
+		return -EPERM;
+	}
 
 	/* FIXME (pedantic): Should check if any process has my group id */
 	proc_lockSet(&pinfo->lock);
@@ -2349,7 +2350,7 @@ pid_t posix_setsid(void)
 	proc_lockClear(&pinfo->lock);
 	pinfo_put(pinfo);
 
-	return EOK;
+	return pinfo->pgid;
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - posix: fix setsid() return value and set errno

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

POSIX compliance:

Upon successful completion, setsid() shall return the value of the new process group ID of the calling process. Otherwise, it shall return -1 and set errno to indicate the error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
