### PR TITLE
proc: do not check sizes in not loadable sections

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -359,9 +359,11 @@ static int process_validateElf32(void *iehdr, size_t size)
 		return -ENOEXEC;
 	}
 	for (i = 0; i < ehdr->e_phnum; i++) {
-		if ((phdr->p_type != PT_LOAD) &&
-			(process_isPtrValid(iehdr, size, ((char *)ehdr) + phdr[i].p_offset, phdr[i].p_filesz) == 0)) {
-			return -ENOEXEC;
+		if (phdr->p_type != PT_LOAD) {
+			if (process_isPtrValid(iehdr, size, ((char *)ehdr) + phdr[i].p_offset, phdr[i].p_filesz) == 0) {
+				return -ENOEXEC;
+			}
+			continue;
 		}
 
 		offs = phdr->p_offset & ~(phdr->p_align - 1);
@@ -432,9 +434,11 @@ static int process_validateElf64(void *iehdr, size_t size)
 		return -ENOEXEC;
 	}
 	for (i = 0; i < ehdr->e_phnum; i++) {
-		if ((phdr->p_type != PT_LOAD) &&
-			(process_isPtrValid(iehdr, size, ((char *)ehdr) + phdr[i].p_offset, phdr[i].p_filesz) == 0)) {
-			return -ENOEXEC;
+		if (phdr->p_type != PT_LOAD) {
+			if (process_isPtrValid(iehdr, size, ((char *)ehdr) + phdr[i].p_offset, phdr[i].p_filesz) == 0) {
+				return -ENOEXEC;
+			}
+			continue;
 		}
 
 		offs = phdr->p_offset & ~(phdr->p_align - 1);


### PR DESCRIPTION
JIRA: RTOS-912

<!--- Provide a general summary of your changes in the Title above -->

## Description
memsz doesn't matter in that case, caused bug if there was a section with arch data

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: riscv-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
