### PR TITLE
hal/ia32: Fix potential buffer overflow in hal_timerFeatures()

### DIFF
--- a/hal/armv7a/string.c
+++ b/hal/armv7a/string.c
@@ -224,7 +224,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/armv7m/string.c
+++ b/hal/armv7m/string.c
@@ -225,7 +225,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/armv8m/string.c
+++ b/hal/armv8m/string.c
@@ -228,7 +228,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/ia32/string.c
+++ b/hal/ia32/string.c
@@ -160,7 +160,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/riscv64/string.c
+++ b/hal/riscv64/string.c
@@ -108,7 +108,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/sparcv8leon3/string.c
+++ b/hal/sparcv8leon3/string.c
@@ -278,7 +278,7 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
-unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero)
+unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/hal/string.h
+++ b/hal/string.h
@@ -44,7 +44,7 @@ extern char *hal_strcpy(char *dest, const char *src);
 extern char *hal_strncpy(char *dest, const char *src, size_t n);
 
 
-extern unsigned long hal_i2s(char *prefix, char *s, unsigned long i, unsigned char b, char zero);
+extern unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned char b, char zero);
 
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Fixes bugs reported by @kemonats  here https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/479#issuecomment-1830501494

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
