### PR TITLE
imx6ull: remove dead code

### DIFF
--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -462,8 +462,6 @@ init_syspage:
 	orr r1, r1, #(1 << 6)
 	mcr p15, 0, r1, c1, c0, 1
 
-
-#ifndef CPU_IMX6UL
 	/* Set ARM clock to 792 MHz */
 	/* Set ARM clock divider to 1 */
 	ldr r0, =0x20c4000
@@ -472,9 +470,6 @@ init_syspage:
 	dsb
 
 	mov r2, #3
-#else
-	mov r2, #2
-#endif
 
 	/* Enable usermode device accesses */
 	/* AIPSTZ1, 2, 3 */

--- a/hal/armv7a/imx6ull/imx6ull.c
+++ b/hal/armv7a/imx6ull/imx6ull.c
@@ -178,12 +178,8 @@ static int _imx6ull_setIOmux(int mux, char sion, char mode)
 	volatile u32 *base = imx6ull_common.iomux;
 
 	if (mux >= pctl_mux_boot_mode0 && mux <= pctl_mux_tamper9) {
-#ifdef CPU_IMX6UL
-		mux = (mux - pctl_mux_boot_mode0) + 5;
-#else
 		mux = (mux - pctl_mux_boot_mode0);
 		base = imx6ull_common.iomux_snvs;
-#endif
 	}
 	else if (mux < pctl_mux_jtag_mod || mux > pctl_mux_csi_d7)
 		return -1;
@@ -200,12 +196,8 @@ static int _imx6ull_setIOpad(int pad, char hys, char pus, char pue, char pke, ch
 	volatile u32 *base = imx6ull_common.iomux;
 
 	if (pad >= pctl_pad_test_mode && pad <= pctl_pad_tamper9) {
-#ifdef CPU_IMX6UL
-		pad = (pad - pctl_pad_test_mode) + 163;
-#else
 		pad = pad - pctl_pad_test_mode + 12;
 		base = imx6ull_common.iomux_gpr;
-#endif
 	}
 	else if (pad < pctl_pad_jtag_mod || pad > pctl_pad_csi_d7)
 		return -1;
@@ -252,12 +244,8 @@ static int _imx6ull_getIOmux(int mux, char *sion, char *mode)
 		return -1;
 
 	if (mux >= pctl_mux_boot_mode0 && mux <= pctl_mux_tamper9) {
-#ifdef CPU_IMX6UL
-		mux = (mux - pctl_mux_boot_mode0) + 5;
-#else
 		mux = (mux - pctl_mux_boot_mode0);
 		base = imx6ull_common.iomux_snvs;
-#endif
 	}
 	else if (mux < pctl_mux_jtag_mod || mux > pctl_mux_csi_d7)
 		return -1;
@@ -280,12 +268,8 @@ static int _imx6ull_getIOpad(int pad, char *hys, char *pus, char *pue, char *pke
 		return -1;
 
 	if (pad >= pctl_pad_test_mode && pad <= pctl_pad_tamper9) {
-#ifdef CPU_IMX6UL
-		pad = (pad - pctl_pad_test_mode) + 163;
-#else
 		pad = pad - pctl_pad_test_mode + 12;
 		base = imx6ull_common.iomux_gpr;
-#endif
 	}
 	else if (pad < pctl_pad_jtag_mod || pad > pctl_pad_csi_d7)
 		return -1;


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

The reason for the removal is that support for the `older iMX6UL` has been replaced by the newer `iMX6ULL`. The code related to the older processor has become dead.

Similarly in [plo/pull/270](https://github.com/phoenix-rtos/plo/pull/270)

JIRA: RTOS-519
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
