### PR TITLE
proc_threadsList: Fix some thread fields being accessed with the spinlock

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1877,11 +1877,11 @@ int proc_threadsList(int n, threadinfo_t *info)
 			info[i].ppid = 0;
 		}
 
+		hal_spinlockSet(&threads_common.spinlock, &sc);
 		info[i].tid = t->id;
 		info[i].priority = t->priorityBase;
 		info[i].state = t->state;
 
-		hal_spinlockSet(&threads_common.spinlock, &sc);
 		now = _proc_gettimeRaw();
 		if (now != t->startTime)
 			info[i].load = (t->cpuTime * 1000) / (now - t->startTime);


### PR DESCRIPTION

DONE: RTOS-557

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/624

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
