### PR TITLE
hal/ia32: cast operands to correct sizes

### DIFF
--- a/hal/ia32/ia32.h
+++ b/hal/ia32/ia32.h
@@ -29,7 +29,7 @@ static inline u8 hal_inb(void *addr)
 	__asm__ volatile (
 		"inb %1, %0\n\t"
 	: "=a" (b)
-	: "d" (addr)
+	: "d" ((u16)(addr_t)addr)
 	: );
 	/* clang-format on */
 	return b;
@@ -42,7 +42,7 @@ static inline void hal_outb(void *addr, u8 b)
 	__asm__ volatile (
 		"outb %1, %0"
 	:
-	: "d" (addr), "a" (b)
+	: "d" ((u16)(addr_t)addr), "a" (b)
 	: );
 	/* clang-format on */
 
@@ -58,7 +58,7 @@ static inline u16 hal_inw(void *addr)
 	__asm__ volatile (
 		"inw %1, %0\n\t"
 	: "=a" (w)
-	: "d" (addr)
+	: "d" ((u16)(addr_t)addr)
 	: );
 	/* clang-format on */
 
@@ -72,7 +72,7 @@ static inline void hal_outw(void *addr, u16 w)
 	__asm__ volatile (
 		"outw %1, %0"
 	:
-	: "d" (addr), "a" (w)
+	: "d" ((u16)(addr_t)addr), "a" (w)
 	: );
 	/* clang-format on */
 


### PR DESCRIPTION
Newer binutils versions check closely if asm instructions get operands of correct size.

JIRA: RTOS-912

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
