### PR TITLE
log: fix setting custom log size

### DIFF
--- a/log/log.c
+++ b/log/log.c
@@ -23,9 +23,11 @@
 #include "../proc/threads.h"
 #include "../proc/ports.h"
 
+#include <board_config.h>
 
-#ifndef SIZE_LOG
-#define SIZE_LOG 2048
+
+#ifndef KERNEL_LOG_SIZE
+#define KERNEL_LOG_SIZE 2048
 #endif
 
 #define TCGETS 0x405c7401
@@ -51,7 +53,7 @@ typedef struct _log_reader_t {
 
 
 static struct {
-	char buf[SIZE_LOG];
+	char buf[KERNEL_LOG_SIZE];
 	offs_t head;
 	offs_t tail;
 	lock_t lock;
@@ -69,25 +71,25 @@ static int _log_empty(void)
 
 static int _log_full(void)
 {
-	return ((log_common.tail - log_common.head) == SIZE_LOG) ? 1 : 0;
+	return ((log_common.tail - log_common.head) == KERNEL_LOG_SIZE) ? 1 : 0;
 }
 
 
 static char _log_pop(void)
 {
-	return log_common.buf[log_common.head++ % SIZE_LOG];
+	return log_common.buf[log_common.head++ % KERNEL_LOG_SIZE];
 }
 
 
 static void _log_push(char c)
 {
-	log_common.buf[log_common.tail++ % SIZE_LOG] = c;
+	log_common.buf[log_common.tail++ % KERNEL_LOG_SIZE] = c;
 }
 
 
 static char _log_getc(offs_t off)
 {
-	return log_common.buf[off % SIZE_LOG];
+	return log_common.buf[off % KERNEL_LOG_SIZE];
 }
 
 


### PR DESCRIPTION
## Description

After removing BOARD_CONFIG env variable, it became impossible to configure custom kernel log size. Use board_config.h include to re-add this functionality.

## Motivation and Context

JIRA: DTR-3

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes shortly -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
