### PR TITLE
riscv64: boot from PLO

### DIFF
--- a/.codespell_ignore
+++ b/.codespell_ignore
@@ -3,3 +3,5 @@ ptd
 mapp
 pmapp
 HSI
+sie
+hart

--- a/hal/riscv64/Makefile
+++ b/hal/riscv64/Makefile
@@ -4,7 +4,7 @@
 # Copyright 2018, 2020 Phoenix Systems
 #
 
-OBJS += $(addprefix $(PREFIX_O)hal/riscv64/, _init.o _string.o _interrupts.o hal.o spinlock.o interrupts.o cpu.o pmap.o dtb.o timer.o string.o exceptions.o plic.o)
+OBJS += $(addprefix $(PREFIX_O)hal/riscv64/, _init.o _string.o _interrupts.o hal.o spinlock.o interrupts.o cpu.o pmap.o dtb.o timer.o string.o exceptions.o plic.o sbi.o)
 CFLAGS += -Ihal/riscv64
 
 OBJS += $(PREFIX_O)hal/riscv64/console.o

--- a/hal/riscv64/_init.S
+++ b/hal/riscv64/_init.S
@@ -15,28 +15,21 @@
 
 #define __ASSEMBLY__
 
-
-#define SBI_SET_TIMER 0
-#define SBI_CONSOLE_PUTCHAR 1
-#define SBI_CONSOLE_GETCHAR 2
-#define SBI_CLEAR_IPI 3
-#define SBI_SEND_IPI 4
-#define SBI_REMOTE_FENCE_I 5
-#define SBI_REMOTE_SFENCE_VMA 6
-#define SBI_REMOTE_SFENCE_VMA_ASID 7
-#define SBI_SHUTDOWN 8
+#include <arch/cpu.h>
+#include <arch/pmap.h>
 
 #define SR_FS           0x00006000
 #define SR_SUM          0x00040000
 #define SR_MER          0x00080000
 
-#include <arch/cpu.h>
-#include <arch/pmap.h>
+#define VADDR_SYSPAGE (_end + SIZE_PAGE - 1)
 
 
 .section .init, "x"
 
-/* a1 - contains address of dtb (reserved for use in dtb_parse() ) */
+/* a0 - contains address of syspage
+ * a1 - contains address of dtb (reserved for use in dtb_parse())
+ */
 .globl _start
 .type _start, @function
 _start:
@@ -63,51 +56,37 @@ _start:
 	li t0, SR_SUM | SR_MER
 	csrs sstatus, t0
 
+	la t0, hal_syspage /* t0 = &hal_syspage (phy) */
+	li s1, VADDR_KERNEL
+	la s2, _start      /* s2 = kernel start (phy) */
+	la t1, VADDR_SYSPAGE
+	srli t1, t1, 12
+	slli t1, t1, 12
+	add t2, t1, s1
+	sub t2, t2, s2
+	/* store virt addr of syspage in hal_syspage */
+	sd t2, (t0)
+	la t3, hal_relOffs
+	sub t4, t2, a0 /* t4 = offset between syspage VADDR and syspage PHYADDR */
+	sd t4, (t3)
 
-/* Temporary solution: code allowing skipping phoenix-rtos-loader */
-	la t0, _syspage_data
-	ld t0, 28(t0) /* points to syspage->progs address (circular list) */
-	mv t1, t0
-	beqz t1, dtb
+	/* calculate phy addr of syspage end */
+	lw t2, 4(a0) /* t2 = syspage->size */
+	add t2, t2, t1
 
-	/* Copy application to _end + 4MB */
-	la t4, _end + 4 * 1024 * 1024
-
-	li a2, SIZE_PAGE - 1
-	not a3, a2
-
-update_apps:
-	ld t2, 16(t1) /* prog->start */
-	ld t3, 24(t1) /* prog->end */
-
-	/* Align destination address to SIZE_PAGE */
-	add t4, t4, a2
-	and t4, t4, a3
-
-	/* Set new start in prog->start */
-	sd t4, 16(t1)
-
-copy_app:
-	ld t5, (t2)
-	addi t2, t2, 8
-	sd t5, (t4)
-	addi t4, t4, 8
-	bltu t2, t3, copy_app
-
-	/* Set new end in prog->end */
-	sd t4, 24(t1)
-
-	ld t1, (t1)
-	bne t1, t0, update_apps
-/* End of the the temporary code */
+syspage_cpy:
+	ld t3, (a0)
+	addi a0, a0, 8
+	sd t3, (t1)
+	addi t1, t1, 8
+	bltu t1, t2, syspage_cpy
 
 dtb:
 	call dtb_parse
 	call _pmap_preinit
 
-	li a1, VADDR_KERNEL
-	la a0, _start
-	sub a1, a1, a0
+	/* s1 = VADDR_KERNEL, s2 = _start (phy) */
+	sub a1, s1, s2
 
 	/* Point stvec to virtual address of intruction after satp write */
 	la a0, 1f
@@ -119,15 +98,6 @@ dtb:
 	li t0, 3 * SIZE_PAGE + SIZE_PAGE              /* pdirs + stack */
 	add sp, sp, t0
 	add sp, sp, a1
-
-	/* Initialize syspage pointer */
-	la t0, _syspage_data
-	add t0, t0, a1
-	la t1, hal_syspage
-	sd t0, (t1)
-
-	la a0, hal_relOffs
-	sd a1, (a0)
 
 	la a0, pmap_common
 	srl a0, a0, 12
@@ -143,9 +113,7 @@ dtb:
 	la a0, .Lsecondary_park
 	csrw stvec, a0
 
-	call main
-	li a7, SBI_SHUTDOWN
-	ecall
+	j main
 
 .align 4
 .Lsecondary_park:
@@ -153,10 +121,3 @@ dtb:
 	j .Lsecondary_park
 
 .size _start, .-_start
-
-.align 8
-.global _syspage_data
-_syspage_data:
-	/* fill by syspagen */
-.org _syspage_data + 0x400, 0x0
-_syspage_data_end:

--- a/hal/riscv64/_init.S
+++ b/hal/riscv64/_init.S
@@ -20,7 +20,6 @@
 
 #define SR_FS           0x00006000
 #define SR_SUM          0x00040000
-#define SR_MER          0x00080000
 
 #define VADDR_SYSPAGE (_end + SIZE_PAGE - 1)
 
@@ -52,8 +51,8 @@ _start:
 	 */
 	li t0, SR_FS
 	csrc sstatus, t0
-	/* Allow supervisor access to user space and reading from execute pages (for the time being) */
-	li t0, SR_SUM | SR_MER
+	/* Allow supervisor access to user space */
+	li t0, SR_SUM
 	csrs sstatus, t0
 
 	la t0, hal_syspage /* t0 = &hal_syspage (phy) */

--- a/hal/riscv64/_init.S
+++ b/hal/riscv64/_init.S
@@ -18,8 +18,6 @@
 #include <arch/cpu.h>
 #include <arch/pmap.h>
 
-#define SR_FS           0x00006000
-#define SR_SUM          0x00040000
 
 #define VADDR_SYSPAGE (_end + SIZE_PAGE - 1)
 
@@ -49,10 +47,10 @@ _start:
 	 * Disable FPU to detect illegal usage of
 	 * floating point in kernel space
 	 */
-	li t0, SR_FS
+	li t0, SSTATUS_FS
 	csrc sstatus, t0
 	/* Allow supervisor access to user space */
-	li t0, SR_SUM
+	li t0, SSTATUS_SUM
 	csrs sstatus, t0
 
 	la t0, hal_syspage /* t0 = &hal_syspage (phy) */

--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -17,35 +17,44 @@
 
 #include <arch/cpu.h>
 
+.extern hal_cpuKernelStack
+
 .text
 
 .macro SAVE
-	/* If coming from userspace, save thread pointer in sscratch and load kernel sp.
-	 * If coming from kernel, sscratch is 0, so we don't swap.
-	 */
-	csrrw tp, sscratch, tp
-	bnez tp, 1f
+	/* Save a0 to sscratch */
+	csrw sscratch, a0
 
-	/* Current stack is kernel stack */
+	/* Read sstatus to a0 */
+	csrr a0, sstatus
+
+	/* Determine in which mode we were executing before interrupt
+	 * SPP = 0 -> user mode, 1 -> kernel mode
+	 */
+	andi a0, a0, 0x100
+	beqz a0, 1f
+
+	/* Kernel mode */
 	sd sp, -8(sp)
 
 	addi sp, sp, -296
 	j 2f
 
 1:
-	/* Save context, tp now holds kernel stack pointer.
-	 * Original tp is saved in sscratch
+	/* User mode
+	 * Load kernel stack pointer from hal_cpuKernelStack
 	 */
+	ld a0, hal_cpuKernelStack
 
 	/* Save task's stack pointer */
-	sd sp, -8(tp)
+	sd sp, -8(a0)
 
-	/* Swap to current stack */
-	addi sp, tp, -296
+	/* Swap to kernel stack */
+	addi sp, a0, -296
 
 2:
-	/* restore tp & sscratch */
-	csrrw tp, sscratch, tp
+	/* restore a0 */
+	csrr a0, sscratch
 
 	/* Save context */
 	sd x1, (sp)          /* ra */
@@ -91,28 +100,19 @@
 	csrr s2, sepc
 	csrr s3, sbadaddr
 	csrr s4, scause
-	csrr s5, sscratch
 
 	sd s1, 240(sp)   /* sstatus */
 	sd s2, 248(sp)   /* sepc */
 	sd s3, 256(sp)   /* sbadaddr */
 	sd s4, 264(sp)   /* scause */
-	sd s5, 272(sp)   /* sscratch */
 
 	sd tp, 280(sp)   /* tp */
-
-	/* Kernel mode entered */
-	csrw sscratch, zero
 .endm
 
 
 .macro RESTORE
 	/* Switch kernel stack */
 	ld sp, 232(sp)
-	ld tp, 272(sp)
-
-	/* Kernel mode left - this loads ksp to sscratch if returning to userspace, else 0 */
-	csrw sscratch, tp
 
 	ld a0, 240(sp)
 	andi a0, a0, ~SSTATUS_SIE
@@ -210,6 +210,9 @@ _interrupts_return:
 hal_cpuReschedule:
 	/* Disable interrupts */
 	csrc sstatus, SSTATUS_SIE
+	/* Set SPP to supervisor mode */
+	li t0, SSTATUS_SPP
+	csrs sstatus, t0
 
 	/* Save return address */
 	csrw sepc, ra
@@ -230,10 +233,10 @@ hal_cpuReschedule:
 	ld t0, 240(sp)
 	sd zero, 56(sp)
 
-	ori t0, t0, 0x100
-	andi t1, t0, 0x2
+	ori t0, t0, SSTATUS_SPP
+	andi t1, t0, SSTATUS_SIE
 	sll t1, t1, 4
-	andi t0, t0, ~2
+	andi t0, t0, ~SSTATUS_SIE
 	or t0, t0, t1
 
 	/* Save modified flags in old context */
@@ -289,8 +292,6 @@ hal_jmp:
 	jr s0
 
 2:
-	csrw sscratch, s1 /* kernel stack pointer */
-
 	mv sp, s2 /* user stack pointer */
 
 	addi s3, s3, -1

--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -15,13 +15,6 @@
 
 #define __ASSEMBLY__
 
-
-#define SR_SIE 0x00000002
-#define SR_FS  0x00006000
-#define SR_SUM 0x00040000
-#define SR_MXR 0x00080000
-
-
 #include <arch/cpu.h>
 
 .text
@@ -88,13 +81,13 @@
 	sd sp, 232(sp)       /* ksp */
 
 	/* Disable FPU */
-	li t0, SR_FS
+	li t0, SSTATUS_FS
 	csrc sstatus, t0
 	/* Allow supervisor access to user space */
-	li t0, SR_SUM
+	li t0, SSTATUS_SUM
 	csrs sstatus, t0
 
-	csrrc s1, sstatus, SR_SIE
+	csrrc s1, sstatus, SSTATUS_SIE
 	csrr s2, sepc
 	csrr s3, sbadaddr
 	csrr s4, scause
@@ -122,7 +115,7 @@
 	csrw sscratch, tp
 
 	ld a0, 240(sp)
-	andi a0, a0, ~SR_SIE
+	andi a0, a0, ~SSTATUS_SIE
 	csrw sstatus, a0
 
 	ld a2, 248(sp)
@@ -170,7 +163,7 @@
 _interrupts_dispatch:
 .align 8
 	/* Disable interrupts */
-	csrc sstatus, SR_SIE
+	csrc sstatus, SSTATUS_SIE
 
 	SAVE
 	mv a1, sp
@@ -195,10 +188,10 @@ _interrupts_notIrq:
 	mv a0, a7      /* syscall number */
 	ld a1, 288(sp) /* ustack */
 
-	csrs sstatus, SR_SIE
+	csrs sstatus, SSTATUS_SIE
 	call syscalls_dispatch
 	sd a0, 56(sp)
-	csrc sstatus, SR_SIE
+	csrc sstatus, SSTATUS_SIE
 
 	j _interrupts_return
 
@@ -216,7 +209,7 @@ _interrupts_return:
 .global hal_cpuReschedule
 hal_cpuReschedule:
 	/* Disable interrupts */
-	csrc sstatus, SR_SIE
+	csrc sstatus, SSTATUS_SIE
 
 	/* Save return address */
 	csrw sepc, ra
@@ -270,7 +263,7 @@ hal_jmp:
 	mv s1, a1
 	mv s2, a2
 	mv s3, a3
-	csrc sstatus, SR_SIE /* disable interrupts */
+	csrc sstatus, SSTATUS_SIE /* disable interrupts */
 
 	bnez a2, 2f
 
@@ -292,7 +285,7 @@ hal_jmp:
 	ld a3, (sp)
 	addi sp, sp, 8
 1:
-	csrs sstatus, SR_SIE /* enable interrupts */
+	csrs sstatus, SSTATUS_SIE /* enable interrupts */
 	jr s0
 
 2:

--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -90,8 +90,8 @@
 	/* Disable FPU */
 	li t0, SR_FS
 	csrc sstatus, t0
-	/* Allow supervisor access to user space and reading from execute pages (for the time being) */
-	li t0, SR_SUM | SR_MXR
+	/* Allow supervisor access to user space */
+	li t0, SR_SUM
 	csrs sstatus, t0
 
 	csrrc s1, sstatus, SR_SIE
@@ -165,62 +165,51 @@
 .endm
 
 
-.global interrupts_handleintexc
-.type interrupts_handleintexc, @function
-interrupts_handleintexc:
+.global _interrupts_dispatch
+.type _interrupts_dispatch, @function
+_interrupts_dispatch:
 .align 8
 	/* Disable interrupts */
 	csrc sstatus, SR_SIE
 
 	SAVE
-	mv a0, sp
-
-	li t1, 8
-	beq s4, t1, 3f
-	bge s4, zero, 2f
-
-	li t1, 0x8000000000000009
-	bne s4, t1, 33f
-	li a0, 0xa
-	j 34f
-
-33:
-	li t1, 0x8000000000000005
-	bne s4, t1, 34f
-	call handler
-	mv a0, zero
-34:
 	mv a1, sp
-	call interrupts_dispatchIRQ
-	j 4f
 
-2:
-	mv a0, s4
-	andi a0, a0, 0xf
-	mv a1, sp
-	call exceptions_dispatch
-	j 5f
-3:
+	/* Check interrupt source */
+	li s1, SCAUSE_INTR
+	and s0, s4, s1
+	andi a0, s4, 0xff /* Exception code */
+	beqz s0, _interrupts_notIrq
+
+	/* IRQ */
+	call interrupts_dispatch
+	j _interrupts_return
+
+_interrupts_notIrq:
+	li t1, SCAUSE_ECALL
+	bne a0, t1, _interrupts_exception
+
+	/* Syscall */
 	addi s2, s2, 4 /* move pc past ecall instruction */
 	sd s2, 248(sp)
-	mv a0, a7 /* syscall number */
+	mv a0, a7      /* syscall number */
 	ld a1, 288(sp) /* ustack */
 
 	csrs sstatus, SR_SIE
 	call syscalls_dispatch
 	sd a0, 56(sp)
 	csrc sstatus, SR_SIE
-	j 5f
-4:
-	beq a0, zero, 5f
-	li a0, 0
-	mv a1, sp
-	call threads_schedule
 
-5:
+	j _interrupts_return
+
+_interrupts_exception:
+	mv a1, sp
+	call exceptions_dispatch
+
+_interrupts_return:
 	RESTORE
 	sret
-.size interrupts_handleintexc, .-interrupts_handleintexc
+.size _interrupts_dispatch, .-_interrupts_dispatch
 
 
 

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -30,10 +30,20 @@
 #define SIZE_USTACK (8 * SIZE_PAGE)
 #endif
 
-/* CSR bits */
+/* Supervisor Cause Register */
 #define SCAUSE_INTR (1u << 63)
 
+/* Exception codes */
 #define SCAUSE_ECALL 8u /* Environment call from S-mode */
+
+/* Supervisor Status Register */
+#define SSTATUS_SIE  (1u << 1)  /* Supervisor Interrupt Enable */
+#define SSTATUS_SPP  (1u << 8)  /* Previous Supervisor */
+#define SSTATUS_SPIE (1u << 5)  /* Previous Supervisor IE */
+#define SSTATUS_FS   (3u << 13) /* FPU status */
+#define SSTATUS_SUM  (1u << 18) /* Supervisor may access User Memory */
+#define SSTATUS_MXR  (1u << 19) /* Make eXecutable Readable */
+
 
 /* Interrupts */
 #define CLINT_IRQ_FLG (1u << 31) /* Marks that interrupt handler is installed for CLINT, not PLIC */
@@ -115,18 +125,6 @@ typedef struct {
 } cpu_context_t;
 
 #pragma pack(pop)
-
-
-/* CSR routines */
-
-
-#define SR_SIE  0x00000002UL /* Supervisor Interrupt Enable */
-#define SR_SPIE 0x00000020UL /* Previous Supervisor IE */
-#define SR_SPP  0x00000100UL /* Previously Supervisor */
-#define SR_SUM  0x00040000UL /* Supervisor may access User Memory */
-
-#define SIE_STIE 0x00000020UL
-#define SIE_SEIE 0x00000200UL
 
 
 /* interrupts */

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -30,6 +30,14 @@
 #define SIZE_USTACK (8 * SIZE_PAGE)
 #endif
 
+/* CSR bits */
+#define SCAUSE_INTR (1u << 63)
+
+#define SCAUSE_ECALL 8u /* Environment call from S-mode */
+
+/* Interrupts */
+#define CLINT_IRQ_FLG (1u << 31) /* Marks that interrupt handler is installed for CLINT, not PLIC */
+
 
 #ifndef __ASSEMBLY__
 

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -126,13 +126,13 @@ typedef struct {
 
 static inline void hal_cpuDisableInterrupts(void)
 {
-	__asm__ ("csrc sstatus, 2");
+	__asm__ volatile("csrc sstatus, 2");
 }
 
 
 static inline void hal_cpuEnableInterrupts(void)
 {
-	__asm__ ("csrs sstatus, 2");
+	__asm__ volatile("csrs sstatus, 2");
 }
 
 
@@ -141,21 +141,21 @@ static inline void hal_cpuEnableInterrupts(void)
 
 static inline void hal_cpuHalt(void)
 {
-	__asm__ ("wfi");
+	__asm__ volatile("wfi");
 }
 
 
 static inline void hal_cpuSetDevBusy(int s)
 {
+	(void)s;
 }
 
 
 static inline void hal_cpuGetCycles(cycles_t *cb)
 {
-	__asm__ __volatile__ (
-		"rdcycle %0"
-		: "=r" (*(cycles_t *)cb));
-	return;
+	/* clang-format off */
+	__asm__ volatile("rdcycle %0" : "=r"(*(cycles_t *)cb));
+	/* clang-format on */
 }
 
 
@@ -164,11 +164,14 @@ static inline void hal_cpuGetCycles(cycles_t *cb)
 
 static inline void hal_cpuSetCtxGot(cpu_context_t *ctx, void *got)
 {
+	(void)ctx;
+	(void)got;
 }
 
 
 static inline void hal_cpuSetGot(void *got)
 {
+	(void)got;
 }
 
 
@@ -204,7 +207,7 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 
 static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
 {
-	return (ctx->sscratch == 0);
+	return (ctx->sscratch == 0) ? 1 : 0;
 }
 
 

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -213,7 +213,7 @@ static inline void *hal_cpuGetUserSP(cpu_context_t *ctx)
 
 static inline int hal_cpuSupervisorMode(cpu_context_t *ctx)
 {
-	return (ctx->sscratch == 0) ? 1 : 0;
+	return ((ctx->sstatus & SSTATUS_SPP) != 0) ? 1 : 0;
 }
 
 

--- a/hal/riscv64/arch/interrupts.h
+++ b/hal/riscv64/arch/interrupts.h
@@ -20,7 +20,8 @@
 #include "cpu.h"
 
 
-#define SYSTICK_IRQ 0
+#define SYSTICK_IRQ (5u | CLINT_IRQ_FLG)
+
 
 typedef struct _intr_handler_t {
 	struct _intr_handler_t *next;

--- a/hal/riscv64/arch/pmap.h
+++ b/hal/riscv64/arch/pmap.h
@@ -17,10 +17,10 @@
 #define _HAL_RISCV64_PMAP_H_
 
 /* Predefined virtual addresses */
-#define VADDR_KERNEL   0x0000003fc0000000L   /* base virtual address of kernel space */
-#define VADDR_MIN      0x00000000
-#define VADDR_MAX      0xffffffffffffffffL
-#define VADDR_USR_MAX  VADDR_KERNEL
+#define VADDR_KERNEL  0x0000003fc0000000L /* base virtual address of kernel space */
+#define VADDR_MIN     0x00000000
+#define VADDR_MAX     0xffffffffffffffffL
+#define VADDR_USR_MAX VADDR_KERNEL
 
 
 /* Architecure dependent page attributes */
@@ -34,26 +34,26 @@
 
 
 /* Architecure dependent page table attributes */
-#define PTHD_PRESENT  0x01
-#define PTHD_READ     0x02
-#define PTHD_WRITE    0x04
-#define PTHD_EXEC     0x08
-#define PTHD_USER     0x10
+#define PTHD_PRESENT 0x01
+#define PTHD_READ    0x02
+#define PTHD_WRITE   0x04
+#define PTHD_EXEC    0x08
+#define PTHD_USER    0x10
 
 
 /* Page flags */
-#define PAGE_FREE            0x00000001
+#define PAGE_FREE 0x00000001
 
-#define PAGE_OWNER_BOOT      (0 << 1)
-#define PAGE_OWNER_KERNEL    (1 << 1)
-#define PAGE_OWNER_APP       (2 << 1)
+#define PAGE_OWNER_BOOT   (0 << 1)
+#define PAGE_OWNER_KERNEL (1 << 1)
+#define PAGE_OWNER_APP    (2 << 1)
 
-#define PAGE_KERNEL_SYSPAGE  (1 << 4)
-#define PAGE_KERNEL_CPU      (2 << 4)
-#define PAGE_KERNEL_PTABLE   (3 << 4)
-#define PAGE_KERNEL_PMAP     (4 << 4)
-#define PAGE_KERNEL_STACK    (5 << 4)
-#define PAGE_KERNEL_HEAP     (6 << 4)
+#define PAGE_KERNEL_SYSPAGE (1 << 4)
+#define PAGE_KERNEL_CPU     (2 << 4)
+#define PAGE_KERNEL_PTABLE  (3 << 4)
+#define PAGE_KERNEL_PMAP    (4 << 4)
+#define PAGE_KERNEL_STACK   (5 << 4)
+#define PAGE_KERNEL_HEAP    (6 << 4)
 
 
 #ifndef __ASSEMBLY__
@@ -83,6 +83,8 @@ typedef struct _pmap_t {
 	page_t *pmapp;
 } pmap_t;
 
+
 #endif
+
 
 #endif

--- a/hal/riscv64/arch/spinlock.h
+++ b/hal/riscv64/arch/spinlock.h
@@ -29,4 +29,5 @@ typedef struct _spinlock_t {
 	u64 lock;
 } spinlock_t;
 
+
 #endif

--- a/hal/riscv64/arch/types.h
+++ b/hal/riscv64/arch/types.h
@@ -50,6 +50,8 @@ typedef struct _oid_t {
 	id_t id;
 } oid_t;
 
+
 #endif
+
 
 #endif

--- a/hal/riscv64/console.c
+++ b/hal/riscv64/console.c
@@ -18,24 +18,27 @@
 #include "sbi.h"
 
 
-struct {
+static struct {
 	spinlock_t spinlock;
 } console_common;
 
 
 void _hal_consolePrint(const char *s)
 {
-	for (; *s; s++)
-		hal_consolePutch(*s);
+	while (*s != '\0') {
+		hal_consolePutch(*s++);
+	}
 }
 
 
 void hal_consolePrint(int attr, const char *s)
 {
-	if (attr == ATTR_BOLD)
+	if (attr == ATTR_BOLD) {
 		_hal_consolePrint(CONSOLE_BOLD);
-	else if (attr != ATTR_USER)
+	}
+	else if (attr != ATTR_USER) {
 		_hal_consolePrint(CONSOLE_CYAN);
+	}
 
 	_hal_consolePrint(s);
 	_hal_consolePrint(CONSOLE_NORMAL);
@@ -47,14 +50,12 @@ void hal_consolePutch(char c)
 	spinlock_ctx_t sc;
 
 	hal_spinlockSet(&console_common.spinlock, &sc);
-	sbi_ecall(1, 0, c, 0, 0, 0, 0, 0);
+	sbi_ecall(SBI_PUTCHAR, 0, c, 0, 0, 0, 0, 0);
 	hal_spinlockClear(&console_common.spinlock, &sc);
 }
 
 
-__attribute__ ((section (".init"))) void _hal_consoleInit(void)
+__attribute__((section(".init"))) void _hal_consoleInit(void)
 {
 	hal_spinlockCreate(&console_common.spinlock, "console.spinlock");
-
-	return;
 }

--- a/hal/riscv64/console.c
+++ b/hal/riscv64/console.c
@@ -50,7 +50,7 @@ void hal_consolePutch(char c)
 	spinlock_ctx_t sc;
 
 	hal_spinlockSet(&console_common.spinlock, &sc);
-	sbi_ecall(SBI_PUTCHAR, 0, c, 0, 0, 0, 0, 0);
+	hal_sbiPutchar(c);
 	hal_spinlockClear(&console_common.spinlock, &sc);
 }
 

--- a/hal/riscv64/cpu.c
+++ b/hal/riscv64/cpu.c
@@ -169,12 +169,12 @@ int hal_cpuCreateContext(cpu_context_t **nctx, void *start, void *kstack, size_t
 
 	if (ustack != NULL) {
 		ctx->sp = (u64)ustack;
-		ctx->sstatus = csr_read(sstatus) | SR_SPIE | SR_SUM;
+		ctx->sstatus = csr_read(sstatus) | SSTATUS_SPIE | SSTATUS_SUM;
 		ctx->sscratch = (u64)ctx;
 		ctx->tp = tls->tls_base;
 	}
 	else {
-		ctx->sstatus = csr_read(sstatus) | SR_SPIE | SR_SPP;
+		ctx->sstatus = csr_read(sstatus) | SSTATUS_SPIE | SSTATUS_SPP;
 		ctx->sscratch = 0;
 		ctx->tp = 0;
 	}

--- a/hal/riscv64/cpu.c
+++ b/hal/riscv64/cpu.c
@@ -321,10 +321,14 @@ void _hal_cpuInit(void)
 
 void hal_cpuBroadcastIPI(unsigned int intr)
 {
+	(void)intr;
+	/* TODO */
 }
 
 
 void hal_cpuTlsSet(hal_tls_t *tls, cpu_context_t *ctx)
 {
+	(void)ctx;
+
 	__asm__ volatile("mv tp, %0" ::"r"(tls->tls_base));
 }

--- a/hal/riscv64/dtb.c
+++ b/hal/riscv64/dtb.c
@@ -36,7 +36,7 @@ struct _fdt_header_t {
 };
 
 
-struct {
+static struct {
 	struct _fdt_header_t *fdth;
 
 	void *start;

--- a/hal/riscv64/hal.c
+++ b/hal/riscv64/hal.c
@@ -24,13 +24,14 @@
 #include "config.h"
 #include "halsyspage.h"
 
-struct {
+static struct {
 	int started;
 } hal_common;
 
 
 syspage_t *hal_syspage;
 addr_t hal_relOffs;
+
 
 void *hal_syspageRelocate(void *data)
 {
@@ -66,7 +67,7 @@ void hal_lockScheduler(void)
 }
 
 
-__attribute__ ((section (".init"))) void _hal_init(void)
+__attribute__((section(".init"))) void _hal_init(void)
 {
 	_hal_spinlockInit();
 	_hal_consoleInit();
@@ -80,6 +81,4 @@ __attribute__ ((section (".init"))) void _hal_init(void)
 	_hal_cpuInit();
 #endif
 	hal_common.started = 0;
-
-	return;
 }

--- a/hal/riscv64/hal.c
+++ b/hal/riscv64/hal.c
@@ -69,6 +69,7 @@ void hal_lockScheduler(void)
 
 __attribute__((section(".init"))) void _hal_init(void)
 {
+	_hal_sbiInit();
 	_hal_spinlockInit();
 	_hal_consoleInit();
 

--- a/hal/riscv64/interrupts.c
+++ b/hal/riscv64/interrupts.c
@@ -25,139 +25,240 @@
 #include "proc/userintr.h"
 #include "include/errno.h"
 
-
-#define SIZE_INTERRUPTS 16
-
-
-struct {
-	spinlock_t spinlocks[SIZE_INTERRUPTS];
-	intr_handler_t *handlers[SIZE_INTERRUPTS];
-	unsigned int counters[SIZE_INTERRUPTS];
-} interrupts;
+#include <board_config.h>
 
 
-int interrupts_dispatchIRQ(unsigned int n, cpu_context_t *ctx)
+#define CLINT_IRQ_SIZE 16
+
+#define EXT_IRQ 9
+
+/* clang-format off */
+enum irq_state { irq_enable = 0, irq_disable };
+/* clang-format on */
+
+
+static struct {
+	struct {
+		spinlock_t spinlocks[CLINT_IRQ_SIZE];
+		unsigned int counters[CLINT_IRQ_SIZE];
+		intr_handler_t *handlers[CLINT_IRQ_SIZE];
+	} clint;
+
+	struct {
+		spinlock_t spinlocks[PLIC_IRQ_SIZE];
+		unsigned int counters[PLIC_IRQ_SIZE];
+		intr_handler_t *handlers[PLIC_IRQ_SIZE];
+	} plic;
+} interrupts_common;
+
+
+extern int threads_schedule(unsigned int n, cpu_context_t *context, void *arg);
+
+
+static void interrupts_dispatchPlic(cpu_context_t *ctx)
 {
+	int reschedule = 0;
 	intr_handler_t *h;
 	spinlock_ctx_t sc;
-	unsigned int cn = 0;
-	int res = 0;
 
-	if (n >= SIZE_INTERRUPTS)
-		return 0;
+	unsigned int irq = plic_claim(1);
 
-	if (dtb_getPLIC() && (n != 0)) {
-
-		cn = plic_claim(1);
-		if (cn == 0) {
-			return 0;
-		}
-		n = cn;
+	if (irq == 0) {
+		return;
 	}
 
-	hal_spinlockSet(&interrupts.spinlocks[n], &sc);
+	hal_spinlockSet(&interrupts_common.plic.spinlocks[irq], &sc);
 
-	interrupts.counters[n]++;
+	interrupts_common.plic.counters[irq]++;
 
-	if ((h = interrupts.handlers[n]) != NULL) {
-		do
-			if (h->f(n, ctx, h->data))
-				res = 1;
-
-		while ((h = h->next) != interrupts.handlers[n]);
+	h = interrupts_common.plic.handlers[irq];
+	if (h != NULL) {
+		do {
+			reschedule |= h->f(irq, NULL, h->data);
+			h = h->next;
+		} while (h != interrupts_common.plic.handlers[irq]);
 	}
 
-	hal_spinlockClear(&interrupts.spinlocks[n], &sc);
-
-	if (cn != 0) {
-		plic_complete(1, cn);
+	if (reschedule != 0) {
+		threads_schedule(irq, ctx, NULL);
 	}
 
-	return res;
+	hal_spinlockClear(&interrupts_common.plic.spinlocks[irq], &sc);
+
+	plic_complete(1, irq);
+}
+
+
+static void interrupts_dispatchClint(unsigned int n, cpu_context_t *ctx)
+{
+	intr_handler_t *h;
+	int reschedule = 0;
+	spinlock_ctx_t sc;
+
+	hal_spinlockSet(&interrupts_common.clint.spinlocks[n], &sc);
+
+	interrupts_common.clint.counters[n]++;
+
+	h = interrupts_common.clint.handlers[n];
+	if (h != NULL) {
+		do {
+			reschedule |= h->f(n, NULL, h->data);
+			h = h->next;
+		} while (h != interrupts_common.clint.handlers[n]);
+	}
+
+	if (reschedule != 0) {
+		threads_schedule(n, ctx, NULL);
+	}
+
+	hal_spinlockClear(&interrupts_common.clint.spinlocks[n], &sc);
+}
+
+
+void interrupts_dispatch(unsigned int n, cpu_context_t *ctx)
+{
+	if ((n == EXT_IRQ) && (dtb_getPLIC() != 0)) {
+		interrupts_dispatchPlic(ctx);
+	}
+	else {
+		interrupts_dispatchClint(n, ctx);
+	}
+}
+
+
+static int interrupts_setPlic(intr_handler_t *h, enum irq_state enable)
+{
+	spinlock_ctx_t sc;
+
+	if (h->n >= PLIC_IRQ_SIZE) {
+		return -EINVAL;
+	}
+
+	hal_spinlockSet(&interrupts_common.plic.spinlocks[h->n], &sc);
+
+	if (enable == irq_enable) {
+		HAL_LIST_ADD(&interrupts_common.plic.handlers[h->n], h);
+		plic_priority(h->n, 2);
+		plic_enableInterrupt(1, h->n);
+	}
+	else {
+		plic_disableInterrupt(1, h->n);
+		HAL_LIST_REMOVE(&interrupts_common.plic.handlers[h->n], h);
+	}
+
+	hal_spinlockClear(&interrupts_common.plic.spinlocks[h->n], &sc);
+
+	return 0;
+}
+
+
+static int interrupts_setClint(intr_handler_t *h, enum irq_state enable)
+{
+	spinlock_ctx_t sc;
+
+	if (h->n >= CLINT_IRQ_SIZE) {
+		return -EINVAL;
+	}
+
+	hal_spinlockSet(&interrupts_common.clint.spinlocks[h->n], &sc);
+
+	if (enable == irq_enable) {
+		HAL_LIST_ADD(&interrupts_common.clint.handlers[h->n], h);
+		csr_set(sie, 1u << h->n);
+	}
+	else {
+		csr_clear(sie, 1u << h->n);
+		HAL_LIST_REMOVE(&interrupts_common.clint.handlers[h->n], h);
+	}
+
+
+	hal_spinlockClear(&interrupts_common.clint.spinlocks[h->n], &sc);
+
+	return 0;
 }
 
 
 int hal_interruptsSetHandler(intr_handler_t *h)
 {
-	spinlock_ctx_t sc;
+	int ret;
 
-	if (h == NULL || h->f == NULL || h->n >= SIZE_INTERRUPTS)
+	if (h == NULL) {
 		return -EINVAL;
-
-	hal_spinlockSet(&interrupts.spinlocks[h->n], &sc);
-	HAL_LIST_ADD(&interrupts.handlers[h->n], h);
-
-	if (dtb_getPLIC() && (h->n)) {
-		plic_priority(h->n, 2);
-		plic_enableInterrupt(1, h->n, 1);
 	}
 
-	hal_spinlockClear(&interrupts.spinlocks[h->n], &sc);
+	if ((h->n & CLINT_IRQ_FLG) != 0) {
+		h->n = h->n & ~CLINT_IRQ_FLG;
+		ret = interrupts_setClint(h, irq_enable);
+	}
+	else {
+		ret = interrupts_setPlic(h, irq_enable);
+	}
 
-	return EOK;
+	return ret;
 }
 
 
 int hal_interruptsDeleteHandler(intr_handler_t *h)
 {
-	spinlock_ctx_t sc;
+	int ret;
 
-	if (h == NULL || h->f == NULL || h->n >= SIZE_INTERRUPTS)
+	if (h == NULL) {
 		return -EINVAL;
+	}
 
-	hal_spinlockSet(&interrupts.spinlocks[h->n], &sc);
-	HAL_LIST_REMOVE(&interrupts.handlers[h->n], h);
-	hal_spinlockClear(&interrupts.spinlocks[h->n], &sc);
+	if ((h->n & CLINT_IRQ_FLG) != 0) {
+		h->n = h->n & ~CLINT_IRQ_FLG;
+		ret = interrupts_setClint(h, irq_disable);
+	}
+	else {
+		ret = interrupts_setPlic(h, irq_disable);
+	}
 
-	return EOK;
-}
-
-
-__attribute__((aligned(4))) void handler(cpu_context_t *ctx)
-{
-	cycles_t c;
-
-	c = hal_cpuGetCycles2();
-
-	sbi_ecall(SBI_SETTIMER, 0, c + 1000, 0, 0, 0, 0, 0);
+	return ret;
 }
 
 
 char *hal_interruptsFeatures(char *features, unsigned int len)
 {
-	if (dtb_getPLIC())
+	if (dtb_getPLIC()) {
 		hal_strncpy(features, "Using PLIC interrupt controller", len);
-	else
+	}
+	else {
 		hal_strncpy(features, "PLIC interrupt controller not found", len);
+	}
 
-	features[len - 1] = 0;
+	features[len - 1] = '\0';
 
 	return features;
 }
 
 
-extern void interrupts_handleintexc(void *);
+extern void _interrupts_dispatch(void *);
 
 
 __attribute__((section(".init"))) void _hal_interruptsInit(void)
 {
-	unsigned int k;
+	unsigned int i;
 
-	for (k = 0; k < SIZE_INTERRUPTS; k++) {
-		interrupts.handlers[k] = NULL;
-		interrupts.counters[k] = 0;
-		hal_spinlockCreate(&interrupts.spinlocks[k], "interrupts.spinlocks[]");
+	for (i = 0; i < CLINT_IRQ_SIZE; i++) {
+		interrupts_common.clint.handlers[i] = NULL;
+		interrupts_common.clint.counters[i] = 0;
+		hal_spinlockCreate(&interrupts_common.clint.spinlocks[i], "interrupts_common.clint");
+	}
+
+	for (i = 0; i < PLIC_IRQ_SIZE; i++) {
+		interrupts_common.plic.handlers[i] = NULL;
+		interrupts_common.plic.counters[i] = 0;
+		hal_spinlockCreate(&interrupts_common.plic.spinlocks[i], "interrupts_common.plic");
 	}
 
 	/* Enable HART interrupts */
 	csr_write(sscratch, 0);
 	csr_write(sie, -1);
-
-	csr_write(stvec, interrupts_handleintexc);
+	csr_write(stvec, _interrupts_dispatch);
 
 	/* Initialize PLIC if present */
-	if (dtb_getPLIC())
+	if (dtb_getPLIC()) {
 		_plic_init();
-
-	return;
+	}
 }

--- a/hal/riscv64/plic.h
+++ b/hal/riscv64/plic.h
@@ -19,31 +19,34 @@
 #include <arch/types.h>
 
 
-extern void plic_priority(unsigned int n, unsigned int priority);
+void plic_priority(unsigned int n, unsigned int priority);
 
 
-extern u32 plic_priorityGet(unsigned int n);
+u32 plic_priorityGet(unsigned int n);
 
 
-extern int plic_isPending(unsigned int n);
+int plic_isPending(unsigned int n);
 
 
-extern void plic_tresholdSet(unsigned int hart, unsigned int priority);
+void plic_tresholdSet(unsigned int context, unsigned int priority);
 
 
-extern u32 plic_tresholdGet(unsigned int hart);
+u32 plic_tresholdGet(unsigned int context);
 
 
-extern unsigned int plic_claim(unsigned int hart);
+unsigned int plic_claim(unsigned int context);
 
 
-extern int plic_complete(unsigned int hart, unsigned int n);
+void plic_complete(unsigned int context, unsigned int n);
 
 
-extern int plic_enableInterrupt(unsigned int hart, unsigned int n, char enable);
+int plic_enableInterrupt(unsigned int context, unsigned int n);
 
 
-extern int _plic_init(void);
+int plic_disableInterrupt(unsigned int context, unsigned int n);
+
+
+void _plic_init(void);
 
 
 #endif

--- a/hal/riscv64/pmap.c
+++ b/hal/riscv64/pmap.c
@@ -393,6 +393,7 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 
 	/* Initialize kernel heap start address */
 	(*vstart) = (void *)((e + SIZE_PAGE - 1) & ~(SIZE_PAGE - 1));
+	(*vstart) += SIZE_PAGE; /* Reserve space for syspage */
 
 	/* Initialize temporary page table (used for page table mapping) */
 	pmap_common.ptable = (*vstart);
@@ -462,7 +463,8 @@ void _pmap_preinit(void)
 
 	/* Get physical kernel address */
 	pmap_common.kernel = (addr_t)&_start;
-	pmap_common.kernelsz = (addr_t)&_end - (addr_t)&_start;
+	/* Add SIZE_PAGE to kernel size for syspage */
+	pmap_common.kernelsz = (((addr_t)&_end + SIZE_PAGE - 1) & ~(SIZE_PAGE - 1)) - (addr_t)&_start + SIZE_PAGE;
 
 	/* pmap_common.pdir2[(VADDR_KERNEL >> 30) % 512] = ((((u64)_start >> 30) << 28) | 0xcf); */
 

--- a/hal/riscv64/riscv64.h
+++ b/hal/riscv64/riscv64.h
@@ -16,52 +16,66 @@
 #ifndef _HAL_RISCV64_H_
 #define _HAL_RISCV64_H_
 
+
 #include <arch/types.h>
 
 
 #define csr_set(csr, val) \
 	({ \
 		unsigned long __v = (unsigned long)(val); \
-		__asm__ __volatile__("csrs " #csr ", %0" \
-							 : \
-							 : "rK"(__v) \
-							 : "memory"); \
-		__v; \
+		__asm__ volatile( \
+			"csrs " #csr ", %0" \
+			: \
+			: "rK"(__v) \
+			: "memory"); \
 	})
 
 
 #define csr_write(csr, val) \
 	({ \
 		unsigned long __v = (unsigned long)(val); \
-		__asm__ __volatile__("csrw " #csr ", %0" \
-							 : \
-							 : "rK"(__v) \
-							 : "memory"); \
+		__asm__ volatile( \
+			"csrw " #csr ", %0" \
+			: \
+			: "rK"(__v) \
+			: "memory"); \
 	})
 
 
 #define csr_read(csr) \
 	({ \
 		register unsigned long __v; \
-		__asm__ __volatile__("csrr %0, " #csr \
-							 : "=r"(__v) \
-							 : \
-							 : "memory"); \
+		__asm__ volatile( \
+			"csrr %0, " #csr \
+			: "=r"(__v) \
+			: \
+			: "memory"); \
 		__v; \
+	})
+
+
+#define csr_clear(csr, val) \
+	({ \
+		unsigned long __v = (unsigned long)(val); \
+		__asm__ volatile( \
+			"csrc " #csr ", %0" \
+			: \
+			: "rK"(__v) \
+			: "memory"); \
 	})
 
 
 static inline void hal_cpuFlushTLB(void *vaddr)
 {
-	__asm__ ("sfence.vma"::);
+	(void)vaddr;
+
+	__asm__ volatile("sfence.vma" ::);
 }
 
 
 static inline void hal_cpuSwitchSpace(addr_t pdir)
 {
-	__asm__ ("sfence.vma; csrw sptbr, %0"::"r" (pdir));
-
-	return;
+	__asm__ volatile("sfence.vma; csrw sptbr, %0" ::"r"(pdir));
 }
 
 
@@ -69,9 +83,9 @@ static inline cycles_t hal_cpuGetCycles2(void)
 {
 	register cycles_t n;
 
-	__asm__ __volatile__ (
+	__asm__ __volatile__(
 		"rdtime %0"
-		: "=r" (n));
+		: "=r"(n));
 	return n;
 }
 

--- a/hal/riscv64/riscv64.h
+++ b/hal/riscv64/riscv64.h
@@ -75,18 +75,13 @@ static inline void hal_cpuFlushTLB(void *vaddr)
 
 static inline void hal_cpuSwitchSpace(addr_t pdir)
 {
-	__asm__ volatile("sfence.vma; csrw sptbr, %0" ::"r"(pdir));
+	/* clang-format off */
+	__asm__ volatile(
+		"sfence.vma\n\t"
+		"csrw sptbr, %0\n\t"
+		::"r"(pdir));
+	/* clang-format on */
 }
 
-
-static inline cycles_t hal_cpuGetCycles2(void)
-{
-	register cycles_t n;
-
-	__asm__ __volatile__(
-		"rdtime %0"
-		: "=r"(n));
-	return n;
-}
 
 #endif

--- a/hal/riscv64/sbi.c
+++ b/hal/riscv64/sbi.c
@@ -1,0 +1,141 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * SBI routines (RISCV64)
+ *
+ * Copyright 2018, 2020, 2024 Phoenix Systems
+ * Author: Pawel Pisarczyk, Lukasz Leczkowski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "sbi.h"
+
+/* Base extension */
+#define SBI_EXT_BASE 0x10
+
+#define SBI_BASE_SPEC_VER      0x0
+#define SBI_BASE_IMPL_ID       0x1
+#define SBI_BASE_IMPL_VER      0x2
+#define SBI_BASE_PROBE_EXT     0x3
+#define SBI_BASE_GET_MVENDORID 0x4
+#define SBI_BASE_GET_MARCHID   0x5
+#define SBI_BASE_GET_MIMPLID   0x6
+
+/* Timer extension */
+#define SBI_EXT_TIME 0x54494D45
+
+#define SBI_TIME_SETTIMER 0x0
+
+/* Legacy extensions */
+#define SBI_LEGACY_SETTIMER               0x0
+#define SBI_LEGACY_PUTCHAR                0x1
+#define SBI_LEGACY_GETCHAR                0x2
+#define SBI_LEGACY_CLEARIPI               0x3
+#define SBI_LEGACY_SENDIPI                0x4
+#define SBI_LEGACY_REMOTE_FENCE_I         0x5
+#define SBI_LEGACY_REMOTE_SFENCE_VMA      0x6
+#define SBI_LEGACY_REMOTE_SFENCE_VMA_ASID 0x7
+#define SBI_LEGACY_SHUTDOWN               0x8
+
+/* clang-format off */
+#define SBI_MINOR(x) ((x) & 0xffffff)
+/* clang-format on */
+#define SBI_MAJOR(x) ((x) >> 24)
+
+
+static struct {
+	u32 specVersion;
+	void (*setTimer)(u64);
+} sbi_common;
+
+
+static sbiret_t hal_sbiEcall(int ext, int fid, u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5)
+{
+	sbiret_t ret;
+
+	register u64 a0 asm("a0") = arg0;
+	register u64 a1 asm("a1") = arg1;
+	register u64 a2 asm("a2") = arg2;
+	register u64 a3 asm("a3") = arg3;
+	register u64 a4 asm("a4") = arg4;
+	register u64 a5 asm("a5") = arg5;
+	register u64 a6 asm("a6") = fid;
+	register u64 a7 asm("a7") = ext;
+
+	/* clang-format off */
+	__asm__ volatile (
+		"ecall"
+		: "+r" (a0), "+r" (a1)
+		: "r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
+		: "memory");
+	/* clang-format on */
+
+	ret.error = a0;
+	ret.value = a1;
+
+	return ret;
+}
+
+/* Legacy SBI v0.1 calls */
+
+static void hal_sbiSetTimerv01(u64 stime)
+{
+	(void)hal_sbiEcall(SBI_LEGACY_SETTIMER, 0, stime, 0, 0, 0, 0, 0);
+}
+
+
+long hal_sbiPutchar(int ch)
+{
+	return hal_sbiEcall(SBI_LEGACY_PUTCHAR, 0, ch, 0, 0, 0, 0, 0).error;
+}
+
+
+long hal_sbiGetchar(void)
+{
+	return hal_sbiEcall(SBI_LEGACY_GETCHAR, 0, 0, 0, 0, 0, 0, 0).error;
+}
+
+/* SBI v0.2+ calls */
+
+sbiret_t hal_sbiGetSpecVersion(void)
+{
+	return hal_sbiEcall(SBI_EXT_BASE, SBI_BASE_SPEC_VER, 0, 0, 0, 0, 0, 0);
+}
+
+
+sbiret_t hal_sbiProbeExtension(long extid)
+{
+	return hal_sbiEcall(SBI_EXT_BASE, SBI_BASE_PROBE_EXT, extid, 0, 0, 0, 0, 0);
+}
+
+
+static void hal_sbiSetTimerv02(u64 stime)
+{
+	(void)hal_sbiEcall(SBI_EXT_TIME, SBI_TIME_SETTIMER, stime, 0, 0, 0, 0, 0);
+}
+
+
+void hal_sbiSetTimer(u64 stime)
+{
+	sbi_common.setTimer(stime);
+}
+
+
+void _hal_sbiInit(void)
+{
+	sbiret_t ret = hal_sbiGetSpecVersion();
+	sbi_common.specVersion = ret.value;
+
+	ret = hal_sbiProbeExtension(SBI_EXT_TIME);
+	if (ret.error == 0) {
+		sbi_common.setTimer = hal_sbiSetTimerv02;
+	}
+	else {
+		sbi_common.setTimer = hal_sbiSetTimerv01;
+	}
+}

--- a/hal/riscv64/sbi.h
+++ b/hal/riscv64/sbi.h
@@ -18,15 +18,16 @@
 
 #include <arch/types.h>
 
-#define SBI_SETTIMER                0
-#define SBI_PUTCHAR                 1
-#define SBI_GETCHAR                 2
-#define SBI_CLEARIPI                3
-#define SBI_SENDIPI                 4
-#define SBI_REMOTE_FENCE_I          5
-#define SBI_REMOTE_SFENCE_VMA       6
-#define SBI_REMOTE_SFENCE_VMA_ASID  7
-#define SBI_SHUTDOWN                8
+
+#define SBI_SETTIMER               0
+#define SBI_PUTCHAR                1
+#define SBI_GETCHAR                2
+#define SBI_CLEARIPI               3
+#define SBI_SENDIPI                4
+#define SBI_REMOTE_FENCE_I         5
+#define SBI_REMOTE_SFENCE_VMA      6
+#define SBI_REMOTE_SFENCE_VMA_ASID 7
+#define SBI_SHUTDOWN               8
 
 
 typedef struct _sbiret_t {
@@ -39,20 +40,22 @@ static inline sbiret_t sbi_ecall(int ext, int fid, u64 arg0, u64 arg1, u64 arg2,
 {
 	sbiret_t ret;
 
-	register u64 a0 asm ("a0") = arg0;
-	register u64 a1 asm ("a1") = arg1;
-	register u64 a2 asm ("a2") = arg2;
-	register u64 a3 asm ("a3") = arg3;
-	register u64 a4 asm ("a4") = arg4;
-	register u64 a5 asm ("a5") = arg5;
-	register u64 a6 asm ("a6") = fid;
-	register u64 a7 asm ("a7") = ext;
+	register u64 a0 asm("a0") = arg0;
+	register u64 a1 asm("a1") = arg1;
+	register u64 a2 asm("a2") = arg2;
+	register u64 a3 asm("a3") = arg3;
+	register u64 a4 asm("a4") = arg4;
+	register u64 a5 asm("a5") = arg5;
+	register u64 a6 asm("a6") = fid;
+	register u64 a7 asm("a7") = ext;
 
-	__asm__ volatile ("\
-		ecall"
-	: "+r" (a0), "+r" (a1)
-	: "r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
-	: "memory");
+	/* clang-format off */
+	__asm__ volatile (
+		"ecall"
+		: "+r" (a0), "+r" (a1)
+		: "r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
+		: "memory");
+	/* clang-format on */
 
 	ret.error = a0;
 	ret.value = a1;

--- a/hal/riscv64/sbi.h
+++ b/hal/riscv64/sbi.h
@@ -5,8 +5,8 @@
  *
  * SBI routines (RISCV64)
  *
- * Copyright 2018, 2020 Phoenix Systems
- * Author: Pawel Pisarczyk
+ * Copyright 2018, 2020, 2024 Phoenix Systems
+ * Author: Pawel Pisarczyk, Lukasz Leczkowski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -19,49 +19,34 @@
 #include <arch/types.h>
 
 
-#define SBI_SETTIMER               0
-#define SBI_PUTCHAR                1
-#define SBI_GETCHAR                2
-#define SBI_CLEARIPI               3
-#define SBI_SENDIPI                4
-#define SBI_REMOTE_FENCE_I         5
-#define SBI_REMOTE_SFENCE_VMA      6
-#define SBI_REMOTE_SFENCE_VMA_ASID 7
-#define SBI_SHUTDOWN               8
-
-
-typedef struct _sbiret_t {
+typedef struct {
 	long error;
 	long value;
 } sbiret_t;
 
 
-static inline sbiret_t sbi_ecall(int ext, int fid, u64 arg0, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5)
-{
-	sbiret_t ret;
+/* Legacy SBI v0.1 calls */
 
-	register u64 a0 asm("a0") = arg0;
-	register u64 a1 asm("a1") = arg1;
-	register u64 a2 asm("a2") = arg2;
-	register u64 a3 asm("a3") = arg3;
-	register u64 a4 asm("a4") = arg4;
-	register u64 a5 asm("a5") = arg5;
-	register u64 a6 asm("a6") = fid;
-	register u64 a7 asm("a7") = ext;
 
-	/* clang-format off */
-	__asm__ volatile (
-		"ecall"
-		: "+r" (a0), "+r" (a1)
-		: "r" (a2), "r" (a3), "r" (a4), "r" (a5), "r" (a6), "r" (a7)
-		: "memory");
-	/* clang-format on */
+long hal_sbiPutchar(int ch);
 
-	ret.error = a0;
-	ret.value = a1;
 
-	return ret;
-}
+long hal_sbiGetchar(void);
+
+
+/* SBI v0.2+ calls */
+
+
+sbiret_t hal_sbiGetSpecVersion(void);
+
+
+sbiret_t hal_sbiProbeExtension(long extid);
+
+
+void hal_sbiSetTimer(u64 stime);
+
+
+void _hal_sbiInit(void);
 
 
 #endif

--- a/hal/riscv64/spinlock.c
+++ b/hal/riscv64/spinlock.c
@@ -18,7 +18,7 @@
 #include "hal/list.h"
 
 
-struct {
+static struct {
 	spinlock_t spinlock;
 	spinlock_t *first;
 } spinlock_common;
@@ -90,7 +90,7 @@ void hal_spinlockDestroy(spinlock_t *spinlock)
 }
 
 
-__attribute__ ((section (".init"))) void _hal_spinlockInit(void)
+__attribute__((section(".init"))) void _hal_spinlockInit(void)
 {
 	spinlock_common.first = NULL;
 	_hal_spinlockCreate(&spinlock_common.spinlock, "spinlock_common.spinlock");

--- a/hal/riscv64/timer.c
+++ b/hal/riscv64/timer.c
@@ -39,7 +39,7 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 	(void)ctx;
 
 	++timer_common.jiffies;
-	sbi_ecall(SBI_SETTIMER, 0, csr_read(time) + timer_common.interval, 0, 0, 0, 0, 0);
+	hal_sbiSetTimer(csr_read(time) + timer_common.interval);
 
 	return 0;
 }
@@ -92,5 +92,5 @@ __attribute__((section(".init"))) void _hal_timerInit(u32 interval)
 	timer_common.handler.data = NULL;
 	hal_interruptsSetHandler(&timer_common.handler);
 
-	sbi_ecall(SBI_SETTIMER, 0, csr_read(time) + timer_common.interval, 0, 0, 0, 0, 0);
+	hal_sbiSetTimer(csr_read(time) + timer_common.interval);
 }

--- a/syscalls.c
+++ b/syscalls.c
@@ -1468,7 +1468,7 @@ void syscalls_sbi_putchar(char *ustack)
 #ifdef __TARGET_RISCV64
 	char c;
 	GETFROMSTACK(ustack, char, c, 0);
-	sbi_ecall(SBI_PUTCHAR, 0, c, 0, 0, 0, 0, 0);
+	(void)hal_sbiPutchar(c);
 #endif
 }
 
@@ -1476,9 +1476,7 @@ void syscalls_sbi_putchar(char *ustack)
 int syscalls_sbi_getchar(char *ustack)
 {
 #ifdef __TARGET_RISCV64
-	sbiret_t ret;
-	ret = sbi_ecall(SBI_GETCHAR, 0, 0, 0, 0, 0, 0, 0);
-	return (int)ret.error;
+	return (int)hal_sbiGetchar();
 #else
 	return -1;
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- Adapt initialization code to booting from PLO
- Reformat code and apply MISRA
- Refactor interrupt handling - properly handle 2 interrupt controllers (CLINT and PLIC), simplify interrupt dispatcher
- Add (partial) support for SBI calls in version 0.2 and higher.
- Modify kernel stack handling: use `hal_cpuKernelStack` variable to store `kstack` value - same approach as on `sparcv8leon3`. Previously `kstack` was set incorrectly, causing exception after `fork`. Variable use here is the most optimal, as when in the future we'll use more cores, `tp` register will have to be reserved in kernel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/plo/pull/285
- [ ] I will merge this PR by myself when appropriate.
