### PR TITLE
riscv64 assembly improvements and thread-local storage fix

### DIFF
--- a/hal/armv7a/cpu.c
+++ b/hal/armv7a/cpu.c
@@ -23,10 +23,12 @@
 
 
 /* Function creates new cpu context on top of given thread kernel stack */
-int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg)
+int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg, hal_tls_t *tls)
 {
 	cpu_context_t *ctx;
 	int i;
+
+	(void)tls;
 
 	*nctx = 0;
 	if (kstack == NULL)

--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -84,9 +84,11 @@ void hal_cpuSetDevBusy(int s)
 }
 
 
-int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg)
+int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg, hal_tls_t *tls)
 {
 	cpu_context_t *ctx;
+
+	(void)tls;
 
 	*nctx = 0;
 	if (kstack == NULL)

--- a/hal/cpu.h
+++ b/hal/cpu.h
@@ -67,7 +67,7 @@ extern void hal_cpuSetGot(void *got);
 extern void *hal_cpuGetGot(void);
 
 
-extern int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg);
+extern int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg, struct _hal_tls_t *tls);
 
 
 extern int hal_cpuReschedule(struct _spinlock_t *spinlock, spinlock_ctx_t *scp);

--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -90,9 +90,11 @@ u32 cpu_getEFLAGS(void)
 }
 
 
-int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg)
+int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg, hal_tls_t *tls)
 {
 	cpu_context_t *ctx;
+
+	(void)tls;
 
 	*nctx = NULL;
 	if (kstack == NULL) {

--- a/hal/riscv64/_init.S
+++ b/hal/riscv64/_init.S
@@ -43,6 +43,7 @@ _start:
 	/* Mask all interrupts */
 	csrw sie, zero
 	csrw sscratch, zero
+	mv tp, zero
 
 	la sp, pmap_common + 4 * SIZE_PAGE
 

--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -5,8 +5,8 @@
  *
  * Interrupt stubs
  *
- * Copyright 2018, 2020 Phoenix Systems
- * Author; Pawel Pisarczyk, Julia Kosowska
+ * Copyright 2018, 2020, 2023 Phoenix Systems
+ * Author: Pawel Pisarczyk, Julia Kosowska, Lukasz Leczkowski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -15,32 +15,46 @@
 
 #define __ASSEMBLY__
 
-#define SR_FS           0x00006000
-#define SR_SUM          0x00040000
-#define SR_MER          0x00080000
+
+#define SR_SIE 0x00000002
+#define SR_FS  0x00006000
+#define SR_SUM 0x00040000
+#define SR_MXR 0x00080000
+
 
 #include <arch/cpu.h>
 
 .text
 
 .macro SAVE
-	csrc sstatus, 2
-	addi sp, sp, -16
-
-//	j 1f
-
-	/* If coming from userspace sscratch register holds kernel stack */
+	/* If coming from userspace, save thread pointer in sscratch and load kernel sp.
+	 * If coming from kernel, sscratch is 0, so we don't swap.
+	 */
 	csrrw tp, sscratch, tp
-	beqz tp, 1f
+	bnez tp, 1f
 
-	/* save user stack and task register in case of priv. switch */
-	sd sp, -8(tp)        /* usp */
-	csrr sp, sscratch
-	sd sp, -16(tp)       /* tp */
-	mv sp, tp
-	addi sp, sp, -16
+	/* Current stack is kernel stack */
+	sd sp, -8(sp)
+
+	addi sp, sp, -296
+	j 2f
+
 1:
-	addi sp, sp, -280
+	/* Save context, tp now holds kernel stack pointer.
+	 * Original tp is saved in sscratch
+	 */
+
+	/* Save task's stack pointer */
+	sd sp, -8(tp)
+
+	/* Swap to current stack */
+	addi sp, tp, -296
+
+2:
+	/* restore tp & sscratch */
+	csrrw tp, sscratch, tp
+
+	/* Save context */
 	sd x1, (sp)          /* ra */
 	sd x3, 8(sp)         /* gp */
 	sd x5, 16(sp)        /* t0 */
@@ -71,26 +85,28 @@
 	sd x30, 216(sp)      /* t5 */
 	sd x31, 224(sp)      /* t6 */
 
-	mv s0, sp
+	sd sp, 232(sp)       /* ksp */
 
 	/* Disable FPU */
 	li t0, SR_FS
 	csrc sstatus, t0
 	/* Allow supervisor access to user space and reading from execute pages (for the time being) */
-	li t0, SR_SUM | SR_MER
+	li t0, SR_SUM | SR_MXR
 	csrs sstatus, t0
 
-	csrrc s1, sstatus, 2
+	csrrc s1, sstatus, SR_SIE
 	csrr s2, sepc
 	csrr s3, sbadaddr
 	csrr s4, scause
+	csrr s5, sscratch
 
-	sd s0, 232(sp)
-	sd s1, 240(sp)
-	sd s2, 248(sp)
-	sd s3, 256(sp)
-	sd s4, 264(sp)
-	sd tp, 272(sp)
+	sd s1, 240(sp)   /* sstatus */
+	sd s2, 248(sp)   /* sepc */
+	sd s3, 256(sp)   /* sbadaddr */
+	sd s4, 264(sp)   /* scause */
+	sd s5, 272(sp)   /* sscratch */
+
+	sd tp, 280(sp)   /* tp */
 
 	/* Kernel mode entered */
 	csrw sscratch, zero
@@ -98,16 +114,15 @@
 
 
 .macro RESTORE
-
 	/* Switch kernel stack */
 	ld sp, 232(sp)
 	ld tp, 272(sp)
 
-	/* Kernel mode left */
+	/* Kernel mode left - this loads ksp to sscratch if returning to userspace, else 0 */
 	csrw sscratch, tp
 
 	ld a0, 240(sp)
-	andi a0, a0, ~2
+	andi a0, a0, ~SR_SIE
 	csrw sstatus, a0
 
 	ld a2, 248(sp)
@@ -143,29 +158,12 @@
 	ld x30, 216(sp)      /* t5 */
 	ld x31, 224(sp)      /* t6 */
 
-//	csrr s0, sstatus
-	addi sp, sp, 280
-//	j 1f
+	ld tp, 280(sp)       /* tp */
 
-	beqz tp, 1f
-	addi sp, sp, 16
-	ld tp, -16(sp)
+	addi sp, sp, 296
+
+	/* Restore task's stack pointer */
 	ld sp, -8(sp)
-
-1:
-	addi sp, sp, 16
-//	li tp, 0
-.endm
-
-
-.macro CHECKSIGNAL
-//	mv a0, zero
-//	call _proc_sigwant
-//	beqz a0, 1f
-//	mv a0, sp
-//	call proc_sighandle
-	/* Not reached */
-1:
 .endm
 
 
@@ -173,8 +171,6 @@
 .type interrupts_handleintexc, @function
 interrupts_handleintexc:
 .align 8
-	csrc sstatus, 2
-//	csrc sie, 8
 	SAVE
 	mv a0, sp
 
@@ -187,7 +183,7 @@ interrupts_handleintexc:
 	li a0, 0xa
 	j 34f
 
-33:	
+33:
 	li t1, 0x8000000000000005
 	bne s4, t1, 34f
 	call handler
@@ -197,7 +193,6 @@ interrupts_handleintexc:
 	call interrupts_dispatchIRQ
 	j 4f
 
-//	call interrupts_checkSignal
 2:
 	mv a0, s4
 	andi a0, a0, 0xf
@@ -207,36 +202,33 @@ interrupts_handleintexc:
 3:
 	addi s2, s2, 4 /* move pc past ecall instruction */
 	sd s2, 248(sp)
-	mv a0, a7
-	ld a1, 288(sp)      /* usp */
-	li t0, 16
-	add a1, a1, t0
+	mv a0, a7 /* syscall number */
+	ld a1, 288(sp) /* ustack */
 
-csrs sstatus, 2
+	csrs sstatus, SR_SIE
 	call syscalls_dispatch
 	sd a0, 56(sp)
-	csrc sstatus, 2
+	csrc sstatus, SR_SIE
 	j 5f
 4:
 	beq a0, zero, 5f
 	li a0, 0
 	mv a1, sp
-	call threads_schedule;
+	call threads_schedule
 
 5:
-	CHECKSIGNAL
 	RESTORE
 	sret
-
 .size interrupts_handleintexc, .-interrupts_handleintexc
 
 
 
 .global hal_cpuReschedule
 hal_cpuReschedule:
-	csrrc tp, sstatus, 2
+	/* Disable interrupts */
+	csrc sstatus, SR_SIE
 
-	/* Change correctly status register */
+	/* Save return address */
 	csrw sepc, ra
 
 	SAVE
@@ -267,7 +259,6 @@ hal_cpuReschedule:
 	mv a2, zero
 	call threads_schedule
 
-	CHECKSIGNAL
 	RESTORE
 	sret
 .size hal_cpuReschedule, .-hal_cpuReschedule
@@ -284,66 +275,61 @@ hal_longjmp:
 
 .global hal_jmp  /* void hal_jmp(void *f, void *kstack, void *stack, int argc) */
 hal_jmp:
-       mv s0, a0
-       mv s1, a1
-       mv s2, a2
-       mv s3, a3
-       csrc sstatus, 2 /* disable interrupts */
+	mv s0, a0
+	mv s1, a1
+	mv s2, a2
+	mv s3, a3
+	csrc sstatus, SR_SIE /* disable interrupts */
 
-       bnez a2, 2f
+	bnez a2, 2f
 
-       mv sp, s1
-       addi s3, s3, -1
-       blt s3, zero, 1f
-       ld a0, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 1f
-       ld a1, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 1f
-       ld a2, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 1f
-       ld a3, (sp)
-       addi sp, sp, 8
+	mv sp, s1
+	addi s3, s3, -1
+	blt s3, zero, 1f
+	ld a0, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 1f
+	ld a1, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 1f
+	ld a2, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 1f
+	ld a3, (sp)
+	addi sp, sp, 8
 1:
-       csrs sstatus, 2 /* enable interrupts */
-       jr s0
+	csrs sstatus, SR_SIE /* enable interrupts */
+	jr s0
 
 2:
-//       csrc sstatus, 2 /* disable interrupts */
+	csrw sscratch, s1 /* kernel stack pointer */
 
-       csrw sscratch, s1 /* kernel stack pointer */
+	mv sp, s2 /* user stack pointer */
+	addi sp, sp, 8 /* skip return address */
 
-       mv sp, s2 /* user stack pointer */
-       addi sp, sp, 8 /* skip return address */
-
-       addi s3, s3, -1
-       blt s3, zero, 3f
-       ld a0, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 3f
-       ld a1, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 3f
-       ld a2, (sp)
-       addi sp, sp, 8
-       addi s3, s3, -1
-       blt s3, zero, 3f
-       ld a3, (sp)
-       addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 3f
+	ld a0, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 3f
+	ld a1, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 3f
+	ld a2, (sp)
+	addi sp, sp, 8
+	addi s3, s3, -1
+	blt s3, zero, 3f
+	ld a3, (sp)
+	addi sp, sp, 8
 3:
-//	csrs sstatus, 2 /* enable interrupts */
+	li t0, 0x120
+	csrc sstatus, t0 /* sret will return to usermode */
+	csrw sepc, s0 /* address to return to */
 
-       li t0, 0x120
-       csrc sstatus, t0 /* sret will return to usermode */
-       csrw sepc, s0 /* address to return to */
-
-       sret
-
+	sret
 .size hal_jmp, .-hal_jmp

--- a/hal/riscv64/cpu.c
+++ b/hal/riscv64/cpu.c
@@ -111,7 +111,7 @@ unsigned int hal_cpuGetFirstBit(unsigned long v)
 /* context management */
 
 
-int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg)
+int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t kstacksz, void *ustack, void *arg, hal_tls_t *tls)
 {
 	cpu_context_t *ctx;
 
@@ -172,8 +172,9 @@ int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t
 		ctx->sp = (u64)ustack;
 		ctx->sstatus = csr_read(sstatus) | SR_SPIE | SR_SUM;
 		ctx->sscratch = (u64)ctx;
-		ctx->tp = ctx->ksp;
-	} else {
+		ctx->tp = tls->tls_base;
+	}
+	else {
 		ctx->sstatus = csr_read(sstatus) | SR_SPIE | SR_SPP;
 		ctx->sscratch = 0;
 		ctx->tp = 0;
@@ -293,5 +294,5 @@ void _hal_cpuInit(void)
 
 void hal_cpuTlsSet(hal_tls_t *tls, cpu_context_t *ctx)
 {
-	ctx->tp = tls->tls_base;
+	__asm__ volatile("mv tp, %0" ::"r"(tls->tls_base));
 }

--- a/hal/riscv64/cpu.c
+++ b/hal/riscv64/cpu.c
@@ -169,10 +169,7 @@ int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t
 	ctx->ksp = (u64)ctx;
 
 	if (ustack != NULL) {
-		/* While restoring registers sp is incremented by 16
-		 * so it has to be subtracted here
-		 */
-		ctx->sp = (u64)ustack - 16;
+		ctx->sp = (u64)ustack;
 		ctx->sstatus = csr_read(sstatus) | SR_SPIE | SR_SUM;
 		ctx->sscratch = (u64)ctx;
 		ctx->tp = ctx->ksp;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -832,10 +832,6 @@ int proc_threadCreate(process_t *process, void (*start)(void *), unsigned int *i
 	t->startTime = hal_timerGetUs();
 	t->lastTime = t->startTime;
 
-	/* Prepare initial stack */
-	hal_cpuCreateContext(&t->context, start, t->kstack, t->kstacksz, (stack == NULL) ? NULL : (unsigned char *)stack + stacksz, arg);
-	threads_canaryInit(t, stack);
-
 	if (process != NULL && (process->tls.tdata_sz != 0 || process->tls.tbss_sz != 0)) {
 		err = process_tlsInit(&t->tls, &process->tls, process->mapp);
 		if (err != EOK) {
@@ -851,6 +847,10 @@ int proc_threadCreate(process_t *process, void (*start)(void *), unsigned int *i
 		t->tls.tls_sz = 0;
 		t->tls.arm_m_tls = NULL;
 	}
+
+	/* Prepare initial stack */
+	hal_cpuCreateContext(&t->context, start, t->kstack, t->kstacksz, (stack == NULL) ? NULL : (unsigned char *)stack + stacksz, arg, &t->tls);
+	threads_canaryInit(t, stack);
 
 	thread_alloc(t);
 	if (id != NULL) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR:
- improves riscv64 asm, removes dead code
- fixes issue with thread-local storage on targets where pointer to tls is set in context
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
FIXES: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/740

DONE: JIRA: RTOS-514
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`, `riscv64-generic-spike`, `sparcv8leon3-gr716-mini`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
