### PR TITLE
log: postpone log scrub to respond to write earlier

### DIFF
--- a/log/log.c
+++ b/log/log.c
@@ -367,6 +367,10 @@ void log_msgHandler(msg_t *msg, oid_t oid, unsigned long int rid)
 			break;
 		case mtWrite:
 			msg->o.io.err = log_write(msg->i.data, msg->i.size);
+			/* Writing thread is blocked on this write. Response should be sent as soon as possible */
+			proc_respond(oid.port, msg, rid);
+			respond = 0;
+			/* TODO: consider moving scrub to minimize delay before next message can be received */
 			log_scrub();
 			break;
 		case mtClose:


### PR DESCRIPTION
This can improve relatively slow klog write times. It is still important to know that logging from threads with higher priority than usrv can result in priority inversion.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
