### PR TITLE
move fstat to libphoenix

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -82,7 +82,7 @@
 	ID(sys_pipe) \
 	ID(sys_mkfifo) \
 	ID(sys_chmod) \
-	ID(sys_fstat) \
+	ID(fdResolve) \
 	ID(sys_fsync) \
 	\
 	ID(sys_accept) \

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1850,7 +1850,7 @@ int posix_bind(int socket, const struct sockaddr *address, socklen_t address_len
 				err = inet_bind(f->oid.port, address, address_len);
 				break;
 			case ftUnixSocket:
-				err = unix_bind(f->oid.id, address, address_len);
+				err = unix_bind(f->oid.id, address, address_len, &f->oid, &f->ln);
 				break;
 			default:
 				err = -ENOTSOCK;

--- a/posix/posix.h
+++ b/posix/posix.h
@@ -74,7 +74,7 @@ extern int posix_mkfifo(const char *path, mode_t mode);
 extern int posix_chmod(const char *path, mode_t mode);
 
 
-extern int posix_fstat(int fd, struct stat *buf);
+extern int posix_fdResolve(int fd, oid_t *oid, oid_t *dev);
 
 
 extern int posix_fsync(int fd);

--- a/posix/posix_private.h
+++ b/posix/posix_private.h
@@ -201,7 +201,7 @@ extern int inet_getfl(unsigned socket);
 extern int unix_accept4(unsigned socket, struct sockaddr *address, socklen_t *address_len, int flags);
 
 
-extern int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address_len);
+extern int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address_len, oid_t *odir, oid_t *dev);
 
 
 extern int unix_connect(unsigned socket, const struct sockaddr *address, socklen_t address_len);

--- a/posix/unix.c
+++ b/posix/unix.c
@@ -413,11 +413,10 @@ int unix_accept4(unsigned socket, struct sockaddr *address, socklen_t *address_l
 }
 
 
-int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address_len)
+int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address_len, oid_t *odir, oid_t *dev)
 {
 	char *path, *name, *dir;
 	int err;
-	oid_t odir, dev;
 	unixsock_t *s;
 	void *v = NULL;
 
@@ -439,7 +438,7 @@ int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address
 		do {
 			lib_splitname(path, &name, &dir);
 
-			if (proc_lookup(dir, NULL, &odir) < 0) {
+			if (proc_lookup(dir, NULL, odir) < 0) {
 				err = -ENOTDIR;
 				break;
 			}
@@ -453,9 +452,9 @@ int unix_bind(unsigned socket, const struct sockaddr *address, socklen_t address
 				_cbuffer_init(&s->buffer, v, s->buffsz);
 			}
 
-			dev.port = US_PORT;
-			dev.id = socket;
-			err = proc_create(odir.port, 2 /* otDev */, S_IFSOCK, dev, odir, name, &dev);
+			dev->port = US_PORT;
+			dev->id = socket;
+			err = proc_create(odir->port, 2 /* otDev */, S_IFSOCK, *dev, *odir, name, dev);
 
 			if (err) {
 				if (s->type == SOCK_DGRAM) {

--- a/syscalls.c
+++ b/syscalls.c
@@ -697,6 +697,20 @@ int syscalls_lookup(void *ustack)
 }
 
 
+int syscalls_fdResolve(void *ustack)
+{
+	int fd;
+	oid_t *oid;
+	oid_t *dev;
+
+	GETFROMSTACK(ustack, int, fd, 0);
+	GETFROMSTACK(ustack, oid_t *, oid, 1);
+	GETFROMSTACK(ustack, oid_t *, dev, 2);
+
+	return posix_fdResolve(fd, oid, dev);
+}
+
+
 /*
  * Time management
  */
@@ -1066,18 +1080,6 @@ int syscalls_sys_mkfifo(char *ustack)
 	GETFROMSTACK(ustack, mode_t, mode, 1);
 
 	return posix_mkfifo(path, mode);
-}
-
-
-int syscalls_sys_fstat(char *ustack)
-{
-	int fd;
-	struct stat *buf;
-
-	GETFROMSTACK(ustack, int, fd, 0);
-	GETFROMSTACK(ustack, struct stat *, buf, 1);
-
-	return posix_fstat(fd, buf);
 }
 
 


### PR DESCRIPTION
JIRA: RTOS-790, RTOS-791

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- save unix socket oid in `open_file_t` structure after binding
- remove `fstat`
- add `fdResolve` syscall to resolve `fd -> oid`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/libphoenix/pull/352
- [ ] I will merge this PR by myself when appropriate.
