### PR TITLE
map: fix mprotected pages not being copied

### DIFF
--- a/vm/map.c
+++ b/vm/map.c
@@ -1060,8 +1060,8 @@ int vm_mapCopy(process_t *proc, vm_map_t *dst, vm_map_t *src)
 
 		if ((proc == NULL) || (proc->lazy == 0)) {
 			for (offs = 0; offs < f->size; offs += SIZE_PAGE) {
-				if ((_map_force(dst, f, f->vaddr + offs, f->prot) < 0) ||
-						(_map_force(src, e, e->vaddr + offs, e->prot) < 0)) {
+				if ((_map_force(dst, f, f->vaddr + offs, f->prot) != 0) ||
+						(_map_force(src, e, e->vaddr + offs, e->prot) != 0)) {
 					proc_lockClear(&dst->lock);
 					proc_lockClear(&src->lock);
 					return -ENOMEM;


### PR DESCRIPTION
JIRA: RTOS-953

## Description
When a memory region with prot read-write got changed to read, then the
memory would not be copied on fork. This result in child and parent
sharing this page that can be changed back to being writeable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/381.
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
