### PR TITLE
ia32: add passing of graphmode params via syspage and platformctl

### DIFF
--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -568,6 +568,17 @@ int hal_platformctl(void *ptr)
 			}
 			break;
 
+		case pctl_graphmode:
+			if (data->action == pctl_get) {
+				data->graphmode.width = syspage->hs.graphmode.width;
+				data->graphmode.height = syspage->hs.graphmode.height;
+				data->graphmode.bpp = syspage->hs.graphmode.bpp;
+				data->graphmode.pitch = syspage->hs.graphmode.pitch;
+				data->graphmode.framebuffer = syspage->hs.graphmode.framebuffer;
+				return EOK;
+			}
+			break;
+
 		default:
 			break;
 	}

--- a/include/arch/ia32/ia32.h
+++ b/include/arch/ia32/ia32.h
@@ -71,9 +71,11 @@ typedef struct {
 } __attribute__((packed)) pci_dev_t;
 
 
+/* clang-format off */
+
 typedef struct {
 	enum { pctl_set = 0, pctl_get } action;
-	enum { pctl_pci = 0, pctl_busmaster, pctl_reboot } type;
+	enum { pctl_pci = 0, pctl_busmaster, pctl_reboot, pctl_graphmode } type;
 
 	union {
 		struct {
@@ -91,8 +93,18 @@ typedef struct {
 			unsigned int magic;
 			unsigned int reason;
 		} reboot;
+
+		struct {
+			unsigned short width;
+			unsigned short height;
+			unsigned short bpp;
+			unsigned short pitch;
+			unsigned long framebuffer; /* addr_t */
+		} graphmode;
 	};
 } platformctl_t;
+
+/* clang-format on */
 
 
 #endif

--- a/include/arch/ia32/syspage.h
+++ b/include/arch/ia32/syspage.h
@@ -47,6 +47,14 @@ typedef struct {
 	unsigned int hpetLength;
 	unsigned long mcfg; /* addr_t */
 	unsigned int mcfgLength;
+
+	struct {
+		unsigned short width;
+		unsigned short height;
+		unsigned short bpp;
+		unsigned short pitch;
+		unsigned long framebuffer;       /* addr_t */
+	} __attribute__((packed)) graphmode; /* Graphics mode info */
 } __attribute__((packed)) hal_syspage_t;
 
 


### PR DESCRIPTION
plo can now store graphics mode details in syspage (i.e. after setting the mode via VESA VBE) that are then accessible from userspace via platformctl

JIRA: RTOS-906

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: ia32

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
