### PR TITLE
Watchdog changes

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2055,7 +2055,7 @@ unsigned int _imxrt_cpuid(void)
 
 void _imxrt_wdgReload(void)
 {
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	hal_cpuDisableInterrupts();
 	*(imxrt_common.rtwdog + rtwdog_cnt) = RTWDOG_REFRESH_KEY;
 	hal_cpuEnableInterrupts();
@@ -2118,7 +2118,7 @@ void _imxrt_init(void)
 	*(imxrt_common.rtwdog + rtwdog_cnt) = RTWDOG_UPDATE_KEY;
 	while (!(*(imxrt_common.rtwdog + rtwdog_cs) & (1 << 11)))
 		;
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	/* Enable rtwdog: LPO_CLK (256 prescaler), set timeout to WATCHDOG ms */
 	*(imxrt_common.rtwdog + rtwdog_toval) =
 		WATCHDOG / (256 / (LPO_CLK_FREQ_HZ / 1000));

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -129,7 +129,7 @@ enum { nvic_iser = 0, nvic_icer = 32, nvic_ispr = 64, nvic_icpr = 96, nvic_iabr 
 enum { wdog_wcr = 0, wdog_wsr, wdog_wrsr, wdog_wicr, wdog_wmcr };
 
 
-enum { rtwdog_cs = 0, rtwdog_cnt, rtwdog_total, rtwdog_win };
+enum { rtwdog_cs = 0, rtwdog_cnt, rtwdog_toval, rtwdog_win };
 
 
 /* platformctl syscall */
@@ -2120,7 +2120,7 @@ void _imxrt_init(void)
 		;
 #if defined(WATCHDOG) && defined(NDEBUG)
 	/* Enable rtwdog: LPO_CLK (256 prescaler), set timeout to WATCHDOG ms */
-	*(imxrt_common.rtwdog + rtwdog_total) =
+	*(imxrt_common.rtwdog + rtwdog_toval) =
 		WATCHDOG / (256 / (LPO_CLK_FREQ_HZ / 1000));
 	*(imxrt_common.rtwdog + rtwdog_cs) =
 		(*(imxrt_common.rtwdog + rtwdog_cs) | (1 << 7)) |
@@ -2129,7 +2129,7 @@ void _imxrt_init(void)
 	*(imxrt_common.rtwdog + rtwdog_cnt) = RTWDOG_REFRESH_KEY;
 #else
 	/* Disable rtwdog, enable update */
-	*(imxrt_common.rtwdog + rtwdog_total) = 0xffffU;
+	*(imxrt_common.rtwdog + rtwdog_toval) = 0xffffU;
 	*(imxrt_common.rtwdog + rtwdog_cs) =
 		(*(imxrt_common.rtwdog + rtwdog_cs) & ~(1 << 7)) | (1 << 5);
 #endif

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -23,12 +23,20 @@
 #include "../../../../include/errno.h"
 #include "../../../../include/arch/imxrt.h"
 
+#include <board_config.h>
+
+
 #define RTWDOG_UPDATE_KEY 0xd928c520
 #define RTWDOG_REFRESH_KEY 0xb480a602
 #define LPO_CLK_FREQ_HZ 32000
 
+#if defined(WATCHDOG) && !defined(WATCHDOG_TIMEOUT_MS)
+#define WATCHDOG_TIMEOUT_MS (30000)
+#warning "WATCHDOG_TIMEOUT_MS not defined, defaulting to 30000 ms"
+#endif
+
 #if defined(WATCHDOG) && \
-	(WATCHDOG <= 0x0 || WATCHDOG > (0xffffU * 256 / (LPO_CLK_FREQ_HZ / 1000)))
+	(WATCHDOG_TIMEOUT_MS <= 0x0 || WATCHDOG_TIMEOUT_MS > (0xffffU * 256 / (LPO_CLK_FREQ_HZ / 1000)))
 #error "Watchdog timeout out of bounds!"
 #endif
 
@@ -2119,9 +2127,9 @@ void _imxrt_init(void)
 	while (!(*(imxrt_common.rtwdog + rtwdog_cs) & (1 << 11)))
 		;
 #if defined(WATCHDOG)
-	/* Enable rtwdog: LPO_CLK (256 prescaler), set timeout to WATCHDOG ms */
+	/* Enable rtwdog: LPO_CLK (256 prescaler), set timeout to WATCHDOG_TIMEOUT_MS ms */
 	*(imxrt_common.rtwdog + rtwdog_toval) =
-		WATCHDOG / (256 / (LPO_CLK_FREQ_HZ / 1000));
+		WATCHDOG_TIMEOUT_MS / (256 / (LPO_CLK_FREQ_HZ / 1000));
 	*(imxrt_common.rtwdog + rtwdog_cs) =
 		(*(imxrt_common.rtwdog + rtwdog_cs) | (1 << 7)) |
 		(1 << 13) | (1 << 12) | (1 << 8) | (1 << 5);

--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -17,6 +17,12 @@
 #include "../interrupts.h"
 #include "../../../../include/errno.h"
 
+#include <board_config.h>
+
+#if defined(WATCHDOG) && defined(WATCHDOG_TIMEOUT_MS)
+#warning "This target doesn't support WATCHDOG_TIMEOUT_MS. Watchdog timeout is 31992 ms."
+#endif
+
 
 struct {
 	volatile u32 *rcc;

--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -962,7 +962,7 @@ unsigned int _stm32_cpuid(void)
 
 void _stm32_wdgReload(void)
 {
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	*(stm32_common.iwdg + iwdg_kr) = 0xaaaa;
 #endif
 }
@@ -1117,7 +1117,7 @@ void _stm32_init(void)
 	/* Clear pending interrupts */
 	*(stm32_common.exti + exti_pr) |= 0xffffff;
 
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	/* Init watchdog */
 	/* Enable write access to IWDG */
 	*(stm32_common.iwdg + iwdg_kr) = 0x5555;

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -816,7 +816,7 @@ unsigned int _stm32_cpuid(void)
 
 void _stm32_wdgReload(void)
 {
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	*(stm32_common.iwdg + iwdg_kr) = 0xaaaa;
 #endif
 }
@@ -924,7 +924,7 @@ void _stm32_init(void)
 	*(stm32_common.exti + exti_pr1) |= 0xffffff;
 	*(stm32_common.exti + exti_pr2) |= 0xffffff;
 
-#if defined(WATCHDOG) && defined(NDEBUG)
+#if defined(WATCHDOG)
 	/* Init watchdog */
 	/* Enable write access to IWDG */
 	*(stm32_common.iwdg + iwdg_kr) = 0x5555;

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -20,6 +20,12 @@
 #include "../../armv7m.h"
 #include "../../../../include/errno.h"
 
+#include <board_config.h>
+
+#if defined(WATCHDOG) && defined(WATCHDOG_TIMEOUT_MS)
+#warning "This target doesn't support WATCHDOG_TIMEOUT_MS. Watchdog timeout is 31992 ms."
+#endif
+
 
 struct {
 	volatile u32 *rcc;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
hal/imxrt10xx: Fix watchdog register name
hal: Enable watchdog independently of NDEBUG
hal: Introduce WATCHDOG_TIMEOUT_MS

## Description
<!--- Describe your changes shortly -->
Fixes small issues in watchdog, make it indepdent on NDEBUG (see https://github.com/phoenix-rtos/phoenix-rtos-build/pull/163) and introduce configuration WATCHDOG_TIMEOUT_MS as configuration variable for imxrt10xx from board_config.h

Note, that I didn't introduce warning in imx6ull as I'm not sure if it's desired to include board_config.h in init.S

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow to configure WATCHDOG without BOARD_CONFIG env

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Project that uses WATCHDOG variable to specify timeout  need to switch to WATCHDOG_TIMEOUT_MS for that purpose 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo. It would be great if someone could check this changes on armv7a7-im6ull-evk and arm7m7-imxrt117x-evk 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/847
https://github.com/phoenix-rtos/plo/pull/293
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/453
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/163
- [x] I will merge this PR by myself when appropriate.
