### PR TITLE
kernel/hal/ia32: Fix invalid endianess in FPU context

### DIFF
--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -196,13 +196,13 @@
 #pragma pack(push, 1)
 
 typedef struct {
-	u16 _controlWord, controlWord;
-	u16 _statusWord, statusWord;
-	u16 _tagWord, tagWord;
+	u16 controlWord, _controlWord;
+	u16 statusWord, _statusWord;
+	u16 tagWord, _tagWord;
 	u32 fip;
 	u32 fips;
 	u32 fdp;
-	u16 _fds, fds;
+	u16 fds, _fds;
 	ld80 fpuContext[8];
 } fpu_context_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Low 16 bits of FPU control word, status word, tag word and Data Pointer Selector are incorrectly placed in the `fpu_context_t` structure.

JIRA: RTOS-842

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
