### PR TITLE
proc_fork: Disable interrupts before changing kernel stack

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -1595,6 +1595,7 @@ int proc_fork(void)
 		current->sigmask = sigmask;
 
 		current->kstack = current->execkstack;
+		hal_cpuDisableInterrupts();
 		_hal_cpuSetKernelStack(current->kstack + current->kstacksz);
 
 		if (err < 0) {
@@ -1603,6 +1604,9 @@ int proc_fork(void)
 			PUTONSTACK(kstack, process_spawn_t *, current->execdata);
 			PUTONSTACK(kstack, thread_t *, current);
 			hal_jmp(proc_vforkedExit, kstack, NULL, 3);
+		}
+		else {
+			hal_cpuEnableInterrupts();
 		}
 	}
 #endif


### PR DESCRIPTION
Fix possible stack corruption on an error path

DONE: RTOS-598

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Interrupt may indeed corrupt arguments on the kernel stack on some platforms (e.g. ia32)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-kernel/issues/147

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
