### PR TITLE
syscalls: Remove log_scrub from syscalls_dispatch

### DIFF
--- a/syscalls.c
+++ b/syscalls.c
@@ -25,7 +25,6 @@
 #include "vm/object.h"
 #include "posix/posix.h"
 #include "syspage.h"
-#include "log/log.h"
 
 #define SYSCALLS_NAME(name)   syscalls_##name,
 #define SYSCALLS_STRING(name) #name,
@@ -1496,11 +1495,6 @@ const char *const syscall_strings[] = { SYSCALLS(SYSCALLS_STRING) };
 void *syscalls_dispatch(int n, char *ustack)
 {
 	void *retval;
-
-	/* Do before syscall to reduce jitter.
-	 * We don't have spare kernel threads (apart from idle) to do this.
-	 * Only kernel logs need scrubing, so in most cases this is a no-op */
-	log_scrubTry();
 
 	if (n >= sizeof(syscalls) / sizeof(syscalls[0]))
 		return (void *)-EINVAL;


### PR DESCRIPTION
There is a problem in msg implementation on MMU targets - it is assumed that the same process does proc_respond and it got the msg from proc_recv. In this case kernel thread did proc_recv and some random user thread does proc_respond, which causes unability to unmap msg related memory in proc_respond. log_scrub is not really needed here, so I chose to fix the problem this way.

DONE: RTOS-434

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (DTR, SKAL).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
