### PR TITLE
!imxrt: Changes related to RTT

### DIFF
--- a/include/sysinfo.h
+++ b/include/sysinfo.h
@@ -70,6 +70,7 @@ typedef struct {
 	addr_t vend;
 	size_t alloc;
 	size_t free;
+	char name[16];
 } mapinfo_t;
 
 

--- a/vm/map.c
+++ b/vm/map.c
@@ -1125,6 +1125,7 @@ void vm_mapinfo(meminfo_t *info)
 	rbnode_t *n;
 	map_entry_t *e;
 	vm_map_t *map;
+	const syspage_map_t *spMap;
 	unsigned int size;
 	process_t *process;
 	int i;
@@ -1314,6 +1315,14 @@ void vm_mapinfo(meminfo_t *info)
 				info->maps.map[size].pend = (addr_t)map->pmap.end;
 				info->maps.map[size].vstart = (ptr_t)map->start;
 				info->maps.map[size].vend = (ptr_t)map->stop;
+				spMap = syspage_mapIdResolve(size);
+				if ((spMap != NULL) && (spMap->name != NULL)) {
+					hal_strncpy(info->maps.map[size].name, spMap->name, sizeof(info->maps.map[size].name));
+					info->maps.map[size].name[sizeof(info->maps.map[size].name) - 1] = '\0';
+				}
+				else {
+					info->maps.map[size].name[0] = '\0';
+				}
 			}
 		}
 


### PR DESCRIPTION
Add reporting of map name in `meminfo` syscall.

## Motivation and Context
These features allow implementation of RTT in a more elegant way, with RTT details defined in PLO being passed through to the userspace driver. Using this it is also possible to have console over RTT continuously, using the same buffers, from system start. 

NOTE: This change changes the `meminfo_t` struct used for the `meminfo` syscall. Existing code using this syscall may need to be recompiled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1170

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
