### PR TITLE
ia32: move hal_cpuReschedule() to asm

### DIFF
--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -5,9 +5,9 @@
  *
  * Interrupt stubs
  *
- * Copyright 2012, 2016, 2020 Phoenix Systems
+ * Copyright 2012, 2016, 2020, 2023 Phoenix Systems
  * Copyright 2001, 2005 Pawel Pisarczyk
- * Author; Pawel Pisarczyk, Jan Sikorski
+ * Author; Pawel Pisarczyk, Jan Sikorski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -18,7 +18,7 @@
 
 #include <arch/cpu.h>
 
-.extern _interrupts_multilock;
+.extern _interrupts_multilock
 
 .text
 
@@ -28,7 +28,24 @@
 #define EAX_OFFSET (16 + (FPU_CONTEXT_SIZE))
 
 
+.macro _INTERRUPTS_MULTILOCKSET reg
+	xorl \reg, \reg
+1:
+	xchgl _interrupts_multilock, \reg
+	orl \reg, \reg
+	jz 1b
+.endm
+
+
+.macro _INTERRUPTS_MULTILOCKCLEAR reg
+	xorl \reg, \reg
+	incl \reg
+	xchgl _interrupts_multilock, \reg
+.endm
+
+
 .global interrupts_pushContext
+.align 4, 0x90
 interrupts_pushContext:
 	xchgl (%esp), %edx
 	movl %edx, -(4 * CTXPUSHL)(%esp)
@@ -39,10 +56,10 @@ interrupts_pushContext:
 	subl $FPU_CONTEXT_SIZE, %esp
 	andl $CR0_TS_BIT, %eax
 	xchgl FPU_CONTEXT_SIZE(%esp), %eax
-	jnz .interrupts_pushRegisters
+	jnz .Linterrupts_pushRegisters
 	/* Save FPU context */
 	fsave (%esp)
-.interrupts_pushRegisters:
+.Linterrupts_pushRegisters:
 	pushw %ds
 	pushw %es
 	pushw %fs
@@ -61,6 +78,7 @@ interrupts_pushContext:
 
 
 .global interrupts_popContext
+.align 4, 0x90
 interrupts_popContext:
 	popl %esp
 	popl %edi
@@ -78,13 +96,13 @@ interrupts_popContext:
 	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
 	movl %eax, FPU_CONTEXT_SIZE(%esp)
 	movl %cr0, %eax
-	jz .interrupts_popFPU
+	jz .Linterrupts_popFPU
 	orl $CR0_TS_BIT, %eax
 	movl %eax, %cr0
 	addl $FPU_CONTEXT_SIZE, %esp
 	popl %eax
-	iret;
-	.interrupts_popFPU:
+	iret
+.Linterrupts_popFPU:
 	andl $~CR0_TS_BIT, %eax
 	mov %eax, %cr0
 	frstor (%esp)
@@ -92,30 +110,6 @@ interrupts_popContext:
 	popl %eax
 	iret
 .size interrupts_popContext, .-interrupts_popContext
-
-
-.global _interrupts_multilockSet
-_interrupts_multilockSet:
-	pushl %eax
-	xorl %eax, %eax
-_interrupts_multilockSet_l1:
-	xchgl _interrupts_multilock, %eax
-	orl %eax, %eax
-	jz _interrupts_multilockSet_l1
-	popl %eax
-	ret
-.size _interrupts_multiLockSet, .-_interrupts_multilockSet
-
-
-.global _interrupts_multilockClear
-_interrupts_multilockClear:
-	pushl %eax
-	xorl %eax, %eax
-	incl %eax
-	xchgl _interrupts_multilock, %eax
-	popl %eax
-	ret
-.size _interrupts_multilockClear, .-_interrupts_multilockClear
 
 
 #define INTERRUPT(name, intr, func) \
@@ -139,16 +133,14 @@ name:; \
 	addl $4, %esp; \
 	cmpl $0, %ebx; \
 	jz interrupts_popContext; \
-	leal 0(%esp), %eax; \
+	movl %esp, %eax; \
 	pushl $0; \
 	pushl %eax; \
 	pushl $0; \
-	call _interrupts_multilockSet; \
+	_INTERRUPTS_MULTILOCKSET %eax; \
 	call threads_schedule; \
 	addl $12, %esp; \
-	popl %esp; \
-	call _interrupts_multilockClear; \
-	pushl %esp; \
+	_INTERRUPTS_MULTILOCKCLEAR %eax; \
 	jmp interrupts_popContext; \
 .size name, .-name
 
@@ -190,3 +182,89 @@ _interrupts_syscall:
 	movl %eax, (4 * CTXPUSHL - EAX_OFFSET)(%esp)	/* Save return value to eax in context */
 	jmp interrupts_popContext
 .size _interrupts_syscall, .-_interrupts_syscall
+
+
+/* int hal_cpuReschedule(struct _spinlock_t *spinlock, spinlock_ctx_t *scp) */
+.global	hal_cpuReschedule
+.type	hal_cpuReschedule, @function
+.align 4, 0x90
+hal_cpuReschedule:
+	pushl %ebp
+	movl %esp, %ebp
+	pushl %ebx
+
+	cli                    /* hal_cpuDisableInterrupts() */
+
+	movl 8(%ebp), %ecx     /* ecx := spinlock */
+	testl %ecx, %ecx
+	je .Lspinlock_null
+	/* if (spinlock != NULL): */
+
+	/* optimized call to hal_cpuGetCycles(&spinlock->e) */
+	rdtsc                  /* get 64bit timestamp */
+	movl %eax, 12(%ecx)    /* LO64(spinlock->e) := eax */
+	movl %edx, 16(%ecx)    /* HI64(spinlock->e) := edx */
+
+	/* Calculate maximum and minimum lock time */
+.Lupdate_dmax:
+	subl 4(%ecx), %eax     /* eax := LO64(spinlock->e - spinlock->b) */
+	sbbl 8(%ecx), %edx     /* edx := HI64(spinlock->e - spinlock->b) */
+
+	/* eax:edx := (spinlock->e - spinlock->b) */
+
+	/* if (spinlock->dmax < (spinlock->e - spinlock->b): */
+	cmpl 28(%ecx), %eax    /* LO64(spinlock->dmax) */
+	movl 32(%ecx), %ebx    /* HI64(spinlock->dmax) */
+	sbbl %edx, %ebx
+	jnc .Lupdate_dmin
+
+	movl %eax, 28(%ecx)    /* LO64(spinlock->dmax) := eax */
+	movl %edx, 32(%ecx)    /* HI64(spinlock->dmax) := edx */
+
+.Lupdate_dmin:
+	/* if (spinlock->dmin > (spinlock->e - spinlock->b)) */
+	cmpl 20(%ecx), %eax    /* LO64(spinlock->dmin) */
+	movl %edx, %ebx
+	sbbl 24(%ecx), %ebx    /* HI64(spinlock->dmin) */
+	jnc .Lspinlock_clear
+
+	movl %eax, 20(%ecx)    /* LO64(spinlock->dmin) := eax */
+	movl %edx, 24(%ecx)    /* HI64(spinlock->dmin) := edx */
+
+.Lspinlock_clear:
+	xorl %eax, %eax
+	incl %eax
+	xchgl 44(%ecx), %eax   /* atomic(spinlock->lock <=> eax) */
+	movl 12(%ebp), %eax
+	pushl (%eax)           /* err := *scp */
+
+.Lspinlock_done:
+	pushl %cs
+	leal .Lreturn, %eax
+	pushl %eax             /* push far cs:address of return */
+	xorl %eax, %eax
+	call interrupts_pushContext
+	_INTERRUPTS_MULTILOCKSET %eax
+	mov %esp, %eax
+	pushl $0               /* n */
+	pushl %eax             /* cpu context */
+	pushl $0               /* arg */
+	call threads_schedule
+
+	cli                    /* hal_cpuDisableInterrupts() */
+
+	addl $12, %esp
+	_INTERRUPTS_MULTILOCKCLEAR %eax
+	jmp interrupts_popContext
+
+.Lspinlock_null:
+	pushf                  /* err := cpu_getEFLAGS() */
+	jmp .Lspinlock_done
+
+.Lreturn:
+	leal -4(%ebp), %esp
+	popl %ebx
+	popl %ebp
+	ret
+
+.size hal_cpuReschedule, .-hal_cpuReschedule


### PR DESCRIPTION
Functions modifying the stack pointer needs to be implemented in asm, (not as inline asm), this is because the compiler requires the value of the stack pointer to be the same after an asm statement as it was on entry to the statement.

Also listing the stack pointer register `esp` in a clobber list is deprecated now and further will became an error. The previous versions of GCC did not enforce this rule and allowed the stack pointer to appear in the clobber list, with unclear semantics.

Fixes one of the warnings during compilation (https://github.com/phoenix-rtos/phoenix-rtos-project/issues/141):
```
../phoenix-rtos-kernel/hal/ia32/cpu.c:177:2: warning: listing the stack pointer register 'esp' in a clobber list is deprecated [-Wdeprecated]
```

Additional changes along with a detailed description were added during discussion-suggestions in this code review as separate git commits.

JIRA: RTOS-488

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic (single and multi-core (with [this fix](https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/405))).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
