### PR TITLE
vm_munmap: Fix bad entry split on NOMMU

### DIFF
--- a/lib/idtree.c
+++ b/lib/idtree.c
@@ -179,6 +179,19 @@ int lib_idtreeAlloc(idtree_t *tree, idnode_t *n, int min)
 }
 
 
+static void _lib_idtreeDump(rbnode_t *node)
+{
+	idnode_t *n = lib_treeof(idnode_t, linkage, node);
+	lib_printf("%d <0x%p>]", n->id, n);
+}
+
+
+void lib_idtreeDump(rbnode_t *node)
+{
+	lib_rbDump(node, _lib_idtreeDump);
+}
+
+
 void lib_idtreeInit(idtree_t *tree)
 {
 	lib_rbInit(tree, lib_idtreeCmp, lib_idtreeAugment);

--- a/lib/idtree.h
+++ b/lib/idtree.h
@@ -60,6 +60,9 @@ int lib_idtreeId(idnode_t *node);
 int lib_idtreeAlloc(idtree_t *tree, idnode_t *n, int min);
 
 
+void lib_idtreeDump(rbnode_t *node);
+
+
 void lib_idtreeInit(idtree_t *tree);
 
 #endif

--- a/vm/map.c
+++ b/vm/map.c
@@ -388,6 +388,10 @@ int _vm_munmap(vm_map_t *map, void *vaddr, size_t size)
 			break;
 		}
 
+#ifdef NOMMU
+		proc = e->process;
+#endif
+
 		/* Note: what if NEEDS_COPY? */
 		amap_putanons(e->amap, (e->aoffs + vaddr) - e->vaddr, size);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a problem found in CI with https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/456

New map_entry_t, spawned on entry split during munmap had current proccess assigned to it, instead of the process assiociated with the original entry owner. This caused it to be wrongly unmaped during process end (on vm_mapDestroy).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
