### PR TITLE
interrupts/risc64: fix reschedule invoked indirect

### DIFF
--- a/hal/riscv64/interrupts.c
+++ b/hal/riscv64/interrupts.c
@@ -107,9 +107,6 @@ if (cn != 0) {
 	plic_complete(1, cn);
 }
 
-	if (n == 0)
-		return 0;
-
 	return res;
 }
 


### PR DESCRIPTION
Commit 87aca363a3da0f7bd4ffd59723a5fbd375626318 introduced change to how scheduler is invoked, after that change threads scheduler was never invoked. This fix complements that commit. 

Fix: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/740
Fix: https://github.com/phoenix-rtos/phoenix-rtos-doc/issues/152

JIRA: RTOS-513

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `qemu-system-riscv64`, `spike`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
