### PR TITLE
gr716: remove unnecessary gpio configuration

### DIFF
--- a/hal/sparcv8leon3/gr716/console.c
+++ b/hal/sparcv8leon3/gr716/console.c
@@ -62,28 +62,6 @@ static void _hal_consolePrint(const char *s)
 }
 
 
-static int _hal_consoleSetPin(u8 pin)
-{
-	int err = 0;
-	u8 dir;
-	u8 opt = 0x1, pullup = 0, pulldn = 0;
-
-	switch (pin) {
-		case CONSOLE_TX:
-			dir = GPIO_DIR_OUT;
-			break;
-		case CONSOLE_RX:
-			dir = GPIO_DIR_IN;
-			break;
-		default:
-			err = -1;
-			break;
-	}
-
-	return err == 0 ? _gr716_setIOCfg(pin, opt, dir, pullup, pulldn) : err;
-}
-
-
 static u32 _hal_consoleCalcScaler(u32 baud)
 {
 	u32 scaler = 0;
@@ -119,8 +97,8 @@ void hal_consolePrint(int attr, const char *s)
 
 void _hal_consoleInit(void)
 {
-	_hal_consoleSetPin(CONSOLE_TX);
-	_hal_consoleSetPin(CONSOLE_RX);
+	_gr716_setIomuxCfg(CONSOLE_TX, 0x1, 0, 0);
+	_gr716_setIomuxCfg(CONSOLE_RX, 0x1, 0, 0);
 	_gr716_cguClkEnable(cgu_primary, CONSOLE_CGU);
 	halconsole_common.uart = CONSOLE_BASE;
 	*(halconsole_common.uart + uart_ctrl) = TX_EN;

--- a/hal/sparcv8leon3/gr716/gr716.h
+++ b/hal/sparcv8leon3/gr716/gr716.h
@@ -23,13 +23,6 @@
 #include <arch/types.h>
 
 
-#define GPIO_PORT_0 0
-#define GPIO_PORT_1 1
-
-#define GPIO_DIR_IN  0
-#define GPIO_DIR_OUT 1
-
-
 #define UART0_BASE ((void *)0x80300000)
 #define UART1_BASE ((void *)0x80301000)
 #define UART2_BASE ((void *)0x80302000)
@@ -37,28 +30,13 @@
 #define UART4_BASE ((void *)0x80304000)
 #define UART5_BASE ((void *)0x80305000)
 
-#define GRGPIO0_BASE ((void *)0x8030C000)
-#define GRGPIO1_BASE ((void *)0x8030D000)
-
 #define SYSCLK_FREQ 50000000 /* 50 MHz */
 
 
-extern int _gr716_gpioWritePin(u8 pin, u8 val);
+extern int _gr716_getIomuxCfg(u8 pin, u8 *opt, u8 *pullup, u8 *pulldn);
 
 
-extern int _gr716_gpioReadPin(u8 pin, u8 *val);
-
-
-extern int _gr716_gpioGetPinDir(u8 pin, u8 *dir);
-
-
-extern int _gr716_gpioSetPinDir(u8 pin, u8 dir);
-
-
-extern int _gr716_getIOCfg(u8 pin, u8 *opt, u8 *dir, u8 *pullup, u8 *pulldn);
-
-
-extern int _gr716_setIOCfg(u8 pin, u8 opt, u8 dir, u8 pullup, u8 pulldn);
+extern int _gr716_setIomuxCfg(u8 pin, u8 opt, u8 pullup, u8 pulldn);
 
 
 extern void _gr716_cguClkEnable(u32 cgu, u32 device);

--- a/include/arch/gr716.h
+++ b/include/arch/gr716.h
@@ -39,13 +39,12 @@ enum { cgudev_grdmac0 = 0, cgudev_grdmac1, cgudev_grdmac2, cgudev_grdmac3, cgude
 
 typedef struct {
 	enum { pctl_set = 0, pctl_get } action;
-	enum { pctl_iocfg = 0, pctl_cguctrl, pctl_reboot } type;
+	enum { pctl_iomux = 0, pctl_cguctrl, pctl_reboot } type;
 
 	union {
 		struct {
 			unsigned char pin;
 			unsigned char opt;
-			unsigned char dir;
 			unsigned char pullup;
 			unsigned char pulldn;
 		} iocfg;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Remove unnecessary gpio configuration when setting IO mux
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: RTOS-535

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `sparcv8leon3-gr716-mini`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
