### PR TITLE
schedule: Allow stack canary enable independent of NDEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ CFLAGS += $(BOARD_CONFIG)
 CFLAGS += -I. -I$(PROJECT_PATH)/
 CFLAGS += -DVERSION=\"$(VERSION)\"
 
+# uncomment to enable stack canary checking
+# CFLAGS += -DSTACK_CANARY
+
 EXTERNAL_HEADERS_DIR := ./include
 EXTERNAL_HEADERS := $(shell find $(EXTERNAL_HEADERS_DIR) -name \*.h)
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -615,7 +615,7 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 	/* Update CPU usage */
 	threads_cpuTimeCalc(current, selected);
 
-#ifndef NDEBUG
+#if defined(STACK_CANARY) || !defined(NDEBUG)
 	/* Test stack usage */
 	if (selected != NULL && !selected->execkstack &&
 			((void *)selected->context < selected->kstack + selected->kstacksz - 9 * selected->kstacksz / 10)) {


### PR DESCRIPTION
DONE: RTOS-310

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
  - https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/360
- [x] I will merge this PR by myself when appropriate.
