### PR TITLE
sparcv8leon3: fix saving registers in syscall

### DIFF
--- a/hal/sparcv8leon3/_traps.S
+++ b/hal/sparcv8leon3/_traps.S
@@ -582,6 +582,20 @@ _traps_syscall:
 	restore
 
 s_wovfl_done:
+	/* for signal handling: */
+	restore
+
+	std %l0, [%sp + 0x00]
+	std %l2, [%sp + 0x08]
+	std %l4, [%sp + 0x10]
+	std %l6, [%sp + 0x18]
+	std %i0, [%sp + 0x20]
+	std %i2, [%sp + 0x28]
+	std %i4, [%sp + 0x30]
+	std %fp, [%sp + 0x38]
+
+	save
+
 	/* write arguments to stack reserved space */
 	st %i0, [%fp + 0x44]
 	st %i1, [%fp + 0x48]
@@ -606,7 +620,8 @@ s_wovfl_done:
 	add %l2, 4, %l3
 	st  %l2, [%sp + 0x0c] /* pc */
 	st  %l3, [%sp + 0x10] /* npc */
-	st  %g6, [%sp + 0x28]
+	std %g4, [%sp + 0x20]
+	std %g6, [%sp + 0x28]
 	std %fp, [%sp + 0x48] /* fp (task's sp), return address */
 
 	/* allocate stack frame for syscall handler */


### PR DESCRIPTION
Change needed in case of signal handling.

JIRA: RTOS-699

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Some registers used by application weren't saved on entry to syscall. Then if signal was handled, values of these registers couldn't be correctly restored.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`test-libc-exit` would fail before this change
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on:  `sparcv8leon3-gr712rc-board`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
