### PR TITLE
imxrt/timer: Fix wrong GPT rollover handling during time fetch

### DIFF
--- a/hal/armv7m/imxrt/timer.c
+++ b/hal/armv7m/imxrt/timer.c
@@ -75,7 +75,9 @@ static time_t hal_timerGetCyc(void)
 
 	if ((*(timer_common.base + gpt_sr) & (1 << 5)) != 0) {
 		lower = *(timer_common.base + gpt_cnt);
-		++upper;
+		if (lower != 0xffffffffUL) {
+			++upper;
+		}
 	}
 	hal_spinlockClear(&timer_common.sp, &sc);
 


### PR DESCRIPTION
DONE: RTOS-533

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fix analogous to the STM32L4 timer fix - rollover interrupt is triggered just before rollover, not after. That caused race during timer value rollover adjustment

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
