### PR TITLE
riscv64: make hal_jmp consistent with other targets

### DIFF
--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -308,7 +308,6 @@ hal_jmp:
 	csrw sscratch, s1 /* kernel stack pointer */
 
 	mv sp, s2 /* user stack pointer */
-	addi sp, sp, 8 /* skip return address */
 
 	addi s3, s3, -1
 	blt s3, zero, 3f

--- a/proc/process.c
+++ b/proc/process.c
@@ -1218,11 +1218,7 @@ static void process_exec(thread_t *current, process_spawn_t *spawn)
 		hal_cpuTlsSet(&current->tls, current->context);
 	}
 
-#ifdef __TARGET_RISCV64
-	hal_jmp(entry, current->kstack + current->kstacksz, stack, 3);
-#else
 	hal_jmp(entry, current->kstack + current->kstacksz, stack, 0);
-#endif
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- remove skipping return address
- call hal_jmp in process_exec with same arguments as on other targets

JIRA: RTOS-559
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work 
- [ ] I will merge this PR by myself when appropriate.
