### PR TITLE
process: return error on not existing codeMap

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -1216,7 +1216,16 @@ int proc_syspageSpawnName(const char *imap, const char *dmap, const char *name, 
 	}
 
 	sysMap = (dmap == NULL) ? syspage_mapIdResolve(prog->dmaps[0]) : syspage_mapNameResolve(dmap);
-	codeMap = (imap == NULL) ? syspage_mapIdResolve(prog->imaps[0]) : syspage_mapNameResolve(imap);
+
+	if (imap != NULL) {
+		codeMap = syspage_mapNameResolve(imap);
+		if (codeMap == NULL) {
+			return -EINVAL;
+		}
+	}
+	else {
+		codeMap = syspage_mapIdResolve(prog->imaps[0]);
+	}
 
 	if (codeMap != NULL) {
 		if ((codeMap->attr & (mAttrRead | mAttrExec)) != (mAttrRead | mAttrExec)) {


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

The change adds a check for the existence of a named imap; if a non-existent codeMap (imap) name is provided, an error is reported. If imap name is NULL, codeMap can be NULL, then the default map (imapp = NULL) will be used.

The change fixes a bug related to the psh `sysexec` command, which did not return an error if a non-existent code map was specified.

JIRA: RTOS-810

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
