### PR TITLE
hal/ia32: Remove stack canary (debug registers)

### DIFF
--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -23,11 +23,7 @@
 .text
 
 
-#ifndef NDEBUG
-#define CTXPUSHL 42 /* 10 + 4 (DEBUG) + 28 (FPU) */
-#else
 #define CTXPUSHL 38 /* 10 + 28 (FPU) */
-#endif
 
 #define EAX_OFFSET (16 + (FPU_CONTEXT_SIZE))
 
@@ -58,16 +54,6 @@ interrupts_pushContext:
 	pushl %ebp
 	pushl %esi
 	pushl %edi
-#ifndef NDEBUG
-	movl %dr3, %edx
-	pushl %edx
-	movl %dr2, %edx
-	pushl %edx
-	movl %dr1, %edx
-	pushl %edx
-	movl %dr0, %edx
-	pushl %edx
-#endif
 	pushl %esp
 	subl $4, %esp
 	ret
@@ -77,16 +63,6 @@ interrupts_pushContext:
 .global interrupts_popContext
 interrupts_popContext:
 	popl %esp
-#ifndef NDEBUG
-	popl %edx
-	movl %edx, %dr0
-	popl %edx
-	movl %edx, %dr1
-	popl %edx
-	movl %edx, %dr2
-	popl %edx
-	movl %edx, %dr3
-#endif
 	popl %edi
 	popl %esi
 	popl %ebp

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -134,12 +134,6 @@
 /* CPU context saved by interrupt handlers on thread kernel stack */
 typedef struct {
 	u32 savesp;
-#ifndef NDEBUG
-	u32 dr0;
-	u32 dr1;
-	u32 dr2;
-	u32 dr3;
-#endif
 	u32 edi;
 	u32 esi;
 	u32 ebp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Existing implementation of stack canary that uses debug registers does not work correctly: value of debug registers is not changed after stack change.
It requires too many changes in API to make it work correctly, so we're removing it.

DONE: RTOS-360

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
