### PR TITLE
riscv64/Makefile: disable gp relaxations

### DIFF
--- a/hal/riscv64/Makefile
+++ b/hal/riscv64/Makefile
@@ -11,3 +11,8 @@ include hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/Makefile
 
 CFLAGS += -Ihal/$(TARGET_SUFF) -Ihal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)
 
+# binutils 2.41 silently introduced gp relaxations which for some reason make kernel impossible to build
+# TODO: investigate further
+ifeq ($(shell expr $(LD_VERSION_MINOR) ">=" 41), 1)
+LDFLAGS += $(LDFLAGS_PREFIX)--no-relax-gp
+endif


### PR DESCRIPTION
binutils 2.41 silently introduced gp relaxations which for some reason make kernel impossible to build
JIRA: RTOS-912


## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work 
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/587
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/203/files
- [ ] I will merge this PR by myself when appropriate.
