### PR TITLE
armv7m/imxrt117x: LPSR GPR0-GPR25 exist but are not usable 

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -748,10 +748,10 @@ static int _imxrt_getIOgpr(int which, unsigned int *what)
 static int _imxrt_setIOlpsrGpr(int which, unsigned int what)
 {
 	/*
-	 * GPR0 - GPR25, GPR27 - GPR32 don't exist
+	 * GPR27 - GPR32 don't exist
 	 * GPR40 and GPR41 are read only
 	 */
-	if ((which < 26) || ((which > 26) && (which < 33)) || (which > 39)) {
+	if ((which < 0) || ((which > 26) && (which < 33)) || (which > 39)) {
 		return -EINVAL;
 	}
 
@@ -765,9 +765,9 @@ static int _imxrt_setIOlpsrGpr(int which, unsigned int what)
 static int _imxrt_getIOlpsrGpr(int which, unsigned int *what)
 {
 	/*
-	 * GPR0 - GPR25, GPR27 - GPR32 don't exist
+	 * GPR27 - GPR32 don't exist
 	 */
-	if ((which < 26) || ((which > 26) && (which < 33)) || (which > 41) || (what == NULL)) {
+	if ((which < 0) || ((which > 26) && (which < 33)) || (which > 41) || (what == NULL)) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
According to reference manual Rev. 1, 05/2021 registers LPSR GPR0-GPR25 do not exist, but in Rev. 2, 06/2023 they do.

JIRA: RTOS-838

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
