### PR TITLE
syscalls: enable getting functions from stack

### DIFF
--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -55,9 +55,9 @@
 
 #define GETFROMSTACK(ustack, t, v, n) \
 	do { \
-		ustack = (void *)(((addr_t)ustack + sizeof(t) - 1) & ~(sizeof(t) - 1)); \
-		(v) = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack = (void *)(((addr_t)ustack + sizeof(typeof(v)) - 1) & ~(sizeof(typeof(v)) - 1)); \
+		(v) = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 typedef struct _cpu_context_t {

--- a/hal/armv7m/arch/cpu.h
+++ b/hal/armv7m/arch/cpu.h
@@ -64,9 +64,9 @@
 
 #define GETFROMSTACK(ustack, t, v, n) \
 	do { \
-		ustack = (void *)(((ptr_t)ustack + sizeof(t) - 1) & ~(sizeof(t) - 1)); \
-		(v) = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack = (void *)(((ptr_t)ustack + sizeof(typeof(v)) - 1) & ~(sizeof(typeof(v)) - 1)); \
+		(v) = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 

--- a/hal/armv8m/arch/cpu.h
+++ b/hal/armv8m/arch/cpu.h
@@ -48,9 +48,9 @@
 
 #define GETFROMSTACK(ustack, t, v, n) \
 	do { \
-		ustack = (void *)(((ptr_t)ustack + sizeof(t) - 1) & ~(sizeof(t) - 1)); \
-		(v) = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack = (void *)(((ptr_t)ustack + sizeof(typeof(v)) - 1) & ~(sizeof(typeof(v)) - 1)); \
+		(v) = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 

--- a/hal/armv8r/arch/cpu.h
+++ b/hal/armv8r/arch/cpu.h
@@ -61,9 +61,9 @@
 
 #define GETFROMSTACK(ustack, t, v, n) \
 	do { \
-		ustack = (void *)(((addr_t)ustack + sizeof(t) - 1) & ~(sizeof(t) - 1)); \
-		(v) = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack = (void *)(((addr_t)ustack + sizeof(typeof(v)) - 1) & ~(sizeof(typeof(v)) - 1)); \
+		(v) = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 typedef struct _cpu_context_t {

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -187,10 +187,9 @@
 	do { \
 		if (n == 0) \
 			ustack += 4; \
-		v = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		v = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
-
 
 
 #pragma pack(push, 1)

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -72,9 +72,9 @@
 
 #define GETFROMSTACK(ustack, t, v, n) \
 	do { \
-		ustack = (void *)(((addr_t)ustack + sizeof(t) - 1) & ~(sizeof(t) - 1)); \
-		(v) = *(t *)ustack; \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack = (void *)(((addr_t)ustack + sizeof(typeof(v)) - 1) & ~(sizeof(typeof(v)) - 1)); \
+		(v) = *(typeof(v) *)ustack; \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 

--- a/hal/sparcv8leon3/arch/cpu.h
+++ b/hal/sparcv8leon3/arch/cpu.h
@@ -150,10 +150,10 @@
 	do { \
 		/* 8-byte values might have been put on stack unaligned */ \
 		/* clang-format off */ \
-		if (sizeof(t) == 8 && ((ptr_t)(ustack) & 0x7) != 0) { \
+		if (sizeof(typeof(v)) == 8 && ((ptr_t)(ustack) & 0x7) != 0) { \
 			/* clang-format on */ \
 			union { \
-				t val; \
+				typeof(v) val; \
 				struct { \
 					u32 lo; \
 					u32 hi; \
@@ -164,9 +164,9 @@
 			v = data##n.val; \
 		} \
 		else { \
-			(v) = *(t *)ustack; \
+			(v) = *(typeof(v) *)ustack; \
 		} \
-		ustack += SIZE_STACK_ARG(sizeof(t)); \
+		ustack += SIZE_STACK_ARG(sizeof(typeof(v))); \
 	} while (0)
 
 

--- a/proc/process.h
+++ b/proc/process.h
@@ -66,7 +66,7 @@ typedef struct _process_t {
 
 	unsigned sigpend;
 	unsigned sigmask;
-	void *sighandler;
+	void (*sighandler)(void);
 
 	void *got;
 	hal_tls_t tls;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1486,7 +1486,7 @@ void threads_setupUserReturn(void *retval)
 {
 	spinlock_ctx_t sc;
 	cpu_context_t *ctx, *signalCtx;
-	void *f;
+	void (*f)(void);
 	void *kstackTop;
 	thread_t *thread;
 
@@ -1501,7 +1501,7 @@ void threads_setupUserReturn(void *retval)
 	if (_threads_checkSignal(thread, thread->process, signalCtx, SIG_SRC_SCALL) == 0) {
 		f = thread->process->sighandler;
 		hal_spinlockClear(&threads_common.spinlock, &sc);
-		hal_jmp(f, kstackTop, hal_cpuGetUserSP(signalCtx), 0, NULL);
+		hal_jmp((void *)f, kstackTop, hal_cpuGetUserSP(signalCtx), 0, NULL);
 		/* no return */
 	}
 

--- a/syscalls.c
+++ b/syscalls.c
@@ -294,7 +294,7 @@ int syscalls_beginthreadex(void *ustack)
 	int *id;
 	int err;
 
-	GETFROMSTACK(ustack, void *, start, 0);
+	GETFROMSTACK(ustack, void (*)(void *), start, 0);
 	GETFROMSTACK(ustack, unsigned int, priority, 1);
 	GETFROMSTACK(ustack, void *, stack, 2);
 	GETFROMSTACK(ustack, unsigned int, stacksz, 3);
@@ -659,14 +659,14 @@ int syscalls_interrupt(void *ustack)
 {
 	process_t *proc = proc_current()->process;
 	unsigned int n;
-	void *f;
+	int (*f)(unsigned int, void *);
 	void *data;
 	handle_t cond;
 	handle_t *handle;
 	int res;
 
 	GETFROMSTACK(ustack, unsigned int, n, 0);
-	GETFROMSTACK(ustack, void *, f, 1);
+	GETFROMSTACK(ustack, int (*)(unsigned int, void *), f, 1);
 	GETFROMSTACK(ustack, void *, data, 2);
 	GETFROMSTACK(ustack, handle_t, cond, 3);
 	GETFROMSTACK(ustack, handle_t *, handle, 4);
@@ -941,11 +941,11 @@ addr_t syscalls_va2pa(void *ustack)
 
 int syscalls_signalHandle(void *ustack)
 {
-	void *handler;
+	void (*handler)(void);
 	unsigned mask, mmask;
 	thread_t *thread;
 
-	GETFROMSTACK(ustack, void *, handler, 0);
+	GETFROMSTACK(ustack, void (*)(void), handler, 0);
 	GETFROMSTACK(ustack, unsigned, mask, 1);
 	GETFROMSTACK(ustack, unsigned, mmask, 2);
 


### PR DESCRIPTION
DONE: RTOS-947

## Description
Adjust `GETFROMSTACK` to enable passing functions as type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
