### PR TITLE
zynq7000: Fix system reboot on pctl_get on pctl_reboot

### DIFF
--- a/hal/armv7a/zynq7000/zynq.c
+++ b/hal/armv7a/zynq7000/zynq.c
@@ -645,7 +645,10 @@ int hal_platformctl(void *ptr)
 			break;
 
 		case pctl_reboot:
-			zynq_softRst();
+			if ((data->action == pctl_set) && (data->reboot.magic == PCTL_REBOOT_MAGIC)) {
+				zynq_softRst();
+			}
+			/* TODO add boot reason for pctl_get */
 			break;
 
 		case pctl_sdwpcd:

--- a/include/arch/armv7a/zynq7000/zynq7000.h
+++ b/include/arch/armv7a/zynq7000/zynq7000.h
@@ -16,6 +16,8 @@
 #ifndef _PHOENIX_ARCH_ZYNQ7000_H_
 #define _PHOENIX_ARCH_ZYNQ7000_H_
 
+#define PCTL_REBOOT_MAGIC 0xaa55aa55UL
+
 /* clang-format off */
 
 /* AMBA peripherals */


### PR DESCRIPTION
DONE: RTOS-940

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1003

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
