### PR TITLE
posix: Reduce max fd count on all NOMMU targets

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -23,8 +23,8 @@
 #include "posix_private.h"
 #include "../lib/cbuffer.h"
 
-#ifdef CPU_STM32
-#define MAX_FD_COUNT 8
+#ifdef NOMMU
+#define MAX_FD_COUNT 32
 #else
 #define MAX_FD_COUNT 512
 #endif


### PR DESCRIPTION
- increase max fd count on STM32 from 8 to 32,
- free ~3840 bytes per process on imxrt* and leon3 targets

DONE: RTOS-522

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
