### PR TITLE
imxrt117x: adjust gpt clock freq to plo clock tree

### DIFF
--- a/hal/armv7m/imxrt/117x/config.h
+++ b/hal/armv7m/imxrt/117x/config.h
@@ -45,7 +45,7 @@
 #define GPT_IRQ  GPT1_IRQ
 
 #define GPT_BUS_CLK       pctl_clk_gpt1
-#define GPT_FREQ_MHZ      16
+#define GPT_FREQ_MHZ      24
 #define GPT_OSC_PRESCALER 8
 #define GPT_PRESCALER     (GPT_FREQ_MHZ / GPT_OSC_PRESCALER)
 #endif


### PR DESCRIPTION
## Do not merge -- PR to abandon

## Description
<!--- Describe your changes shortly -->

The plo ([PR](https://github.com/phoenix-rtos/plo/pull/290)) set GPT bus root clock to 24MHz

## Motivation and Context

JIRA: RTOS-608

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/plo/pull/290
- [ ] I will merge this PR by myself when appropriate.
