### PR TITLE
hal/imxrt106x: fix enet PLL init

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt10xx.c
+++ b/hal/armv7m/imxrt/10xx/imxrt10xx.c
@@ -969,7 +969,7 @@ void _imxrt_ccmInitEnetPll(u8 enclk0, u8 enclk1, u8 enclk2, u8 div0, u8 div1)
 	u32 enet_pll = ((div1 & 0x3) << 2) | (div0 & 0x3);
 
 	if (enclk0 != 0) {
-		enet_pll |= 1 << 12;
+		enet_pll |= 1 << 13;
 	}
 
 	if (enclk1 != 0) {
@@ -980,10 +980,15 @@ void _imxrt_ccmInitEnetPll(u8 enclk0, u8 enclk1, u8 enclk2, u8 div0, u8 div1)
 		enet_pll |= 1 << 21;
 	}
 
-	*(imxrt_common.ccm_analog + ccm_analog_pll_enet) = enet_pll;
+	/* enable bypass during clock frequency change */
+	*(imxrt_common.ccm_analog + ccm_analog_pll_enet) = 1 << 16;
+
+	*(imxrt_common.ccm_analog + ccm_analog_pll_enet) |= enet_pll;
 
 	while ((*(imxrt_common.ccm_analog + ccm_analog_pll_enet) & (1 << 31)) == 0) {
 	}
+
+	*(imxrt_common.ccm_analog + ccm_analog_pll_enet) &= ~(1 << 16);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix `_imxrt_ccmInitEnetPll` to correctly initialize enet PLL.

## Motivation and Context
Enet PLL clk0 is enabled using bit 13 of CCM_ANALOG_PLL_ENET register, but the shift for `enclk0` was  12, which does not match the iMX RT106x RM.
Additionally, bypass was needed during the frequency change.

Related: https://github.com/phoenix-rtos/plo/pull/355

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt106x-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
