### PR TITLE
ia32: optimize rdtsc inline assembly

### DIFF
--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -220,16 +220,9 @@ static inline void hal_cpuSetDevBusy(int s)
 
 static inline void hal_cpuGetCycles(cycles_t *cb)
 {
-	__asm__ volatile
-	(" \
-		rdtsc; \
-		movl %0, %%edi; \
-		movl %%eax, (%%edi); \
-		movl %%edx, 4(%%edi)"
-		:
-		:"g" (cb)
-		:"eax", "edx", "edi");
-	return;
+	/* clang-format off */
+	__asm__ volatile ("rdtsc" : "=A" (*cb));
+	/* clang-format on */
 }
 
 


### PR DESCRIPTION
Change removes manual assignment to fixed `edi` register and let compiler (through constraints) decide the best way to store `edx:eax` into `*cb`, this way function inlines very well.

JIRA: RTOS-578

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
