### PR TITLE
kernel/vm: Make some functions static and remove dead code

### DIFF
--- a/test/vm.c
+++ b/test/vm.c
@@ -50,7 +50,7 @@ void test_vm_alloc(void)
 			break;
 		}
 
-		_page_free(p);
+		vm_pageFree(p);
 
 		lib_printf("\rtest: size=%d, n=%d", size, n);
 

--- a/vm/page-nommu.c
+++ b/vm/page-nommu.c
@@ -72,24 +72,17 @@ page_t *vm_pageAlloc(size_t size, u8 flags)
 }
 
 
-void _page_free(page_t *lh)
+void vm_pageFree(page_t *lh)
 {
+	proc_lockSet(&pages.lock);
+
 	lh->next = pages.freeq;
 	pages.freeq = lh;
 
 	pages.freesz += (1 << lh->idx);
 	pages.allocsz -= (1 << lh->idx);
 
-	return;
-}
-
-
-void vm_pageFree(page_t *lh)
-{
-	proc_lockSet(&pages.lock);
-	_page_free(lh);
 	proc_lockClear(&pages.lock);
-
 	return;
 }
 
@@ -121,11 +114,6 @@ int page_map(pmap_t *pmap, void *vaddr, addr_t pa, int attr)
 page_t *_page_get(addr_t addr)
 {
 	return NULL;
-}
-
-
-void vm_pageFreeAt(pmap_t *pmap, void *vaddr)
-{
 }
 
 

--- a/vm/page.c
+++ b/vm/page.c
@@ -206,7 +206,7 @@ void vm_pageFreeAt(pmap_t *pmap, void *vaddr)
 }
 
 
-void _page_initSizes(void)
+static void _page_initSizes(void)
 {
 	unsigned int i, k, idx;
 	page_t *p;
@@ -344,7 +344,7 @@ void _page_showPages(void)
 }
 
 
-int _page_map(pmap_t *pmap, void *vaddr, addr_t pa, int attrs)
+static int _page_map(pmap_t *pmap, void *vaddr, addr_t pa, int attrs)
 {
 	page_t *ap = NULL;
 

--- a/vm/page.c
+++ b/vm/page.c
@@ -100,10 +100,12 @@ page_t *vm_pageAlloc(size_t size, u8 flags)
 }
 
 
-void _page_free(page_t *p)
+void vm_pageFree(page_t *p)
 {
 	unsigned int idx, i;
 	page_t *lh = p, *rh = p;
+
+	proc_lockSet(&pages.lock);
 
 	if ((lh->flags & PAGE_FREE) != 0) {
 		hal_cpuDisableInterrupts();
@@ -154,14 +156,6 @@ void _page_free(page_t *p)
 
 	LIST_ADD(&pages.sizes[idx], p);
 
-	return;
-}
-
-
-void vm_pageFree(page_t *lh)
-{
-	proc_lockSet(&pages.lock);
-	_page_free(lh);
 	proc_lockClear(&pages.lock);
 	return;
 }
@@ -193,14 +187,6 @@ page_t *_page_get(addr_t addr)
 	p = lib_bsearch((void *)addr, pages.pages, np, sizeof(page_t),  _page_get_cmp);
 
 	return p;
-}
-
-
-void vm_pageFreeAt(pmap_t *pmap, void *vaddr)
-{
-	proc_lockSet(&pages.lock);
-	_page_free(_page_get(pmap_resolve(pmap, vaddr)));
-	proc_lockClear(&pages.lock);
 }
 
 

--- a/vm/page.c
+++ b/vm/page.c
@@ -105,7 +105,6 @@ void _page_free(page_t *p)
 	unsigned int idx, i;
 	page_t *lh = p, *rh = p;
 
-#if 1
 	if ((lh->flags & PAGE_FREE) != 0) {
 		hal_cpuDisableInterrupts();
 		lib_printf("page: double free (%p)\n", lh);
@@ -113,7 +112,6 @@ void _page_free(page_t *p)
 		for (;;) {
 		}
 	}
-#endif
 
 	idx = p->idx;
 
@@ -240,21 +238,6 @@ static void _page_initSizes(void)
 
 		i += ((1UL << idx) / SIZE_PAGE);
 	}
-	return;
-}
-
-
-void _page_showSizes(void)
-{
-	unsigned int i;
-
-	for (i = 0; i < SIZE_VM_SIZES; i++) {
-		lib_printf("[");
-		if (pages.sizes[i] != NULL)
-			lib_printf("%p", pages.sizes[i]->addr);
-		lib_printf("]");
-	}
-	lib_printf("\n");
 	return;
 }
 

--- a/vm/page.h
+++ b/vm/page.h
@@ -24,16 +24,10 @@
 extern page_t *vm_pageAlloc(size_t size, u8 flags);
 
 
-extern void _page_free(page_t *lh);
-
-
 extern void vm_pageFree(page_t *lh);
 
 
 extern page_t *_page_get(addr_t addr);
-
-
-extern void vm_pageFreeAt(pmap_t *pmap, void *vaddr);
 
 
 extern void _page_showPages(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->

- MISRA
- Make `_page_map` and `_page_initSizes` static
- Remove dead function `_page_showSizes`

Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1071
Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1072
Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1073
Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1080
Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1082

JIRA: RTOS-836

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
