### PR TITLE
mmap: add support for MAP_FIXED

### DIFF
--- a/include/mman.h
+++ b/include/mman.h
@@ -18,16 +18,17 @@
 
 
 #define MAP_NONE       0x0
-#define MAP_NEEDSCOPY  0x1
-#define MAP_UNCACHED   0x2
-#define MAP_DEVICE     0x4
-#define MAP_NOINHERIT  0x8
-#define MAP_PHYSMEM    0x10
-#define MAP_CONTIGUOUS 0x20
-#define MAP_ANONYMOUS  0x40
+#define MAP_NEEDSCOPY  (1 << 0)
+#define MAP_UNCACHED   (1 << 1)
+#define MAP_DEVICE     (1 << 2)
+#define MAP_NOINHERIT  (1 << 3)
+#define MAP_PHYSMEM    (1 << 4)
+#define MAP_CONTIGUOUS (1 << 5)
+#define MAP_ANONYMOUS  (1 << 6)
+#define MAP_FIXED      (1 << 7)
+/* NOTE: vm uses u8 to store flags, if more flags are needed this type needs to be changed. */
 #define MAP_SHARED     0x0
 #define MAP_PRIVATE    0x0
-#define MAP_FIXED      0x0
 
 
 #define PROT_NONE  0x0

--- a/vm/map.c
+++ b/vm/map.c
@@ -493,6 +493,12 @@ void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, u8 prot, vm_o
 		return NULL;
 	}
 
+	if ((flags & MAP_FIXED) != 0) {
+		if (_vm_munmap(map, vaddr, size) < 0) {
+			return NULL;
+		}
+	}
+
 	/* NULL page indicates that proc sybsystem is ready */
 	if (p == NULL && (current = proc_current()) != NULL)
 		process = current->process;


### PR DESCRIPTION
JIRA: RTOS-738

<!--- Provide a general summary of your changes in the Title above -->

## Description
Munmap changes needed to not produce MAP_FAILED in case of mapping not yet mapped part of memory.
## Motivation and Context
Needed for dynamic linking.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/507
- [ ] I will merge this PR by myself when appropriate.
