### PR TITLE
hal/ia32: Implement HP timer

### DIFF
--- a/hal/armv7a/imx6ull/timer.c
+++ b/hal/armv7a/imx6ull/timer.c
@@ -87,15 +87,16 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 	spinlock_ctx_t sc;
 	u32 cyc;
 
-	if (!when)
-		++when;
+	if (waitUs == 0) {
+		++waitUs;
+	}
 
-	cyc = when * 66;
+	cyc = waitUs * 66;
 
 	hal_spinlockSet(&timer_common.lock, &sc);
 	*(timer_common.epit1 + epit_lr) = cyc;

--- a/hal/armv7a/zynq7000/timer.c
+++ b/hal/armv7a/zynq7000/timer.c
@@ -90,7 +90,7 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/armv7m/imxrt/timer.c
+++ b/hal/armv7m/imxrt/timer.c
@@ -85,17 +85,17 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 	spinlock_ctx_t sc;
 
-	if (when > timer_common.interval) {
-		when = timer_common.interval;
+	if (waitUs > timer_common.interval) {
+		waitUs = timer_common.interval;
 	}
 
 	hal_spinlockSet(&timer_common.sp, &sc);
 	/* Modulo handled implicitly */
-	*(timer_common.base + gpt_ocr2) = hal_timerUs2Cyc(when) + *(timer_common.base + gpt_cnt);
+	*(timer_common.base + gpt_ocr2) = hal_timerUs2Cyc(waitUs) + *(timer_common.base + gpt_cnt);
 	*(timer_common.base + gpt_sr) |= 1 << 1;
 	hal_cpuDataMemoryBarrier();
 	hal_spinlockClear(&timer_common.sp, &sc);

--- a/hal/armv7m/stm32/l4/timer.c
+++ b/hal/armv7m/stm32/l4/timer.c
@@ -192,7 +192,7 @@ void timer_setAlarm(time_t us)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/armv8m/nrf/91/timer.c
+++ b/hal/armv8m/nrf/91/timer.c
@@ -68,7 +68,7 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 /* Interface functions */
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/ia32/arch/interrupts.h
+++ b/hal/ia32/arch/interrupts.h
@@ -34,6 +34,8 @@
 #define IOAPIC_INTPOL   (1u << 13)
 #define IOAPIC_DESTMOD  (1u << 11)
 
+#define LAPIC_EOI 0
+
 /* Interrupt source override polarity flags */
 #define MADT_ISO_POLAR_MASK 0x3
 #define MADT_ISO_POLAR_BUS  0x0

--- a/hal/ia32/hal.c
+++ b/hal/ia32/hal.c
@@ -76,7 +76,6 @@ void _hal_init(void)
 	_hal_interruptsInit();
 
 	_hal_cpuInit();
-	_hal_timerInit(SYSTICK_INTERVAL);
 	_hal_pciInit();
 
 	hal_common.started = 0;

--- a/hal/ia32/init.h
+++ b/hal/ia32/init.h
@@ -186,6 +186,18 @@ static inline int hal_isLapicPresent(void)
 }
 
 
+static inline void _hal_lapicWrite(u32 reg, u32 value)
+{
+	*(volatile u32 *)(hal_config.localApicAddr + reg) = value;
+}
+
+
+static inline u32 _hal_lapicRead(u32 reg)
+{
+	return *(volatile u32 *)(hal_config.localApicAddr + reg);
+}
+
+
 void _hal_configInit(syspage_t *s);
 
 

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -163,14 +163,13 @@ static inline void _hal_ioapicRoundRobin(unsigned int n)
 
 static inline void _hal_interrupts_8259EOI(unsigned int n)
 {
-	volatile u32 *p = hal_config.localApicAddr + LAPIC_EOI_REG;
 	if ((hal_isLapicPresent() != 0) && (n == TLB_IRQ)) {
-		*p = 0;
+		_hal_lapicWrite(LAPIC_EOI_REG, LAPIC_EOI);
 		return;
 	}
 	/* Check for rare case, when we use 8259 PIC with multiple cores and APIC */
 	if (hal_cpuGetID() != 0) {
-		*p = 0;
+		_hal_lapicWrite(LAPIC_EOI_REG, LAPIC_EOI);
 		return;
 	}
 	if (n < 8) {
@@ -185,9 +184,8 @@ static inline void _hal_interrupts_8259EOI(unsigned int n)
 
 static inline void _hal_interruptsApicEOI(unsigned int n)
 {
-	volatile u32 *p = hal_config.localApicAddr + LAPIC_EOI_REG;
 	_hal_ioapicRoundRobin(n);
-	*p = 0;
+	_hal_lapicWrite(LAPIC_EOI_REG, LAPIC_EOI);
 }
 
 

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -371,7 +371,7 @@ static int _hal_ioapicInit(void)
 		u32 flags;
 	} __attribute__((packed)) *localApic;
 
-	madt_header_t *madt = hal_config.madt;
+	hal_madtHeader_t *madt = hal_config.madt;
 	size_t i;
 	u32 high, low, n;
 	void *ptr;

--- a/hal/ia32/timer.c
+++ b/hal/ia32/timer.c
@@ -31,29 +31,52 @@
 #define PIT_OPERATING_ONE_SHOT (0 << 1)
 #define PIT_OPERATING_RATE_GEN (2 << 1)
 
-#define LAPIC_TIMER_ONE_SHOT 0
+#define LAPIC_TIMER_ONE_SHOT        0
 #define LAPIC_TIMER_DEFAULT_DIVIDER 3 /* 3 means 8 (1 << 3) */
+
+/* 64 bit registers, access must be aligned
+   Trying to use exclusive-access mechanisms (ex. lock mov, xchg, etc.) is undefined */
+#define HPET_ID         0x00
+#define HPET_CONFIG     0x10
+#define HPET_IRQ_STATUS 0x20
+#define HPET_COUNTER    0xf0
+
+#define HPET_ID_LEGACY_CAPABLE           (1u << 15)
+#define HPET_LEGACY_TMR1_IRQ             8
+#define HPET_CONFIG_TMR_IRQ_EN           (1u << 2)
+#define HPET_CONFIG_TMR_PERIODIC         (1u << 3)
+#define HPET_CONFIG_TMR_CAN_BE_PERIODIC  (1u << 4)
+#define HPET_CONFIG_TMR_PERIODIC_CAN_SET (1u << 6)
+#define HPET_CONFIG_TMR_32BIT_MODE       (1u << 8)
+
+typedef enum { timer_unknown, timer_pit, timer_lapic, timer_hpet } timerType_t;
 
 struct {
 	intr_handler_t handler;
 	spinlock_t sp;
 	u32 intervalUs;
 
-	enum { timer_unknown,
-		timer_pit,
-		timer_lapic } timerType;
+	timerType_t schedulerTimerType;
+	timerType_t timestampTimerType;
 	union {
 		struct {
 			volatile time_t jiffies;
 		} pit;
 		struct {
-			u32 frequency;
-			struct {
-				u64 cycles; /* How many ticks were there */
-				u32 wait;   /* Wait time (in cycles) of this CPU */
-			} local[MAX_CPU_COUNT];
+			volatile u64 cycles; /* How many ticks were there on CPU0 */
 		} lapic;
-	};
+		struct {
+			hal_gasMapped_t addr;
+			u32 period;
+			intr_handler_t tmr1;
+		} hpet;
+	} timestampTimer;
+	union {
+		struct {
+			u32 frequency;
+			u32 wait[MAX_CPU_COUNT]; /* Wait time (in cycles) of this CPU */
+		} lapic;
+	} schedulerTimer;
 } timer;
 
 
@@ -75,7 +98,7 @@ static int hal_pitTimerIrqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 	(void)arg;
 	(void)ctx;
 
-	timer.pit.jiffies += timer.intervalUs;
+	(void)hal_cpuAtomAdd((volatile u32 *)&timer.timestampTimer.pit.jiffies, timer.intervalUs);
 	return 0;
 }
 
@@ -119,9 +142,10 @@ static void _hal_pitInit(u32 intervalUs)
 
 	_hal_pitSetTimer(_hal_pitCalculateDivider(intervalUs), PIT_OPERATING_RATE_GEN);
 
-	timer.timerType = timer_pit;
+	timer.timestampTimerType = timer_pit;
+	timer.schedulerTimerType = timer_pit;
 
-	timer.pit.jiffies = 0;
+	timer.timestampTimer.pit.jiffies = 0;
 
 	(void)hal_timerRegister(hal_pitTimerIrqHandler, NULL, &timer.handler);
 }
@@ -173,13 +197,13 @@ static inline void _hal_lapicTimerConfigure(u32 mode, u32 mask, u32 vector)
 
 static inline u32 _hal_lapicTimerCyc2Us(u64 cycles)
 {
-	return (u32)(((cycles << LAPIC_TIMER_DEFAULT_DIVIDER) * 1000) / (u64)timer.lapic.frequency);
+	return (u32)(((cycles << LAPIC_TIMER_DEFAULT_DIVIDER) * 1000) / (u64)timer.schedulerTimer.lapic.frequency);
 }
 
 
 static inline u64 _hal_lapicTimerUs2Cyc(u32 us)
 {
-	return (((u64)us) * (u64)timer.lapic.frequency) / (1000 << LAPIC_TIMER_DEFAULT_DIVIDER);
+	return (((u64)us) * (u64)timer.schedulerTimer.lapic.frequency) / (1000 << LAPIC_TIMER_DEFAULT_DIVIDER);
 }
 
 
@@ -188,59 +212,150 @@ static int hal_lapicTimerIrqHandler(unsigned int n, cpu_context_t *ctx, void *ar
 	spinlock_ctx_t sc;
 	const unsigned int id = hal_cpuGetID();
 	hal_spinlockSet(&timer.sp, &sc);
-	timer.lapic.local[id].cycles += timer.lapic.local[id].wait;
-	timer.lapic.local[id].wait = _hal_lapicTimerUs2Cyc(timer.intervalUs);
-	_hal_lapicTimerStart(timer.lapic.local[id].wait);
+	if ((timer.timestampTimerType == timer_lapic) && (id == 0)) {
+		timer.timestampTimer.lapic.cycles += timer.schedulerTimer.lapic.wait[id];
+	}
+	timer.schedulerTimer.lapic.wait[id] = _hal_lapicTimerUs2Cyc(timer.intervalUs);
+	_hal_lapicTimerStart(timer.schedulerTimer.lapic.wait[id]);
 	hal_spinlockClear(&timer.sp, &sc);
+	return 0;
+}
+
+
+/* High Precision Event Timers */
+
+
+static inline u32 _hal_hpetRead(u32 offset)
+{
+	u32 ret;
+	(void)_hal_gasRead32(&timer.timestampTimer.hpet.addr, offset, &ret);
+	return ret;
+}
+
+
+static inline void _hal_hpetWrite(u32 offset, u32 val)
+{
+	(void)_hal_gasWrite32(&timer.timestampTimer.hpet.addr, offset, val);
+}
+
+
+/* 0 disables, everything else enables */
+static inline void _hal_hpetEnable(int val)
+{
+	_hal_hpetWrite(HPET_CONFIG, (_hal_hpetRead(HPET_CONFIG) & 0x3) | (val != 0 ? 1 : 0));
+}
+
+
+static inline u64 _hal_hpetGetCounter(void)
+{
+	u32 high, low;
+	do {
+		high = _hal_hpetRead(HPET_COUNTER + sizeof(u32));
+		low = _hal_hpetRead(HPET_COUNTER);
+	} while (high != _hal_hpetRead(HPET_COUNTER + sizeof(u32)));
+	return ((u64)high) << 32 | low;
+}
+
+
+static inline void _hal_hpetSetCounter(u64 val)
+{
+	u32 high, low;
+	low = (u32)val;
+	high = (u32)(val >> 32);
+	_hal_hpetWrite(HPET_COUNTER, low);
+	_hal_hpetWrite(HPET_COUNTER + sizeof(u32), high);
+}
+
+
+static time_t _hal_hpetGetUs(void)
+{
+	u64 ret = _hal_hpetGetCounter();
+	ret *= (u64)timer.timestampTimer.hpet.period;
+	ret /= 1000000000LLU;
+	return ret;
+}
+
+
+static int _hal_hpetInit(void)
+{
+	if (hal_config.hpet == NULL) {
+		return -1;
+	}
+	_hal_gasAllocDevice(&hal_config.hpet->baseAddress, &timer.timestampTimer.hpet.addr, 0x400);
+	if (_hal_gasRead32(&timer.timestampTimer.hpet.addr, HPET_ID + sizeof(u32), &timer.timestampTimer.hpet.period) != 0) {
+		return -1;
+	}
+	_hal_hpetSetCounter(0LLU);
+	timer.timestampTimerType = timer_hpet;
+	_hal_hpetEnable(1);
 	return 0;
 }
 
 
 static int _hal_lapicTimerInit(u32 intervalUs)
 {
-	u64 freq;
+	u64 freq, hpetDelta;
+	time_t hpetStart, hpetEnd;
 	u32 lapicDelta;
 	u16 pitDelta;
-	if (hal_isLapicPresent() == 1) {
-		lapicDelta = 0xffffffffu;
-		pitDelta = 0xffff;
-		_hal_lapicTimerConfigure(LAPIC_TIMER_ONE_SHOT, 0, SYSTICK_IRQ + INTERRUPTS_VECTOR_OFFSET);
-		_hal_lapicTimerSetDivider(LAPIC_TIMER_DEFAULT_DIVIDER);
-		_hal_pitSetTimer(pitDelta, PIT_OPERATING_ONE_SHOT);
-		_hal_lapicTimerStart(lapicDelta);
-		while (pitDelta > 0x0fff) { /* Wait is around 51.500 ms*/
-			pitDelta = _hal_pitReadTimer();
-		}
-		lapicDelta -= _hal_lapicTimerGetCounter();
-		_hal_lapicTimerStop();
-		pitDelta = 0xffff - pitDelta; /* timePassed = pitDelta / PIT_FREQUENCY */
-
-		freq = ((u64)lapicDelta) * ((u64)PIT_FREQUENCY);
-		freq <<= LAPIC_TIMER_DEFAULT_DIVIDER;
-		freq /= (u64)pitDelta; /* Frequency in kHz, with current technology it should fit in 32 bit */
-
-		timer.timerType = timer_lapic;
-		timer.intervalUs = intervalUs;
-
-		timer.lapic.frequency = freq;
-
-		(void)hal_timerRegister(hal_lapicTimerIrqHandler, NULL, &timer.handler);
-		return 0;
+	if (hal_isLapicPresent() == 0) {
+		return -1;
 	}
-	else {
-		return 1;
+	_hal_lapicTimerConfigure(LAPIC_TIMER_ONE_SHOT, 0, SYSTICK_IRQ + INTERRUPTS_VECTOR_OFFSET);
+	_hal_lapicTimerSetDivider(LAPIC_TIMER_DEFAULT_DIVIDER);
+	lapicDelta = 0xffffffffu;
+	switch (timer.timestampTimerType) {
+		case timer_pit:
+			pitDelta = 0xffff;
+			_hal_pitSetTimer(pitDelta, PIT_OPERATING_ONE_SHOT);
+			_hal_lapicTimerStart(lapicDelta);
+			while (pitDelta > 0x0fff) { /* Wait is around 51.500 ms*/
+				pitDelta = _hal_pitReadTimer();
+			}
+			lapicDelta -= _hal_lapicTimerGetCounter();
+			_hal_lapicTimerStop();
+			pitDelta = 0xffff - pitDelta; /* timePassed = pitDelta / PIT_FREQUENCY */
+
+			freq = ((u64)lapicDelta) * ((u64)PIT_FREQUENCY);
+			freq <<= LAPIC_TIMER_DEFAULT_DIVIDER;
+			freq /= (u64)pitDelta; /* Frequency in kHz, with current technology it should fit in 32 bit */
+			timer.timestampTimerType = timer_lapic;
+			timer.timestampTimer.lapic.cycles = 0;
+			break;
+		case timer_hpet:
+			_hal_pitSetTimer(0, PIT_OPERATING_ONE_SHOT); /* Disable PIT */
+			hpetStart = _hal_hpetGetUs();
+			_hal_lapicTimerStart(lapicDelta);
+			do {
+				hpetEnd = _hal_hpetGetUs();
+			} while (hpetEnd - hpetStart < 100000); /* 100ms */
+			lapicDelta -= _hal_lapicTimerGetCounter();
+			_hal_lapicTimerStop();
+			hpetDelta = hpetEnd - hpetStart;
+
+			freq = (((u64)lapicDelta) * 1000) << LAPIC_TIMER_DEFAULT_DIVIDER;
+			freq /= hpetDelta;
+			break;
+		default:
+			return -1;
 	}
+	timer.schedulerTimerType = timer_lapic;
+	timer.intervalUs = intervalUs;
+
+	timer.schedulerTimer.lapic.frequency = freq;
+
+	(void)hal_timerRegister(hal_lapicTimerIrqHandler, NULL, &timer.handler);
+	return 0;
 }
 
 
 void hal_timerInitCore(const unsigned int id)
 {
-	switch (timer.timerType) {
+	switch (timer.schedulerTimerType) {
 		case timer_lapic:
 			_hal_lapicTimerConfigure(LAPIC_TIMER_ONE_SHOT, 0, SYSTICK_IRQ + INTERRUPTS_VECTOR_OFFSET);
 			_hal_lapicTimerSetDivider(LAPIC_TIMER_DEFAULT_DIVIDER);
-			timer.lapic.local[id].cycles = 0;
-			timer.lapic.local[id].wait = 1;
+			timer.schedulerTimer.lapic.wait[id] = 1;
 			_hal_lapicTimerStart(1);
 			break;
 		default:
@@ -254,12 +369,15 @@ time_t hal_timerGetUs(void)
 	spinlock_ctx_t sc;
 	time_t ret;
 	hal_spinlockSet(&timer.sp, &sc);
-	switch (timer.timerType) {
+	switch (timer.timestampTimerType) {
 		case timer_lapic:
-			ret = _hal_lapicTimerCyc2Us(timer.lapic.local[0].cycles);
+			ret = _hal_lapicTimerCyc2Us(timer.timestampTimer.lapic.cycles);
 			break;
 		case timer_pit:
-			ret = timer.pit.jiffies;
+			ret = timer.timestampTimer.pit.jiffies;
+			break;
+		case timer_hpet:
+			ret = _hal_hpetGetUs();
 			break;
 		default:
 			ret = -1;
@@ -280,12 +398,14 @@ void hal_timerSetWakeup(u32 waitUs)
 	}
 
 	hal_spinlockSet(&timer.sp, &sc);
-	switch (timer.timerType) {
+	switch (timer.schedulerTimerType) {
 		case timer_lapic:
 			id = hal_cpuGetID();
-			timer.lapic.local[id].cycles += (timer.lapic.local[id].wait - _hal_lapicTimerGetCounter());
-			timer.lapic.local[id].wait = _hal_lapicTimerUs2Cyc(waitUs);
-			_hal_lapicTimerStart(timer.lapic.local[id].wait);
+			if ((timer.timestampTimerType == timer_lapic) && (id == 0)) {
+				timer.timestampTimer.lapic.cycles += (timer.schedulerTimer.lapic.wait[id] - _hal_lapicTimerGetCounter());
+			}
+			timer.schedulerTimer.lapic.wait[id] = _hal_lapicTimerUs2Cyc(waitUs);
+			_hal_lapicTimerStart(timer.schedulerTimer.lapic.wait[id]);
 			break;
 		default:
 			/* Not supported */
@@ -297,8 +417,12 @@ void hal_timerSetWakeup(u32 waitUs)
 
 void _hal_timerInit(u32 intervalUs)
 {
-	timer.timerType = timer_unknown;
+	timer.schedulerTimerType = timer_unknown;
+	timer.timestampTimerType = timer_pit;
+
 	hal_spinlockCreate(&timer.sp, "timer");
+
+	(void)_hal_hpetInit();
 
 	if (_hal_lapicTimerInit(intervalUs) != 0) {
 		_hal_pitInit(intervalUs);

--- a/hal/ia32/timer.c
+++ b/hal/ia32/timer.c
@@ -5,9 +5,9 @@
  *
  * System timer driver
  *
- * Copyright 2012, 2016 Phoenix Systems
+ * Copyright 2012, 2016, 2023 Phoenix Systems
  * Copyright 2001, 2005-2006 Pawel Pisarczyk
- * Author: Pawel Pisarczyk
+ * Author: Pawel Pisarczyk, Andrzej Stalke
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -16,45 +16,45 @@
 
 #include "hal/timer.h"
 #include "hal/cpu.h"
+#include "init.h"
 #include "hal/interrupts.h"
 #include "hal/spinlock.h"
 #include "ia32.h"
 
+#define PIT_FREQUENCY 1193 /* kHz */
+
+#define PIT_BCD                0
+#define PIT_CHANNEL_0          (0 << 6)
+#define PIT_CHANNEL_1          (1 << 6)
+#define PIT_CHANNEL_2          (2 << 6)
+#define PIT_ACCESS_BOTH        (3 << 4)
+#define PIT_OPERATING_ONE_SHOT (0 << 1)
+#define PIT_OPERATING_RATE_GEN (2 << 1)
+
+#define LAPIC_TIMER_ONE_SHOT 0
+#define LAPIC_TIMER_DEFAULT_DIVIDER 3 /* 3 means 8 (1 << 3) */
+
 struct {
 	intr_handler_t handler;
-	volatile time_t jiffies;
 	spinlock_t sp;
+	u32 intervalUs;
 
-	u32 interval;
+	enum { timer_unknown,
+		timer_pit,
+		timer_lapic } timerType;
+	union {
+		struct {
+			volatile time_t jiffies;
+		} pit;
+		struct {
+			u32 frequency;
+			struct {
+				u64 cycles; /* How many ticks were there */
+				u32 wait;   /* Wait time (in cycles) of this CPU */
+			} local[MAX_CPU_COUNT];
+		} lapic;
+	};
 } timer;
-
-
-static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
-{
-	(void)n;
-	(void)arg;
-	(void)ctx;
-
-	timer.jiffies += timer.interval;
-	return 0;
-}
-
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
-time_t hal_timerGetUs(void)
-{
-	spinlock_ctx_t sc;
-	time_t ret;
-
-	hal_spinlockSet(&timer.sp, &sc);
-	ret = timer.jiffies;
-	hal_spinlockClear(&timer.sp, &sc);
-
-	return ret;
-}
 
 
 int hal_timerRegister(int (*f)(unsigned int, cpu_context_t *, void *), void *data, intr_handler_t *h)
@@ -66,30 +66,241 @@ int hal_timerRegister(int (*f)(unsigned int, cpu_context_t *, void *), void *dat
 	return hal_interruptsSetHandler(h);
 }
 
+/* Programmable Interval Timer (Intel 8253/8254) */
 
-__attribute__((section(".init"))) void _hal_timerInit(u32 interval)
+
+static int hal_pitTimerIrqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 {
-	unsigned int t;
+	(void)n;
+	(void)arg;
+	(void)ctx;
 
-	interval /= hal_cpuGetCount();
+	timer.pit.jiffies += timer.intervalUs;
+	return 0;
+}
 
-	timer.interval = interval;
-	timer.jiffies = 0;
 
-	t = (u32)((interval * 1190) / 1000);
+static inline u16 _hal_pitCalculateDivider(u32 intervalUs)
+{
+	u32 tmp;
+	tmp = intervalUs;
+	tmp *= PIT_FREQUENCY;
+	tmp /= 1000;
+	if (tmp >= 65536) {
+		tmp = 0;
+	}
+	return (u16)tmp;
+}
 
+
+static inline void _hal_pitSetTimer(u16 reloadValue, u8 opMode)
+{
 	/* First generator, operation - CE write, work mode 2, binary counting */
-	hal_outb(PORT_PIT_COMMAND, 0x34);
+	hal_outb(PORT_PIT_COMMAND, PIT_CHANNEL_0 | PIT_ACCESS_BOTH | opMode);
+	hal_outb(PORT_PIT_DATA_CHANNEL0, (u8)(reloadValue & 0xff));
+	hal_outb(PORT_PIT_DATA_CHANNEL0, (u8)(reloadValue >> 8));
+}
 
-	/* Set counter */
-	hal_outb(PORT_PIT_DATA_CHANNEL0, (u8)(t & 0xff));
-	hal_outb(PORT_PIT_DATA_CHANNEL0, (u8)(t >> 8));
 
+static inline u16 _hal_pitReadTimer(void)
+{
+	u16 low, high;
+	hal_outb(PORT_PIT_COMMAND, PIT_CHANNEL_0); /* Latch command */
+	low = hal_inb(PORT_PIT_DATA_CHANNEL0);
+	high = hal_inb(PORT_PIT_DATA_CHANNEL0);
+	return (high << 8) | low;
+}
+
+
+static void _hal_pitInit(u32 intervalUs)
+{
+	intervalUs /= hal_cpuGetCount();
+	timer.intervalUs = intervalUs;
+
+	_hal_pitSetTimer(_hal_pitCalculateDivider(intervalUs), PIT_OPERATING_RATE_GEN);
+
+	timer.timerType = timer_pit;
+
+	timer.pit.jiffies = 0;
+
+	(void)hal_timerRegister(hal_pitTimerIrqHandler, NULL, &timer.handler);
+}
+
+
+/* Local APIC Timer */
+
+
+static inline void _hal_lapicTimerSetDivider(u8 divider)
+{
+	/* Divider is a power of 2 */
+	if (divider == 0) {
+		/* Not recommended. It is claimed that it is bugged on some emulators */
+		divider = 0xb;
+	}
+	else if (divider > 4) {
+		divider += 3;
+	}
+	else {
+		divider -= 1;
+	}
+	_hal_lapicWrite(LAPIC_LVT_TMR_DC_REG, divider);
+}
+
+
+static inline void _hal_lapicTimerStart(u32 counter)
+{
+	_hal_lapicWrite(LAPIC_LVT_TMR_IC_REG, counter);
+}
+
+
+static inline void _hal_lapicTimerStop(void)
+{
+	_hal_lapicWrite(LAPIC_LVT_TMR_IC_REG, 0);
+}
+
+
+static inline u32 _hal_lapicTimerGetCounter(void)
+{
+	return _hal_lapicRead(LAPIC_LVT_TMR_CC_REG);
+}
+
+
+static inline void _hal_lapicTimerConfigure(u32 mode, u32 mask, u32 vector)
+{
+	_hal_lapicWrite(LAPIC_LVT_TIMER_REG, (vector & 0xff) | ((mask & 0x1) << 16) | ((mode & 0x3) << 17));
+}
+
+
+static inline u32 _hal_lapicTimerCyc2Us(u64 cycles)
+{
+	return (u32)(((cycles << LAPIC_TIMER_DEFAULT_DIVIDER) * 1000) / (u64)timer.lapic.frequency);
+}
+
+
+static inline u64 _hal_lapicTimerUs2Cyc(u32 us)
+{
+	return (((u64)us) * (u64)timer.lapic.frequency) / (1000 << LAPIC_TIMER_DEFAULT_DIVIDER);
+}
+
+
+static int hal_lapicTimerIrqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
+{
+	spinlock_ctx_t sc;
+	const unsigned int id = hal_cpuGetID();
+	hal_spinlockSet(&timer.sp, &sc);
+	timer.lapic.local[id].cycles += timer.lapic.local[id].wait;
+	timer.lapic.local[id].wait = _hal_lapicTimerUs2Cyc(timer.intervalUs);
+	_hal_lapicTimerStart(timer.lapic.local[id].wait);
+	hal_spinlockClear(&timer.sp, &sc);
+	return 0;
+}
+
+
+static int _hal_lapicTimerInit(u32 intervalUs)
+{
+	u64 freq;
+	u32 lapicDelta;
+	u16 pitDelta;
+	if (hal_isLapicPresent() == 1) {
+		lapicDelta = 0xffffffffu;
+		pitDelta = 0xffff;
+		_hal_lapicTimerConfigure(LAPIC_TIMER_ONE_SHOT, 0, SYSTICK_IRQ + INTERRUPTS_VECTOR_OFFSET);
+		_hal_lapicTimerSetDivider(LAPIC_TIMER_DEFAULT_DIVIDER);
+		_hal_pitSetTimer(pitDelta, PIT_OPERATING_ONE_SHOT);
+		_hal_lapicTimerStart(lapicDelta);
+		while (pitDelta > 0x0fff) { /* Wait is around 51.500 ms*/
+			pitDelta = _hal_pitReadTimer();
+		}
+		lapicDelta -= _hal_lapicTimerGetCounter();
+		_hal_lapicTimerStop();
+		pitDelta = 0xffff - pitDelta; /* timePassed = pitDelta / PIT_FREQUENCY */
+
+		freq = ((u64)lapicDelta) * ((u64)PIT_FREQUENCY);
+		freq <<= LAPIC_TIMER_DEFAULT_DIVIDER;
+		freq /= (u64)pitDelta; /* Frequency in kHz, with current technology it should fit in 32 bit */
+
+		timer.timerType = timer_lapic;
+		timer.intervalUs = intervalUs;
+
+		timer.lapic.frequency = freq;
+
+		(void)hal_timerRegister(hal_lapicTimerIrqHandler, NULL, &timer.handler);
+		return 0;
+	}
+	else {
+		return 1;
+	}
+}
+
+
+void hal_timerInitCore(const unsigned int id)
+{
+	switch (timer.timerType) {
+		case timer_lapic:
+			_hal_lapicTimerConfigure(LAPIC_TIMER_ONE_SHOT, 0, SYSTICK_IRQ + INTERRUPTS_VECTOR_OFFSET);
+			_hal_lapicTimerSetDivider(LAPIC_TIMER_DEFAULT_DIVIDER);
+			timer.lapic.local[id].cycles = 0;
+			timer.lapic.local[id].wait = 1;
+			_hal_lapicTimerStart(1);
+			break;
+		default:
+			break;
+	}
+}
+
+
+time_t hal_timerGetUs(void)
+{
+	spinlock_ctx_t sc;
+	time_t ret;
+	hal_spinlockSet(&timer.sp, &sc);
+	switch (timer.timerType) {
+		case timer_lapic:
+			ret = _hal_lapicTimerCyc2Us(timer.lapic.local[0].cycles);
+			break;
+		case timer_pit:
+			ret = timer.pit.jiffies;
+			break;
+		default:
+			ret = -1;
+			break;
+	}
+	hal_spinlockClear(&timer.sp, &sc);
+
+	return ret;
+}
+
+
+void hal_timerSetWakeup(u32 waitUs)
+{
+	unsigned int id;
+	spinlock_ctx_t sc;
+	if (waitUs > timer.intervalUs) {
+		waitUs = timer.intervalUs;
+	}
+
+	hal_spinlockSet(&timer.sp, &sc);
+	switch (timer.timerType) {
+		case timer_lapic:
+			id = hal_cpuGetID();
+			timer.lapic.local[id].cycles += (timer.lapic.local[id].wait - _hal_lapicTimerGetCounter());
+			timer.lapic.local[id].wait = _hal_lapicTimerUs2Cyc(waitUs);
+			_hal_lapicTimerStart(timer.lapic.local[id].wait);
+			break;
+		default:
+			/* Not supported */
+			break;
+	}
+	hal_spinlockClear(&timer.sp, &sc);
+}
+
+
+void _hal_timerInit(u32 intervalUs)
+{
+	timer.timerType = timer_unknown;
 	hal_spinlockCreate(&timer.sp, "timer");
-	timer.handler.f = timer_irqHandler;
-	timer.handler.n = SYSTICK_IRQ;
-	timer.handler.data = NULL;
-	hal_interruptsSetHandler(&timer.handler);
 
-	return;
+	if (_hal_lapicTimerInit(intervalUs) != 0) {
+		_hal_pitInit(intervalUs);
+	}
 }

--- a/hal/ia32/timer.c
+++ b/hal/ia32/timer.c
@@ -39,7 +39,7 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 	return 0;
 }
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/riscv64/timer.c
+++ b/hal/riscv64/timer.c
@@ -41,7 +41,7 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/sparcv8leon3/gaisler/timer.c
+++ b/hal/sparcv8leon3/gaisler/timer.c
@@ -98,7 +98,7 @@ time_t hal_timerGetUs(void)
 }
 
 
-void hal_timerSetWakeup(u32 when)
+void hal_timerSetWakeup(u32 waitUs)
 {
 }
 

--- a/hal/timer.h
+++ b/hal/timer.h
@@ -23,7 +23,7 @@
 extern time_t hal_timerGetUs(void);
 
 
-extern void hal_timerSetWakeup(u32 when);
+extern void hal_timerSetWakeup(u32 waitUs);
 
 
 extern int hal_timerRegister(int (*f)(unsigned int, cpu_context_t *, void *), void *data, intr_handler_t *h);

--- a/include/arch/syspage-ia32.h
+++ b/include/arch/syspage-ia32.h
@@ -39,10 +39,12 @@ typedef struct {
 	unsigned int ebda;
 	unsigned int acpi_version;
 	unsigned int localApicAddr;
-	unsigned int madt;
+	unsigned long madt; /* addr_t */
 	unsigned int madtLength;
-	unsigned int fadt;
+	unsigned long fadt; /* addr_t */
 	unsigned int fadtLength;
+	unsigned long hpet; /* addr_t */
+	unsigned int hpetLength;
 } __attribute__((packed)) hal_syspage_t;
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add support for 2 timers that may be available in ia32: **Local APIC Timer** and **High Precision Event Timers (HPET)**. If they are available, they will be used instead of old **Programmable Interval Timer (PIT)**.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change makes it possible to sleep times shorter than 10ms.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu, ia32-generic-pc

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/plo/pull/302
- [ ] I will merge this PR by myself when appropriate.
