### PR TITLE
msg API changes

### DIFF
--- a/include/ioctl.h
+++ b/include/ioctl.h
@@ -18,16 +18,9 @@
 
 
 typedef struct {
-	id_t id;
-	unsigned pid;
 	unsigned long request;
 	char data[];
 } ioctl_in_t;
 
-
-typedef struct {
-	int err;
-	char data[];
-} ioctl_out_t;
 
 #endif

--- a/include/msg.h
+++ b/include/msg.h
@@ -23,13 +23,14 @@ typedef int msg_rid_t;
  * Message types
  */
 
+/* clang-format off */
 
 enum {
 	/* File operations */
 	mtOpen = 0, mtClose, mtRead, mtWrite, mtTruncate, mtDevCtl,
 
 	/* Object operations */
-	mtCreate, mtDestroy, mtSetAttr, mtGetAttr,
+	mtCreate, mtDestroy, mtSetAttr, mtGetAttr, mtGetAttrAll,
 
 	/* Directory operations */
 	mtLookup, mtLink, mtUnlink, mtReaddir,
@@ -37,26 +38,52 @@ enum {
 	mtCount
 };
 
+/* clang-format on */
+
 
 #pragma pack(push, 8)
+
+
+struct _attr {
+	long long val;
+	int err;
+};
+
+
+struct _attrAll {
+	struct _attr mode;
+	struct _attr uid;
+	struct _attr gid;
+	struct _attr size;
+	struct _attr blocks;
+	struct _attr ioblock;
+	struct _attr type;
+	struct _attr port;
+	struct _attr pollStatus;
+	struct _attr eventMask;
+	struct _attr cTime;
+	struct _attr mTime;
+	struct _attr aTime;
+	struct _attr links;
+	struct _attr dev;
+};
 
 
 typedef struct _msg_t {
 	int type;
 	unsigned int pid;
 	unsigned int priority;
+	oid_t oid;
 
 	struct {
 		union {
 			/* OPEN/CLOSE */
 			struct {
-				oid_t oid;
 				int flags;
 			} openclose;
 
 			/* READ/WRITE/TRUNCATE */
 			struct {
-				oid_t oid;
 				off_t offs;
 				size_t len;
 				unsigned mode;
@@ -64,38 +91,24 @@ typedef struct _msg_t {
 
 			/* CREATE */
 			struct {
-				oid_t dir;
 				int type;
 				unsigned mode;
 				oid_t dev;
 			} create;
 
-			/* DESTROY */
-			struct {
-				oid_t oid;
-			} destroy;
-
 			/* SETATTR/GETATTR */
 			struct {
-				oid_t oid;
 				long long val;
 				int type;
 			} attr;
 
-			/* LOOKUP */
-			struct {
-				oid_t dir;
-			} lookup;
-
 			/* LINK/UNLINK */
 			struct {
-				oid_t dir;
 				oid_t oid;
 			} ln;
 
 			/* READDIR */
 			struct {
-				oid_t dir;
 				off_t offs;
 			} readdir;
 
@@ -103,37 +116,31 @@ typedef struct _msg_t {
 		};
 
 		size_t size;
-		void *data;
+		const void *data;
 	} i;
 
 	struct {
 		union {
-			struct {
-				int err;
-			} io;
-
 			/* ATTR */
 			struct {
 				long long val;
-				int err;
 			} attr;
 
 			/* CREATE */
 			struct {
 				oid_t oid;
-				int err;
 			} create;
 
 			/* LOOKUP */
 			struct {
 				oid_t fil;
 				oid_t dev;
-				int err;
 			} lookup;
 
 			unsigned char raw[64];
 		};
 
+		int err;
 		size_t size;
 		void *data;
 	} o;

--- a/posix/inet.c
+++ b/posix/inet.c
@@ -270,7 +270,7 @@ int inet_socket(int domain, int type, int protocol)
 	if ((err = socksrvcall(&msg)) < 0)
 		return err;
 
-	return msg.o.lookup.err < 0 ? msg.o.lookup.err : msg.o.lookup.dev.port;
+	return (msg.o.err < 0) ? msg.o.err : msg.o.lookup.dev.port;
 }
 
 

--- a/proc/msg-nommu.c
+++ b/proc/msg-nommu.c
@@ -166,6 +166,7 @@ int proc_respond(u32 port, msg_t *msg, msg_rid_t rid)
 	}
 
 	hal_memcpy(kmsg->msg->o.raw, msg->o.raw, sizeof(msg->o.raw));
+	kmsg->msg->o.err = msg->o.err;
 
 	hal_spinlockSet(&p->spinlock, &sc);
 	kmsg->state = msg_responded;

--- a/test/msg.c
+++ b/test/msg.c
@@ -88,7 +88,7 @@ void test_ping(void *arg)
 			return;
 		}
 
-		if (msg.o.io.err < 0) {
+		if (msg.o.err < 0) {
 			lib_printf("\ntest_msg/ping: pong returned error\n");
 			return;
 		}
@@ -136,12 +136,12 @@ void test_pong(void *arg)
 
 		if (proc_recv(port, &msg, &rid) < 0) {
 			lib_printf("test_msg/pong: receive failed\n");
-			msg.o.io.err = 1;
+			msg.o.err = 1;
 		}
 
 		if (msg.i.size != msg.o.size) {
 			lib_printf("test_msg/pong: i/o buffers are of different sizes: 0x%zx and 0x%zx\n", msg.i.size, msg.o.size);
-			msg.o.io.err = 1;
+			msg.o.err = 1;
 		}
 		else
 			hal_memcpy(msg.o.data, msg.i.data, msg.i.size);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
**Breaking changes!**

#### This PR introduces the following changes in msg API:
- `oid` is moved from `i.<type>` to common message part
- `const` is added to input data pointer - **this introduces warnings in some functions!**
- `err` is moved from `o.<type>` to `o` struct
- `mtGetAttrAll` msg type is added, allowing the caller to get all file attributes through one message. In this case `struct _attrs` should be allocated and pointer to it should be written into `msg.o.data` (and sizeof to `msg.o.size`). https://github.com/phoenix-rtos/libphoenix/pull/351 provides `_phoenix_initAttrsStruct` that initializes errors in `struct _attrs`.
Convention for the return value is following:
    - If the server doesn't at all provide support for `mtGetAttrAll` message, it will return negative value in `msg.o.err` field. Other fields remain uninitialized.
    - Otherwise, `msg.o.err` will be set to `0` and all per-attribute errors will be set accordingly. 

Additionally, `id` and `pid` fields from are removed from `ioctl_in_t` struct and `ioctl_out_t` struct is removed completely (but this structs were only used indirectly through `libphoenix`).
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplify message API.

Speed up `ls` command:
- on `armv7a9-zynq7000-qemu`
    - before changes - `psh_ls` call on directory with 100 files takes 1.8-2.3 s
    - after changes - 0.5-0.9 s
- on `ia32-generic-qemu`
    - before changes - 0.9-1.2 s
    - after changes - 0.5-0.7 s
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
