### PR TITLE
hal/ia32: Rename dr4 and dr5 to dr6 and dr7

### DIFF
--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -50,9 +50,9 @@ exception_pushContext:
 	pushl %esi
 	pushl %edi
 
-	movl %dr5, %eax
+	movl %dr7, %eax
 	pushl %eax
-	movl %dr4, %eax
+	movl %dr6, %eax
 	pushl %eax
 	movl %dr3, %eax
 	pushl %eax
@@ -77,9 +77,9 @@ exception_popContext:
 	popl %eax
 	movl %eax, %dr3
 	popl %eax
-	movl %eax, %dr4
+	movl %eax, %dr6
 	popl %eax
-	movl %eax, %dr5
+	movl %eax, %dr7
 
 	popl %edi
 	popl %esi

--- a/hal/ia32/arch/exceptions.h
+++ b/hal/ia32/arch/exceptions.h
@@ -34,8 +34,8 @@ typedef struct {
 	u32 dr1;
 	u32 dr2;
 	u32 dr3;
-	u32 dr4;
-	u32 dr5;
+	u32 dr6;
+	u32 dr7;
 	u32 edi;
 	u32 esi;
 	u32 ebp;

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -161,8 +161,8 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	i += hal_i2s(" dr1=", &buff[i], ctx->dr1, 16, 1);
 	i += hal_i2s(" dr2=", &buff[i], ctx->dr2, 16, 1);
 	i += hal_i2s(" dr3=", &buff[i], ctx->dr3, 16, 1);
-	i += hal_i2s("\ndr4=", &buff[i], ctx->dr4, 16, 1);
-	i += hal_i2s(" dr5=", &buff[i], ctx->dr5, 16, 1);
+	i += hal_i2s("\ndr6=", &buff[i], ctx->dr6, 16, 1);
+	i += hal_i2s(" dr7=", &buff[i], ctx->dr7, 16, 1);
 
 	__asm__ volatile
 	(" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Debug registers DR4 and DR5 are reserved when debug extensions are
enabled (when the DE flag in control register CR4 is set) and attempts
to reference the DR4 and DR5 registers cause invalid-opcode exceptions
(#UD). When debug extensions are not enabled (the DE flag is clear),
these registers are aliased to debug registers DR6 and DR7

JIRA: RTOS-307

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The change is required for the system to work on some hardware.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-pc

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
