### PR TITLE
hal/ia32: Enable FPU (with lazy context stacking)

### DIFF
--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -18,7 +18,119 @@
 
 #include <arch/cpu.h>
 
+#define CTXPUSHL 43 // 10 + 5 + 28
+
 .text
+
+.align 4, 0x90
+exception_pushContext:
+	/* Save return address for ret */
+	xchg (%esp), %edx
+	movl %edx, -(4 * CTXPUSHL)(%esp)
+	popl %edx
+	/* Check TS flag in CR0 register */
+	pushl %eax
+	movl %cr0, %eax
+	subl $FPU_CONTEXT_SIZE, %esp
+	andl $CR0_TS_BIT, %eax
+	xchgl FPU_CONTEXT_SIZE(%esp), %eax
+	jnz .exception_pushRegisters
+	/* Save FPU context */
+	fsave (%esp)
+.exception_pushRegisters:
+	pushw %ds
+	pushw %es
+	pushw %fs
+	pushw %gs
+	pushl %eax
+	pushl %ebx
+	pushl %ecx
+	pushl %edx
+	pushl %ebp
+	pushl %esi
+	pushl %edi
+
+	movl %dr5, %eax
+	pushl %eax
+	movl %dr4, %eax
+	pushl %eax
+	movl %dr3, %eax
+	pushl %eax
+	movl %dr2, %eax
+	pushl %eax
+	movl %dr1, %eax
+	pushl %eax
+	movl %dr0, %eax
+	pushl %eax
+	subl $4, %esp
+	ret
+.size exception_pushContext, .-exception_pushContext
+
+.align 4, 0x90
+exception_popContext:
+	popl %eax
+	movl %eax, %dr0
+	popl %eax
+	movl %eax, %dr1
+	popl %eax
+	movl %eax, %dr2
+	popl %eax
+	movl %eax, %dr3
+	popl %eax
+	movl %eax, %dr4
+	popl %eax
+	movl %eax, %dr5
+
+	popl %edi
+	popl %esi
+	popl %ebp
+	popl %edx
+	popl %ecx
+	popl %ebx
+	popl %eax
+	popw %gs
+	popw %fs
+	popw %es
+	popw %ds
+	/* FPU context */
+	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
+	movl %eax, FPU_CONTEXT_SIZE(%esp)
+	movl %cr0, %eax
+	jz .exception_popFPU
+	orl $CR0_TS_BIT, %eax
+	movl %eax, %cr0
+	addl $FPU_CONTEXT_SIZE, %esp
+	popl %eax
+	addl $4, %esp
+	iret
+	.exception_popFPU:
+	andl $~CR0_TS_BIT, %eax
+	mov %eax, %cr0
+	frstor (%esp)
+	addl $FPU_CONTEXT_SIZE, %esp
+	popl %eax
+	addl $4, %esp
+	iret
+.size exception_popContext, .-exception_popContext
+
+/* Used for FPU lazy context stacking */
+.globl exceptions_exc7_handler
+.align 4, 0x90
+.type exceptions_exc7_handler, @function
+exceptions_exc7_handler:
+	/* Clear task-switched flag */
+	clts
+	movl 8(%esp), %eax /* eax := ctx */
+	/* ctx->cr0Bits &= ~CR0_TS_BIT */
+	movl 168(%eax), %ecx /* ecx := ctx->cr0Bits */
+	andl $~CR0_TS_BIT, %ecx /* ecx := ctx->cr0Bits & ~CR0_TS_BIT */
+	movl %ecx, 168(%eax)
+	/* Init FPU */
+	fninit
+	fsave 60(%eax) /* Set ctx->fpuContext */
+	ret
+
+.size exceptions_exc7_handler, .-exceptions_exc7_handler
 
 /* Exception stub function definition */
 #define EXCDEF(sym) \
@@ -31,31 +143,7 @@ sym:
 /* Exception handling macro */
 #define EXCSTUB(exc)\
 	cli;\
-	pushw %ds;\
-	pushw %es;\
-	pushw %fs;\
-	pushw %gs;\
-	pushl %eax;\
-	pushl %ebx;\
-	pushl %ecx;\
-	pushl %edx;\
-	pushl %ebp;\
-	pushl %esi;\
-	pushl %edi;\
-	;\
-	movl %dr5, %eax;\
-	pushl %eax;\
-	movl %dr4, %eax;\
-	pushl %eax;\
-	movl %dr3, %eax;\
-	pushl %eax;\
-	movl %dr2, %eax;\
-	pushl %eax;\
-	movl %dr1, %eax;\
-	pushl %eax;\
-	movl %dr0, %eax;\
-	pushl %eax;\
-	;\
+	call exception_pushContext;\
 	movl $SEL_KDATA, %eax;\
 	movw %ax, %ds;\
 	movw %ax, %es;\
@@ -70,32 +158,7 @@ sym:
 	call *%eax;\
 	addl $8, %esp;\
 	;\
-	popl %eax;\
-	movl %eax, %dr0;\
-	popl %eax;\
-	movl %eax, %dr1;\
-	popl %eax;\
-	movl %eax, %dr2;\
-	popl %eax;\
-	movl %eax, %dr3;\
-	popl %eax;\
-	movl %eax, %dr4;\
-	popl %eax;\
-	movl %eax, %dr5;\
-	;\
-	popl %edi;\
-	popl %esi;\
-	popl %ebp;\
-	popl %edx;\
-	popl %ecx;\
-	popl %ebx;\
-	popl %eax;\
-	popw %gs;\
-	popw %fs;\
-	popw %es;\
-	popw %ds;\
-	addl $4, %esp;\
-	iret;
+	jmp exception_popContext
 
 
 /* Exception stubs */

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -18,7 +18,7 @@
 
 #include <arch/cpu.h>
 
-#define CTXPUSHL 43 // 10 + 5 + 28
+#define CTXPUSHL 43 /* 10 + 5 + 28 */
 
 .text
 

--- a/hal/ia32/_init.S
+++ b/hal/ia32/_init.S
@@ -194,6 +194,11 @@ b0:
 b1:	btl $12, (0xfee00300)
 	jc b1
 b3:
+	/* Set FPU */
+	fninit
+	movl %cr0, %eax
+	orl $8, %eax	// Set TS flag
+	mov %eax, %cr0
 	/* Now jump to main function */
 	pushl $0
 	pushl $0

--- a/hal/ia32/_init.S
+++ b/hal/ia32/_init.S
@@ -197,7 +197,7 @@ b3:
 	/* Set FPU */
 	fninit
 	movl %cr0, %eax
-	orl $8, %eax	// Set TS flag
+	orl $8, %eax	/* Set TS flag */
 	mov %eax, %cr0
 	/* Now jump to main function */
 	pushl $0

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -24,10 +24,12 @@
 
 
 #ifndef NDEBUG
-#define CTXPUSHL 14
+#define CTXPUSHL 42 /* 10 + 4 (DEBUG) + 28 (FPU) */
 #else
-#define CTXPUSHL 10
+#define CTXPUSHL 38 /* 10 + 28 (FPU) */
 #endif
+
+#define EAX_OFFSET (16 + (FPU_CONTEXT_SIZE))
 
 
 .global interrupts_pushContext
@@ -35,6 +37,16 @@ interrupts_pushContext:
 	xchgl (%esp), %edx
 	movl %edx, -(4 * CTXPUSHL)(%esp)
 	popl %edx
+	/* Check TS flag in CR0 register */
+	pushl %eax
+	movl %cr0, %eax
+	subl $FPU_CONTEXT_SIZE, %esp
+	andl $CR0_TS_BIT, %eax
+	xchgl FPU_CONTEXT_SIZE(%esp), %eax
+	jnz .interrupts_pushRegisters
+	/* Save FPU context */
+	fsave (%esp)
+.interrupts_pushRegisters:
 	pushw %ds
 	pushw %es
 	pushw %fs
@@ -55,7 +67,7 @@ interrupts_pushContext:
 	pushl %edx
 	movl %dr0, %edx
 	pushl %edx
-#endif	
+#endif
 	pushl %esp
 	subl $4, %esp
 	ret
@@ -86,6 +98,22 @@ interrupts_popContext:
 	popw %fs
 	popw %es
 	popw %ds
+	/* FPU context */
+	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
+	movl %eax, FPU_CONTEXT_SIZE(%esp)
+	movl %cr0, %eax
+	jz .interrupts_popFPU
+	orl $CR0_TS_BIT, %eax
+	movl %eax, %cr0
+	addl $FPU_CONTEXT_SIZE, %esp
+	popl %eax
+	iret;
+	.interrupts_popFPU:
+	andl $~CR0_TS_BIT, %eax
+	mov %eax, %cr0
+	frstor (%esp)
+	addl $FPU_CONTEXT_SIZE, %esp
+	popl %eax
 	iret
 .size interrupts_popContext, .-interrupts_popContext
 
@@ -216,6 +244,6 @@ _interrupts_syscall:
 	call syscalls_dispatch
 	cli
 	addl $8, %esp
-	movl %eax, (4 * CTXPUSHL - 12)(%esp)
+	movl %eax, (4 * CTXPUSHL - EAX_OFFSET)(%esp)	// Save return value to eax in context
 	jmp interrupts_popContext
 .size _interrupts_syscall, .-_interrupts_syscall

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -244,6 +244,6 @@ _interrupts_syscall:
 	call syscalls_dispatch
 	cli
 	addl $8, %esp
-	movl %eax, (4 * CTXPUSHL - EAX_OFFSET)(%esp)	// Save return value to eax in context
+	movl %eax, (4 * CTXPUSHL - EAX_OFFSET)(%esp)	/* Save return value to eax in context */
 	jmp interrupts_popContext
 .size _interrupts_syscall, .-_interrupts_syscall

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -103,6 +103,8 @@
 
 #define TLS_DESC_IDX 5
 
+#define CR0_TS_BIT       8u
+#define FPU_CONTEXT_SIZE 108u /* sizeof(fpu_context_t) */
 
 #ifndef __ASSEMBLY__
 
@@ -149,10 +151,11 @@ typedef struct {
 	u16 fs;
 	u16 es;
 	u16 ds;
+	fpu_context_t fpuContext;
+	u32 cr0Bits;
 	u32 eip; /* eip, cs, eflags, esp, ss saved by CPU on interrupt */
 	u32 cs;
 	u32 eflags;
-
 	u32 esp;
 	u32 ss;
 } cpu_context_t;

--- a/hal/ia32/arch/exceptions.h
+++ b/hal/ia32/arch/exceptions.h
@@ -47,6 +47,8 @@ typedef struct {
 	u16 fs;
 	u16 es;
 	u16 ds;
+	fpu_context_t fpuContext;
+	u32 cr0Bits;
 	u32 err;
 	u32 eip;
 	u32 cs;

--- a/hal/ia32/arch/types.h
+++ b/hal/ia32/arch/types.h
@@ -26,6 +26,18 @@ typedef unsigned short u16;
 typedef unsigned int u32;
 typedef unsigned long long u64;
 
+typedef u8 ld80[10]; /* Long double as bytes */
+typedef struct {
+	u16 _controlWord, controlWord;
+	u16 _statusWord, statusWord;
+	u16 _tagWord, tagWord;
+	u32 fip;
+	u32 fips;
+	u32 fdp;
+	u16 _fds, fds;
+	ld80 fpuContext[8];
+} fpu_context_t;
+
 typedef char s8;
 typedef short s16;
 typedef int s32;

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -74,14 +74,17 @@ int hal_exceptionsFaultType(unsigned int n, exc_context_t *ctx)
 {
 	int prot = PROT_NONE;
 
-	if (ctx->err & 1)
+	if ((ctx->err & 1) != 0) {
 		prot |= PROT_READ;
+	}
 
-	if (ctx->err & 2)
+	if ((ctx->err & 2) != 0) {
 		prot |= PROT_WRITE;
+	}
 
-	if (ctx->err & 4)
+	if ((ctx->err & 4) != 0) {
 		prot |= PROT_USER;
+	}
 
 	return prot;
 }
@@ -211,8 +214,9 @@ int hal_exceptionsSetHandler(unsigned int n, void (*handler)(unsigned int, exc_c
 		return EOK;
 	}
 
-	if (n >= SIZE_EXCHANDLERS)
+	if (n >= SIZE_EXCHANDLERS) {
 		return -EINVAL;
+	}
 
 	hal_spinlockSet(&exceptions.lock, &sc);
 	exceptions.handlers[n] = handler;

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -58,7 +58,7 @@ extern void _exceptions_exc28(void);
 extern void _exceptions_exc29(void);
 extern void _exceptions_exc30(void);
 extern void _exceptions_exc31(void);
-
+extern void exceptions_exc7_handler(unsigned int n, exc_context_t *ctx);
 
 #define SIZE_EXCHANDLERS   32
 
@@ -282,8 +282,10 @@ __attribute__ ((section (".init"))) void _hal_exceptionsInit(void)
 	_exceptions_setIDTStub(30, _exceptions_exc30);
 	_exceptions_setIDTStub(31, _exceptions_exc31);
 
-	for (k = 0; k < SIZE_EXCHANDLERS; k++)
+	for (k = 0; k < SIZE_EXCHANDLERS; k++) {
 		exceptions.handlers[k] = exceptions_trampoline;
+	}
+	exceptions.handlers[7] = exceptions_exc7_handler;
 
 	return;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

DONE: RTOS-354

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After the change, two and more processes can use the FPU, without the risk of overwriting FPU registers.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
