### PR TITLE
kernel: make hal_cpuReschedule atomic on SMP

### DIFF
--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -18,7 +18,6 @@
 
 #include <arch/cpu.h>
 
-.extern _interrupts_multilock
 
 .text
 
@@ -26,22 +25,6 @@
 #define CTXPUSHL 38 /* 10 + 28 (FPU) */
 
 #define EAX_OFFSET (16 + (FPU_CONTEXT_SIZE))
-
-
-.macro _INTERRUPTS_MULTILOCKSET reg
-	xorl \reg, \reg
-1:
-	xchgl _interrupts_multilock, \reg
-	orl \reg, \reg
-	jz 1b
-.endm
-
-
-.macro _INTERRUPTS_MULTILOCKCLEAR reg
-	xorl \reg, \reg
-	incl \reg
-	xchgl _interrupts_multilock, \reg
-.endm
 
 
 .global interrupts_pushContext
@@ -75,7 +58,6 @@ interrupts_pushContext:
 	subl $4, %esp
 	ret
 .size interrupts_pushContext, .-interrupts_pushContext
-
 
 .global interrupts_popContext
 .align 4, 0x90
@@ -137,10 +119,8 @@ name:; \
 	pushl $0; \
 	pushl %eax; \
 	pushl $0; \
-	_INTERRUPTS_MULTILOCKSET %eax; \
 	call threads_schedule; \
 	addl $12, %esp; \
-	_INTERRUPTS_MULTILOCKCLEAR %eax; \
 	jmp interrupts_popContext; \
 .size name, .-name
 
@@ -226,15 +206,12 @@ hal_cpuReschedule:
 	cmpl 20(%ecx), %eax    /* LO64(spinlock->dmin) */
 	movl %edx, %ebx
 	sbbl 24(%ecx), %ebx    /* HI64(spinlock->dmin) */
-	jnc .Lspinlock_clear
+	jnc .Lupdate_done
 
 	movl %eax, 20(%ecx)    /* LO64(spinlock->dmin) := eax */
 	movl %edx, 24(%ecx)    /* HI64(spinlock->dmin) := edx */
 
-.Lspinlock_clear:
-	xorl %eax, %eax
-	incl %eax
-	xchgl 44(%ecx), %eax   /* atomic(spinlock->lock <=> eax) */
+.Lupdate_done:
 	movl 12(%ebp), %eax
 	pushl (%eax)           /* err := *scp */
 
@@ -244,18 +221,27 @@ hal_cpuReschedule:
 	pushl %eax             /* push far cs:address of return */
 	xorl %eax, %eax
 	call interrupts_pushContext
-	_INTERRUPTS_MULTILOCKSET %eax
 	mov %esp, %eax
 	pushl $0               /* n */
 	pushl %eax             /* cpu context */
 	pushl $0               /* arg */
-	call threads_schedule
 
-	cli                    /* hal_cpuDisableInterrupts() */
+	movl 8(%ebp), %ecx     /* ecx := spinlock */
+	testl %ecx, %ecx
+	jz .Lnospinlock
 
+	call _threads_schedule
+
+	xorl %eax, %eax
+	incl %eax
+	movl 8(%ebp), %ecx     /* ecx := spinlock */
+	xchgl 44(%ecx), %eax   /* atomic(spinlock->lock <=> eax) */
+.Lexit:
 	addl $12, %esp
-	_INTERRUPTS_MULTILOCKCLEAR %eax
 	jmp interrupts_popContext
+.Lnospinlock:
+	call threads_schedule
+	jmp .Lexit
 
 .Lspinlock_null:
 	pushf                  /* err := cpu_getEFLAGS() */

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -92,9 +92,6 @@ struct {
 } interrupts;
 
 
-unsigned int _interrupts_multilock;
-
-
 void _interrupts_apicACK(unsigned int n)
 {
 	if (n >= SIZE_INTERRUPTS) {
@@ -214,8 +211,6 @@ char *hal_interruptsFeatures(char *features, unsigned int len)
 __attribute__ ((section (".init"))) void _hal_interruptsInit(void)
 {
 	unsigned int k;
-
-	_interrupts_multilock = 1;
 
 	/* Initialize interrupt controllers (8259A) */
 	hal_outb((void *)0x20, 0x11);  /* ICW1 */

--- a/proc/msg.c
+++ b/proc/msg.c
@@ -504,7 +504,8 @@ int proc_respond(u32 port, msg_t *msg, unsigned long int rid)
 	kmsg->state = msg_responded;
 	kmsg->src = proc_current()->process;
 	proc_threadWakeup(&kmsg->threads);
-	hal_cpuReschedule(&p->spinlock, &sc);
+	hal_spinlockClear(&p->spinlock, &sc);
+	hal_cpuReschedule(NULL, NULL);
 
 	port_put(p, 0);
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -565,17 +565,13 @@ static void _threads_cpuTimeCalc(thread_t *current, thread_t *selected)
 }
 
 
-int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
+int _threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 {
 	thread_t *current, *selected;
 	unsigned int i, sig;
 	process_t *proc;
-	spinlock_ctx_t sc;
-
 	(void)arg;
 	(void)n;
-
-	hal_spinlockSet(&threads_common.spinlock, &sc);
 
 	if (hal_cpuGetID() == 0) {
 		cpu_sendIPI(0, 32);
@@ -618,7 +614,8 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 		threads_common.current[hal_cpuGetID()] = selected;
 		_hal_cpuSetKernelStack(selected->kstack + selected->kstacksz);
 
-		if (((proc = selected->process) != NULL) && (proc->pmapp != NULL)) {
+		proc = selected->process;
+		if ((proc != NULL) && (proc->pmapp != NULL)) {
 			/* Switch address space */
 			pmap_switch(proc->pmapp);
 
@@ -652,11 +649,19 @@ int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 	/* Update CPU usage */
 	_threads_cpuTimeCalc(current, selected);
 
-	hal_spinlockClear(&threads_common.spinlock, &sc);
-
 	return EOK;
 }
 
+
+int threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
+{
+	spinlock_ctx_t sc;
+	int ret;
+	hal_spinlockSet(&threads_common.spinlock, &sc);
+	ret = _threads_schedule(n, context, arg);
+	hal_spinlockClear(&threads_common.spinlock, &sc);
+	return ret;
+}
 
 static thread_t *_proc_current(void)
 {
@@ -1205,8 +1210,8 @@ static int proc_threadWaitEx(thread_t **queue, spinlock_t *spinlock, time_t time
 		return EOK;
 	}
 
-	hal_spinlockClear(&threads_common.spinlock, &tsc);
-	err = hal_cpuReschedule(spinlock, scp);
+	hal_spinlockClear(spinlock, &tsc);
+	err = hal_cpuReschedule(&threads_common.spinlock, scp);
 	hal_spinlockSet(spinlock, scp);
 
 	return err;
@@ -1682,7 +1687,8 @@ static void proc_lockUnlock(lock_t *lock)
 	hal_spinlockSet(&lock->spinlock, &sc);
 
 	if (_proc_lockUnlock(lock) > 0) {
-		hal_cpuReschedule(&lock->spinlock, &sc);
+		hal_spinlockClear(&lock->spinlock, &sc);
+		hal_cpuReschedule(NULL, NULL);
 	}
 	else {
 		hal_spinlockClear(&lock->spinlock, &sc);
@@ -1723,7 +1729,8 @@ int proc_lockClear(lock_t *lock)
 
 	err = _proc_lockClear(lock);
 	if (err > 0) {
-		hal_cpuReschedule(&lock->spinlock, &sc);
+		hal_spinlockClear(&lock->spinlock, &sc);
+		hal_cpuReschedule(NULL, NULL);
 		return EOK;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Makes `hal_cpuReschedule` atomic. Don't merge until changes are done on every platform.
Changed platforms:
- [x] ia32
- [ ] armv7a
- [ ] armv7m
- [ ] riscv64
- [ ] sparcv8leon3

JIRA: RTOS-589

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before this change `hal_cpuReschedule` was protected only by disabled interrupts. It works fine in single-core environment, but it breaks in SMP. After this change, it is protected by `threads_common.spinlock`, so only `threads_common.spinlock` or `NULL` can be given as an argument to `hal_cpuReschedule`.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
