### PR TITLE
proc: Fix race condition when multiple thread execute join()

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1006,13 +1006,19 @@ static void _proc_threadDequeue(thread_t *t)
 {
 	unsigned int i;
 
+	if (t->state == GHOST) {
+		return;
+	}
+
 	_perf_waking(t);
 
-	if (t->wait != NULL)
+	if (t->wait != NULL) {
 		LIST_REMOVE(t->wait, t);
+	}
 
-	if (t->wakeup)
+	if (t->wakeup) {
 		lib_rbRemove(&threads_common.sleeping, &t->sleeplinkage);
+	}
 
 	t->wakeup = 0;
 	t->wait = NULL;
@@ -1021,12 +1027,14 @@ static void _proc_threadDequeue(thread_t *t)
 
 	/* MOD */
 	for (i = 0; i < hal_cpuGetCount(); i++) {
-		if (t == threads_common.current[i])
+		if (t == threads_common.current[i]) {
 			break;
+		}
 	}
 
-	if (i == hal_cpuGetCount())
+	if (i == hal_cpuGetCount()) {
 		LIST_ADD(&threads_common.ready[t->priority], t);
+	}
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Plain wakeup was used instead of broadcast - if multiple wake up events have been triggered at once, only one joining thread has been woken up. This could cause some threads executing join() to miss death of it's thread.

Refactored whole queue handling, so wakeupPending is assigned in one place and consistently for all wakeups

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/857

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
