### PR TITLE
hal/ia32: Remove unused debug registers from context.

### DIFF
--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -5,9 +5,9 @@
  *
  * Exception stubs
  *
- * Copyright 2012, 2016 Phoenix Systems
+ * Copyright 2012, 2016, 2023 Phoenix Systems
  * Copyright 2001, 2005 Pawel Pisarczyk
- * Author: Pawel Pisarczyk
+ * Author: Pawel Pisarczyk, Andrzej Stalke
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -18,26 +18,24 @@
 
 #include <arch/cpu.h>
 
-#define CTXPUSHL 43 /* 10 + 5 + 28 */
+#define CTXSIZE 148 /* REGISTERS + CR0 + FPU_CONTEXT */
 
 .text
 
 .align 4, 0x90
 exception_pushContext:
 	/* Save return address for ret */
-	xchg (%esp), %edx
-	movl %edx, -(4 * CTXPUSHL)(%esp)
-	popl %edx
+	xchgl (%esp), %edx
+	movl %edx, -CTXSIZE(%esp)
 	/* Check TS flag in CR0 register */
-	pushl %eax
-	movl %cr0, %eax
+	movl %cr0, %edx
 	subl $FPU_CONTEXT_SIZE, %esp
-	andl $CR0_TS_BIT, %eax
-	xchgl FPU_CONTEXT_SIZE(%esp), %eax
-	jnz .exception_pushRegisters
+	andl $CR0_TS_BIT, %edx
+	xchgl FPU_CONTEXT_SIZE(%esp), %edx
+	jnz .Lexception_pushRegisters
 	/* Save FPU context */
 	fsave (%esp)
-.exception_pushRegisters:
+.Lexception_pushRegisters:
 	pushw %ds
 	pushw %es
 	pushw %fs
@@ -49,38 +47,12 @@ exception_pushContext:
 	pushl %ebp
 	pushl %esi
 	pushl %edi
-
-	movl %dr5, %eax
-	pushl %eax
-	movl %dr4, %eax
-	pushl %eax
-	movl %dr3, %eax
-	pushl %eax
-	movl %dr2, %eax
-	pushl %eax
-	movl %dr1, %eax
-	pushl %eax
-	movl %dr0, %eax
-	pushl %eax
 	subl $4, %esp
 	ret
 .size exception_pushContext, .-exception_pushContext
 
 .align 4, 0x90
 exception_popContext:
-	popl %eax
-	movl %eax, %dr0
-	popl %eax
-	movl %eax, %dr1
-	popl %eax
-	movl %eax, %dr2
-	popl %eax
-	movl %eax, %dr3
-	popl %eax
-	movl %eax, %dr4
-	popl %eax
-	movl %eax, %dr5
-
 	popl %edi
 	popl %esi
 	popl %ebp
@@ -96,14 +68,14 @@ exception_popContext:
 	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
 	movl %eax, FPU_CONTEXT_SIZE(%esp)
 	movl %cr0, %eax
-	jz .exception_popFPU
+	jz .Lexception_popFPU
 	orl $CR0_TS_BIT, %eax
 	movl %eax, %cr0
 	addl $FPU_CONTEXT_SIZE, %esp
 	popl %eax
 	addl $4, %esp
 	iret
-	.exception_popFPU:
+	.Lexception_popFPU:
 	andl $~CR0_TS_BIT, %eax
 	mov %eax, %cr0
 	frstor (%esp)
@@ -122,12 +94,12 @@ exceptions_exc7_handler:
 	clts
 	movl 8(%esp), %eax /* eax := ctx */
 	/* ctx->cr0Bits &= ~CR0_TS_BIT */
-	movl 168(%eax), %ecx /* ecx := ctx->cr0Bits */
+	movl (CTXSIZE - 4)(%eax), %ecx /* ecx := ctx->cr0Bits */
 	andl $~CR0_TS_BIT, %ecx /* ecx := ctx->cr0Bits & ~CR0_TS_BIT */
-	movl %ecx, 168(%eax)
+	movl %ecx, (CTXSIZE - 4)(%eax)
 	/* Init FPU */
 	fninit
-	fsave 60(%eax) /* Set ctx->fpuContext */
+	fsave (CTXSIZE - FPU_CONTEXT_SIZE - 4)(%eax) /* Set ctx->fpuContext */
 	ret
 
 .size exceptions_exc7_handler, .-exceptions_exc7_handler
@@ -151,11 +123,9 @@ sym:
 	movw %ax, %gs;\
 	;\
 	/* Call exception handler */ ;\
-	leal 0(%esp), %eax;\
-	pushl %eax;\
-	movl exceptions + (exc) * 4, %eax;\
+	pushl %esp;\
 	pushl $exc;\
-	call *%eax;\
+	call *(exceptions + (exc) * 4);\
 	addl $8, %esp;\
 	;\
 	jmp exception_popContext

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -49,13 +49,11 @@
 interrupts_pushContext:
 	xchgl (%esp), %edx
 	movl %edx, -(4 * CTXPUSHL)(%esp)
-	popl %edx
 	/* Check TS flag in CR0 register */
-	pushl %eax
-	movl %cr0, %eax
+	movl %cr0, %edx
 	subl $FPU_CONTEXT_SIZE, %esp
-	andl $CR0_TS_BIT, %eax
-	xchgl FPU_CONTEXT_SIZE(%esp), %eax
+	andl $CR0_TS_BIT, %edx
+	xchgl FPU_CONTEXT_SIZE(%esp), %edx
 	jnz .Linterrupts_pushRegisters
 	/* Save FPU context */
 	fsave (%esp)

--- a/hal/ia32/arch/exceptions.h
+++ b/hal/ia32/arch/exceptions.h
@@ -30,12 +30,6 @@
 #pragma pack(push, 1)
 
 typedef struct {
-	u32 dr0;
-	u32 dr1;
-	u32 dr2;
-	u32 dr3;
-	u32 dr4;
-	u32 dr5;
 	u32 edi;
 	u32 esi;
 	u32 ebp;

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -157,13 +157,6 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	i += hal_i2s(" edi=", &buff[i], ctx->edi, 16, 1);
 	i += hal_i2s("  gs=", &buff[i], (u32)ctx->gs, 16, 1);
 
-	i += hal_i2s("\ndr0=", &buff[i], ctx->dr0, 16, 1);
-	i += hal_i2s(" dr1=", &buff[i], ctx->dr1, 16, 1);
-	i += hal_i2s(" dr2=", &buff[i], ctx->dr2, 16, 1);
-	i += hal_i2s(" dr3=", &buff[i], ctx->dr3, 16, 1);
-	i += hal_i2s("\ndr4=", &buff[i], ctx->dr4, 16, 1);
-	i += hal_i2s(" dr5=", &buff[i], ctx->dr5, 16, 1);
-
 	__asm__ volatile
 	(" \
 		xorl %%eax, %%eax; \


### PR DESCRIPTION
- Remove unused debug registers from exception context
- Change CTXPUSHL to CTXSIZE
- Small memory optimization in FPU context switch.

JIRA: RTOS-360

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
