### PR TITLE
sparcv8leon3: include cpu-specific headers in sparcv8leon3.h

### DIFF
--- a/include/arch/sparcv8leon3/sparcv8leon3.h
+++ b/include/arch/sparcv8leon3/sparcv8leon3.h
@@ -17,6 +17,15 @@
 #define _PHOENIX_ARCH_SPARCV8LEON3_H_
 
 
+#if defined(__CPU_GR716)
+#include "gr716/gr716.h"
+#elif defined(__CPU_GR712RC)
+#include "gr712rc/gr712rc.h"
+#else
+#error "Unsupported TARGET"
+#endif
+
+
 /* GRLIB Cores' IDs - pages 10-18 GRLIB IP CORE Manual
  * https://www.gaisler.com/products/grlib/grip.pdf#page=10
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
include cpu-specific headers in `include/arch/sparcv8leon3/sparcv8leon3.h` to eliminate the need for per-target includes in userspace
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
