### PR TITLE
kernel/hal: `hal_i2s` doesn't display number when `zero == 0` and `i == 0`

### DIFF
--- a/hal/armv7a/string.c
+++ b/hal/armv7a/string.c
@@ -176,6 +176,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;

--- a/hal/armv7m/string.c
+++ b/hal/armv7m/string.c
@@ -177,6 +177,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;

--- a/hal/armv8m/string.c
+++ b/hal/armv8m/string.c
@@ -178,6 +178,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;

--- a/hal/ia32/string.c
+++ b/hal/ia32/string.c
@@ -178,6 +178,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;

--- a/hal/riscv64/string.c
+++ b/hal/riscv64/string.c
@@ -127,6 +127,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;

--- a/hal/sparcv8leon3/string.c
+++ b/hal/sparcv8leon3/string.c
@@ -287,6 +287,10 @@ unsigned long hal_i2s(const char *prefix, char *s, unsigned long i, unsigned cha
 	m = hal_strlen(prefix);
 	hal_memcpy(s, prefix, m);
 
+	if ((zero == 0) && (i == 0)) {
+		s[m++] = '0';
+	}
+
 	for (k = m, l = (unsigned long)-1; l != 0; i /= b, l /= b) {
 		if ((zero == 0) && (i == 0)) {
 			break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- MISRA
- Fix `hal_i2s` not displaying a number when `zero == 0` and `i == 0`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
