### PR TITLE
klog: Separate log_write from readers wakeup

### DIFF
--- a/log/log.h
+++ b/log/log.h
@@ -21,7 +21,14 @@
 extern int log_write(const char *data, size_t len);
 
 
+/* Has to be called after log_write to wakeup klog readers.
+ * Not safe - performs i.a. proc_respond! */
 extern void log_scrub(void);
+
+
+/* Bypass log, change log_write mode to writing directly to the console
+ * Debug feature, allows direct and instant message printing */
+extern void log_disable(void);
 
 
 extern void log_msgHandler(msg_t *msg, oid_t oid, unsigned long int rid);

--- a/log/log.h
+++ b/log/log.h
@@ -21,6 +21,9 @@
 extern int log_write(const char *data, size_t len);
 
 
+extern void log_scrub(void);
+
+
 extern void log_msgHandler(msg_t *msg, oid_t oid, unsigned long int rid);
 
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -620,12 +620,14 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 	/* Test stack usage */
 	if (selected != NULL && !selected->execkstack &&
 			((void *)selected->context < selected->kstack + selected->kstacksz - 9 * selected->kstacksz / 10)) {
+		log_disable();
 		lib_printf("proc: Stack limit exceeded, sp=%p %p %d\n", selected->kstack, selected->context, hal_cpuGetID());
 		for (;;);
 	}
 
 	if (selected != NULL && selected->process != NULL && selected->ustack != NULL &&
 			hal_memcmp(selected->ustack, threads_common.stackCanary, sizeof(threads_common.stackCanary)) != 0) {
+		log_disable();
 		lib_printf("proc: User stack corrupted path=%s, pid=%d, tid=%d\n", selected->process->path, selected->process->id, selected->id);
 		for (;;);
 	}
@@ -1739,6 +1741,7 @@ static void threads_idlethr(void *arg)
 	time_t wakeup;
 
 	for (;;) {
+		/* Scrub any potential kernel logs (wake up readers) */
 		log_scrub();
 
 		wakeup = proc_nextWakeup();

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -23,6 +23,7 @@
 #include "resource.h"
 #include "msg.h"
 #include "ports.h"
+#include "../log/log.h"
 
 
 struct {
@@ -1738,6 +1739,8 @@ static void threads_idlethr(void *arg)
 	time_t wakeup;
 
 	for (;;) {
+		log_scrub();
+
 		wakeup = proc_nextWakeup();
 
 		if (wakeup > (2 * SYSTICK_INTERVAL)) {

--- a/syscalls.c
+++ b/syscalls.c
@@ -1483,7 +1483,9 @@ void *syscalls_dispatch(int n, char *ustack)
 {
 	void *retval;
 
-	/* Do before syscall to reduce jitter */
+	/* Do before syscall to reduce jitter.
+	 * We don't have spare kernel threads (apart from idle) to do this.
+	 * Only kernel logs need scrubing, so in most cases this is a no-op */
 	log_scrub();
 
 	if (n >= sizeof(syscalls) / sizeof(syscalls[0]))

--- a/syscalls.c
+++ b/syscalls.c
@@ -25,6 +25,7 @@
 #include "vm/object.h"
 #include "posix/posix.h"
 #include "syspage.h"
+#include "log/log.h"
 
 #define SYSCALLS_NAME(name)   syscalls_##name,
 #define SYSCALLS_STRING(name) #name,
@@ -1481,6 +1482,9 @@ const char *const syscall_strings[] = { SYSCALLS(SYSCALLS_STRING) };
 void *syscalls_dispatch(int n, char *ustack)
 {
 	void *retval;
+
+	/* Do before syscall to reduce jitter */
+	log_scrub();
 
 	if (n >= sizeof(syscalls) / sizeof(syscalls[0]))
 		return (void *)-EINVAL;


### PR DESCRIPTION
This allows log to be written to in any place, as there are no longer need to take threads_common.spinlock on write. Readers wakeup operation has been moved to:
- after write to klog from user space,
- just before exit from syscall,
- idle thread.

JIRA: RTOS-309

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fix a deadlock on threads_common.spinlock when attempting to use lib_printf from e.g. scheduler.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt-1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
