### PR TITLE
msg: Fix extra spinlock clear in proc_respond

### DIFF
--- a/proc/msg.c
+++ b/proc/msg.c
@@ -505,7 +505,6 @@ int proc_respond(u32 port, msg_t *msg, unsigned long int rid)
 	kmsg->src = proc_current()->process;
 	proc_threadWakeup(&kmsg->threads);
 	hal_cpuReschedule(&p->spinlock, &sc);
-	hal_spinlockClear(&p->spinlock, &sc);
 
 	port_put(p, 0);
 


### PR DESCRIPTION
hal_cpuReschedule is clearing spinlock, so additional clear is a bug

DONE: RTOS-313

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
