### PR TITLE
lseek: Pass resulting offset via a pointer

### DIFF
--- a/posix/posix.h
+++ b/posix/posix.h
@@ -48,7 +48,7 @@ extern int posix_link(const char *path1, const char *path2);
 extern int posix_unlink(const char *pathname);
 
 
-extern off_t posix_lseek(int fildes, off_t offset, int whence);
+extern int posix_lseek(int fildes, off_t *offset, int whence);
 
 
 extern int posix_ftruncate(int fildes, off_t length);

--- a/syscalls.c
+++ b/syscalls.c
@@ -1068,15 +1068,20 @@ int syscalls_sys_unlink(char *ustack)
 }
 
 
-off_t syscalls_sys_lseek(char *ustack)
+int syscalls_sys_lseek(char *ustack)
 {
 	int fildes;
-	off_t offset;
+	off_t *offset;
 	int whence;
 
 	GETFROMSTACK(ustack, int, fildes, 0);
-	GETFROMSTACK(ustack, off_t, offset, 1);
+	GETFROMSTACK(ustack, off_t *, offset, 1);
 	GETFROMSTACK(ustack, int, whence, 2);
+
+	/* TODO verify pointer */
+	if (offset == NULL) {
+		return -EINVAL;
+	}
 
 	return posix_lseek(fildes, offset, whence);
 }


### PR DESCRIPTION
Fix behaviour on resulting negative file offset

JIRA: RTOS-397

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/361
tested in https://github.com/phoenix-rtos/phoenix-rtos-project/pull/939

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (https://github.com/phoenix-rtos/libphoenix/pull/315 and https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/302).
- [ ] I will merge this PR by myself when appropriate.
