### PR TITLE
vm/map: replace dead ends with LIB_ASSERT_ALWAYS

### DIFF
--- a/hal/armv7a/imx6ull/imx6ull.c
+++ b/hal/armv7a/imx6ull/imx6ull.c
@@ -304,7 +304,8 @@ static void _imx6ull_reboot(void)
 {
 	/* assert SRS signal by writing 0 to bit 4 and 1 to bit 2 (WDOG enable) */
 	*(imx6ull_common.wdog + wdog_wcr) = (1 << 2);
-	for (;;) ;
+	for (;;) {
+	}
 }
 
 

--- a/hal/armv7a/imx6ull/memtest.c
+++ b/hal/armv7a/imx6ull/memtest.c
@@ -249,7 +249,7 @@ int test_ddrAll(void)
 	u32 address = 0x80000000, size = 128 * 1024 * 1024;
 	int errors;
 
-	while (1) {
+	for (;;) {
 		++i;
 
 		test_ddrPrintStr("\n\nPass #");

--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -1832,7 +1832,8 @@ void _imxrt_nvicSystemReset(void)
 
 	hal_cpuDataSyncBarrier();
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 

--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -456,7 +456,8 @@ void _imxrt_nvicSystemReset(void)
 	hal_cpuDataSyncBarrier();
 	hal_cpuInstrBarrier();
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 

--- a/hal/armv7m/stm32/l1/stm32l1.c
+++ b/hal/armv7m/stm32/l1/stm32l1.c
@@ -660,7 +660,8 @@ void _stm32_nvicSystemReset(void)
 
 	__asm__ volatile ("dsb");
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -598,7 +598,8 @@ void _stm32_nvicSystemReset(void)
 
 	__asm__ volatile ("dsb");
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 

--- a/main.c
+++ b/main.c
@@ -86,8 +86,9 @@ void main_initthr(void *unused)
 		} while ((prog = prog->next) != syspage_progList());
 	}
 
-	for (;;)
+	for (;;) {
 		proc_reap();
+	}
 }
 
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -443,7 +443,6 @@ static void _threads_updateWakeup(time_t now, thread_t *min)
 int threads_timeintr(unsigned int n, cpu_context_t *context, void *arg)
 {
 	thread_t *t;
-	unsigned int i = 0;
 	time_t now;
 	spinlock_ctx_t sc;
 
@@ -455,7 +454,7 @@ int threads_timeintr(unsigned int n, cpu_context_t *context, void *arg)
 	hal_spinlockSet(&threads_common.spinlock, &sc);
 	now = _proc_gettimeRaw();
 
-	for (;; i++) {
+	for (;;) {
 		t = lib_treeof(thread_t, sleeplinkage, lib_rbMinimum(threads_common.sleeping.root));
 
 		if (t == NULL || t->wakeup > now) {

--- a/test/proc-fpu.c
+++ b/test/proc-fpu.c
@@ -10,45 +10,51 @@ int test_fpuThread1(void *arg)
 {
 	int i;
 	double f[LEN];
-	main_printf(ATTR_INFO,"test: [fpuThread1] start\n");
+	main_printf(ATTR_INFO, "test: [fpuThread1] start\n");
 
 	f[0] = 1 - 0.0123456789;
-	while (1) {
-		for(i = 1;i < LEN;i++) {
-			f[i] = f[i-1] * (1 - 0.00123456789);
+	for (;;) {
+		for (i = 1; i < LEN; i++) {
+			f[i] = f[i - 1] * (1 - 0.00123456789);
 		}
-		for(i = 0;i < LEN;i++)
-			if(f[i] >= 1 || f[i] <= 0)
-				main_printf(ATTR_ERROR,"test: [fpuThread1] invalid result f[%d] = %f\n",i,f[i]);
+		for (i = 0; i < LEN; i++) {
+			if (f[i] >= 1 || f[i] <= 0) {
+				main_printf(ATTR_ERROR, "test: [fpuThread1] invalid result f[%d] = %f\n", i, f[i]);
+			}
+		}
 		f[0] = f[LEN - 1];
-		if(f[0] < 0.005)
+		if (f[0] < 0.005) {
 			f[0] = 1 - 0.0123456789;
+		}
 	}
 	return 0;
 }
 
-int test_fpuThread2(void* arg)
+int test_fpuThread2(void *arg)
 {
 	int i;
 	double f[LEN];
-	main_printf(ATTR_INFO,"test: [fpuThread2] start\n");
+	main_printf(ATTR_INFO, "test: [fpuThread2] start\n");
 	f[0] = -1 + 0.0123456789;
-	while (1) {
-		for(i = 1;i < LEN;i++) {
-			f[i] = -1* f[i-1] * (-1 + 0.00123456789);
+	for (;;) {
+		for (i = 1; i < LEN; i++) {
+			f[i] = -1 * f[i - 1] * (-1 + 0.00123456789);
 		}
-		for(i = 0;i < LEN;i++)
-			if(f[i] <= -1 || f[i] >= 0)
-				main_printf(ATTR_ERROR,"test: [fpuThread2] invalid result f[%d] = %f\n",i,f[i]);
+		for (i = 0; i < LEN; i++) {
+			if (f[i] <= -1 || f[i] >= 0) {
+				main_printf(ATTR_ERROR, "test: [fpuThread2] invalid result f[%d] = %f\n", i, f[i]);
+			}
+		}
 		f[0] = f[LEN - 1];
-		if(f[0] > -0.005)
+		if (f[0] > -0.005) {
 			f[0] = -1 + 0.0123456789;
+		}
 	}
 	return 0;
 }
 
 void test_fpuContextSwitching(void)
 {
-	proc_thread(NULL, test_fpuThread1,NULL,0,NULL,ttRegular);
-	proc_thread(NULL, test_fpuThread2,NULL,0,NULL,ttRegular);
+	proc_thread(NULL, test_fpuThread1, NULL, 0, NULL, ttRegular);
+	proc_thread(NULL, test_fpuThread2, NULL, 0, NULL, ttRegular);
 }

--- a/test/proc.c
+++ b/test/proc.c
@@ -67,8 +67,9 @@ static void test_proc_indthr(void *arg)
 
 static void test_proc_busythr(void *arg)
 {
-	for (;;)
+	for (;;) {
 		hal_cpuHalt();
+	}
 
 	return;
 }

--- a/test/vm.c
+++ b/test/vm.c
@@ -149,7 +149,8 @@ void test_vm_kmalloc(void)
 
 //vm_mapDumpArenas();
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 
@@ -170,7 +171,8 @@ static void _test_vm_msgsimthr(void *arg)
 	lib_printf("test: M, No memory!\n");
 	proc_lockClear(&lock);
 
-	for (;;);
+	for (;;) {
+	}
 }
 
 
@@ -220,7 +222,8 @@ lib_printf("\n");
 	lib_printf("test: U, No memory [%d]!\n", allocsz);
 	proc_lockClear(&lock);
 
-	for(;;);
+	for (;;) {
+	}
 }
 
 


### PR DESCRIPTION
## Description

The change replaces dead ends like `lib_printf(...); for (;;);` by using `LIB_ASSERT_ALWAYS` in places where there is no chance for klog reader to print an appropriate panic message to the debug console.  This PR additionally checks all uses of `for (;;)` and `while (1)` loops to detect potential missing log-useful information, and normalizes its usage to the MISRA 2012 rules.

Changes are split into separate commits.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `ia32-generic`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
