### PR TITLE
unix: fix socket flags

### DIFF
--- a/posix/unix.c
+++ b/posix/unix.c
@@ -947,7 +947,7 @@ int unix_setfl(unsigned socket, int flags)
 	s->nonblock = (flags & O_NONBLOCK) != 0;
 
 	unixsock_put(s);
-	return flags;
+	return 0;
 }
 
 
@@ -959,7 +959,10 @@ int unix_getfl(unsigned socket)
 	if ((s = unixsock_get(socket)) == NULL)
 		return -ENOTSOCK;
 
-	flags = s->nonblock ? O_NONBLOCK : 0;
+	flags = O_RDWR;
+	if (s->nonblock) {
+		flags |= O_NONBLOCK;
+	}
 
 	unixsock_put(s);
 	return flags;


### PR DESCRIPTION
Sockets can read and write by default. Required for fdopen() to work on unix sockets.

JIRA: RTOS-892

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: (https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/369).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
