### PR TITLE
hal: Fix wrong DEBUG reset on exception logic

### DIFF
--- a/hal/armv7a/exceptions.c
+++ b/hal/armv7a/exceptions.c
@@ -106,7 +106,7 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 	hal_cpuReboot();
 #endif
 

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -98,7 +98,7 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 	hal_cpuReboot();
 #endif
 

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -191,7 +191,7 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 	hal_cpuReboot();
 #endif
 

--- a/hal/riscv64/exceptions.c
+++ b/hal/riscv64/exceptions.c
@@ -119,7 +119,7 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 	hal_cpuReboot();
 #endif
 

--- a/hal/sparcv8leon3/exceptions.c
+++ b/hal/sparcv8leon3/exceptions.c
@@ -128,7 +128,7 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
-#ifndef NDEBUG
+#ifdef NDEBUG
 	hal_cpuReboot();
 #endif
 


### PR DESCRIPTION
DONE: RTOS-489

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
We want to reset on exception when not DEBUG

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
