### PR TITLE
hal/imxrt10xx: remove enet PLL deinit

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -2234,7 +2234,6 @@ void _imxrt_init(void)
 
 	/* Power down all unused PLL */
 	_imxrt_ccmDeinitAudioPll();
-	_imxrt_ccmDeinitEnetPll();
 
 	/* Wait for any pending CCM div/mux handshake process to complete */
 	while ((*(imxrt_common.ccm + ccm_cdhipr) & 0x1002b) != 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove deinitialization of CCM_ANALOG_PLL_ENET.

## Motivation and Context
ENET module on imxrt106x-evk needs this clock to run.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt1064-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
