### PR TITLE
vm/amap: Fix wrong type of offs passed to amap_page

### DIFF
--- a/vm/amap.c
+++ b/vm/amap.c
@@ -208,7 +208,7 @@ static int amap_unmap(vm_map_t *map, void *v)
 }
 
 
-page_t *amap_page(vm_map_t *map, amap_t *amap, vm_object_t *o, void *vaddr, int aoffs, int offs, int prot)
+page_t *amap_page(vm_map_t *map, amap_t *amap, vm_object_t *o, void *vaddr, int aoffs, offs_t offs, int prot)
 {
 	page_t *p = NULL;
 	anon_t *a;

--- a/vm/amap.h
+++ b/vm/amap.h
@@ -37,7 +37,7 @@ typedef struct _amap_t {
 } amap_t;
 
 
-extern page_t *amap_page(struct _vm_map_t *map, amap_t *amap, struct _vm_object_t *o, void *vaddr, int aoffs, int offs, int prot);
+extern page_t *amap_page(struct _vm_map_t *map, amap_t *amap, struct _vm_object_t *o, void *vaddr, int aoffs, offs_t offs, int prot);
 
 
 extern void amap_clear(amap_t *amap, size_t offset, size_t size);


### PR DESCRIPTION
This mattered only on `sizeof(int) != sizeof(void *)` targets (i.e. `riscv64`) Caused silent mapping of .data directly from ELF instead of a private per-process page

DONE: RTOS-514

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/529

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (riscv-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
