### PR TITLE
vm/map: Fix NULL dereference in vm_mapinfo

### DIFF
--- a/vm/map.c
+++ b/vm/map.c
@@ -1027,8 +1027,13 @@ void vm_mapinfo(meminfo_t *info)
 			}
 
 			total = (ptr_t)map->stop - (ptr_t)map->start;
-			e = lib_treeof(map_entry_t, linkage, map->tree.root);
-			free = e->lmaxgap + e->rmaxgap;
+			if (map->tree.root == NULL) {
+				free = total; /* Map is empty */
+			}
+			else {
+				e = lib_treeof(map_entry_t, linkage, map->tree.root);
+				free = e->lmaxgap + e->rmaxgap;
+			}
 
 			/* All maps together */
 			info->maps.total += total;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fix NULL dereference in sycall for getting map description

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixed NULL dereference. Probably fixes issue where armv7m4 second flash map was identified as fully used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
