### PR TITLE
posix: posix_ftruncate bugfix

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1146,11 +1146,16 @@ int posix_ftruncate(int fildes, off_t length)
 	int err;
 
 	err = posix_getOpenFile(fildes, &f);
-	if (err == 0) {
-		err = posix_truncate(&f->oid, length);
+	if (err >= 0) {
+		if ((f->status & O_RDONLY) == 0) {
+			err = posix_truncate(&f->oid, length);
+		}
+		else {
+			err = -EBADF;
+		}
+		posix_fileDeref(f);
 	}
 
-	posix_fileDeref(f);
 	return err;
 }
 


### PR DESCRIPTION
- don't allow truncation of read only files,
- don't try to dereference not found file.

DONE: RTOS-558

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/364

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
