### PR TITLE
process: PT_GNU_STACK elf section zero size fix

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -382,7 +382,7 @@ int process_load32(vm_map_t *map, vm_object_t *o, offs_t base, void *iehdr, size
 	offs_t offs;
 
 	for (i = 0, phdr = (void *)ehdr + ehdr->e_phoff; i < ehdr->e_phnum; i++, phdr++) {
-		if (phdr->p_type == PT_GNU_STACK) {
+		if (phdr->p_type == PT_GNU_STACK && phdr->p_memsz != 0) {
 			*ustacksz = round_page(phdr->p_memsz);
 		}
 
@@ -435,7 +435,7 @@ int process_load64(vm_map_t *map, vm_object_t *o, offs_t base, void *iehdr, size
 	offs_t offs;
 
 	for (i = 0, phdr = (void *)ehdr + ehdr->e_phoff; i < ehdr->e_phnum; i++, phdr++) {
-		if (phdr->p_type == PT_GNU_STACK) {
+		if (phdr->p_type == PT_GNU_STACK && phdr->p_memsz != 0) {
 			*ustacksz = round_page(phdr->p_memsz);
 		}
 
@@ -587,8 +587,9 @@ int process_load(process_t *process, vm_object_t *o, offs_t base, size_t size, v
 
 	for (i = 0, j = 0, phdr = (void *)ehdr + ehdr->e_phoff; i < ehdr->e_phnum; i++, phdr++) {
 
-		if (phdr->p_type == PT_GNU_STACK)
+		if (phdr->p_type == PT_GNU_STACK && phdr->p_memsz != 0) {
 			stacksz = round_page(phdr->p_memsz);
+		}
 
 		if (phdr->p_type != PT_LOAD)
 			continue;


### PR DESCRIPTION
PT_GNU_STACK elf section with zero size is used to set non-exec stack.

DONE: RTOS-304

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
