### PR TITLE
ia32/timer: Fix buffer overflow in edge case

### DIFF
--- a/hal/ia32/timer.c
+++ b/hal/ia32/timer.c
@@ -479,15 +479,12 @@ int hal_timerRegister(int (*f)(unsigned int, cpu_context_t *, void *), void *dat
 
 char *hal_timerFeatures(char *features, unsigned int len)
 {
-	static const char textScheduling[] = "Scheduling timer = ";
-	static const char textTimestamp[] = "\nhal: Timestamp timer = ";
+	static const char textScheduling[] = "Scheduling timer: ";
+	static const char textTimestamp[] = "\nhal: Timestamp timer: ";
 	const size_t textSchedulingLength = sizeof(textScheduling) - 1;
 	const size_t textTimestampLength = sizeof(textTimestamp) - 1;
-
 	unsigned int off = 0, n;
-	if (len == 0) {
-		return features;
-	}
+
 	(void)hal_strncpy(features + off, textScheduling, len);
 	n = (textSchedulingLength < len) ? textSchedulingLength : len;
 	off += n;
@@ -501,7 +498,7 @@ char *hal_timerFeatures(char *features, unsigned int len)
 	len -= n;
 
 	off += timer_common.timestampTimer->name(features + off, &len);
-	features[off] = '\0';
+	features[(len == 0) ? off - 1 : off] = '\0';
 	return features;
 }
 


### PR DESCRIPTION
Change features printout style slightly

DONE: RTOS-679

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fix one last remark from https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/485

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
