### PR TITLE
page_showPages: optimize page info printing

### DIFF
--- a/lib/printf.c
+++ b/lib/printf.c
@@ -164,7 +164,7 @@ int lib_vsprintf(char *out, const char *format, va_list args)
 			goto end;
 		}
 
-		/* precission, padding (set default to 6 digits) */
+		/* precision, padding (set default to 6 digits) */
 		u32 flags = 0, min_number_len = 0;
 
 		for (;;) {
@@ -498,6 +498,19 @@ int lib_printf(const char *format, ...)
 
 	va_start(ap, format);
 	ret = lib_vprintf(format, ap);
+	va_end(ap);
+
+	return ret;
+}
+
+
+int lib_sprintf(char *out, const char *format, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, format);
+	ret = lib_vsprintf(out, format, ap);
 	va_end(ap);
 
 	return ret;

--- a/lib/printf.h
+++ b/lib/printf.h
@@ -19,6 +19,8 @@
 
 #include <stdarg.h>
 
+extern int lib_sprintf(char *out, const char *format, ...);
+
 
 extern int lib_vsprintf(char *out, const char *format, va_list args);
 

--- a/vm/page.c
+++ b/vm/page.c
@@ -256,14 +256,16 @@ static unsigned int page_digits(unsigned int n, unsigned int base)
 }
 
 
+#define TTY_COLS 80
 void _page_showPages(void)
 {
 	addr_t a;
 	page_t *p;
-	unsigned int rep, i, k, w = 4;
+	unsigned int rep, i, k, w;
 	char c;
+	char buf[TTY_COLS + 1];
 
-	lib_printf("vm: ");
+	w = lib_sprintf(buf, "vm: ");
 	for (i = 0, a = 0; i < (pages.freesz + pages.allocsz) / SIZE_PAGE; i++) {
 		p = &pages.pages[i];
 
@@ -271,21 +273,19 @@ void _page_showPages(void)
 		if (p->addr > a) {
 			if ((rep = (p->addr - a) / SIZE_PAGE) >= 4) {
 				k = page_digits(rep, 10) + 3;
-				if ((w += k) > 80) {
-					if (w - k < 80)
-						lib_printf("\n");
-					lib_printf("vm: ");
-					w = k + 4;
+				if (w + k > TTY_COLS) {
+					lib_printf("%s\n", buf);
+					w = lib_sprintf(buf, "vm: ");
 				}
-				lib_printf("[%dx]", rep);
+				w += lib_sprintf(buf + w, "[%dx]", rep);
 			}
 			else {
 				for (k = 0; k < rep; k++) {
-					if (++w > 80) {
-						lib_printf("vm: ");
-						w = 5;
+					if (w + 1 > TTY_COLS) {
+						lib_printf("%s\n", buf);
+						w = lib_sprintf(buf, "vm: ");
 					}
-					lib_printf("%c", 'x');
+					w += lib_sprintf(buf + w, "%c", 'x');
 				}
 			}
 		}
@@ -299,21 +299,19 @@ void _page_showPages(void)
 
 		if (rep >= 4) {
 			k = page_digits(rep + 1, 10) + 3;
-			if ((w += k) > 80) {
-				if (w - k < 80)
-					lib_printf("\n");
-				lib_printf("vm: ");
-				w = k + 4;
+			if (w + k > TTY_COLS) {
+				lib_printf("%s\n", buf);
+				w = lib_sprintf(buf, "vm: ");
 			}
-			lib_printf("[%d%c]", rep + 1, c);
+			w += lib_sprintf(buf + w, "[%d%c]", rep + 1, c);
 		}
 		else {
 			for (k = 0; k <= rep; k++) {
-				if (++w > 80) {
-					lib_printf("vm: ");
-					w = 5;
+				if (w + 1 > TTY_COLS) {
+					lib_printf("%s\n", buf);
+					w = lib_sprintf(buf, "vm: ");
 				}
-				lib_printf("%c", pmap_marker(p));
+				w += lib_sprintf(buf + w, "%c", pmap_marker(p));
 			}
 		}
 
@@ -321,8 +319,8 @@ void _page_showPages(void)
 		i += rep;
 	}
 
-	if (w < 80)
-		lib_printf("\n");
+	if (w > 4)
+		lib_printf("%s\n", buf);
 
 	return;
 }


### PR DESCRIPTION
## Description

Remove partial printing as lib_printf always adds ANSI color codes.



## Motivation and Context

Breaks testing on zynq sometimes as newline introduced by libklog breaks ANSI codes.

DONE: RTOS-593

RAW output before the change:
![image](https://github.com/phoenix-rtos/phoenix-rtos-kernel/assets/3939983/791654af-37e2-45f5-9936-e4eaa842566a)


RAW output after the change:
![image](https://github.com/phoenix-rtos/phoenix-rtos-kernel/assets/3939983/49749d9d-729f-40bc-a2a0-5f688f99dae7)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
