### PR TITLE
hal/imxrt117x: fix IOpad get/set

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -180,7 +180,8 @@ int _imxrt_setIOpad(int pad, char sre, char dse, char pue, char pus, char ode, c
 		return -EINVAL;
 	}
 
-	if ((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15)) {
+	if (((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_emc_b2_20)) ||
+			((pad >= pctl_pad_gpio_sd_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15))) {
 		/* Fields have slightly diffrent meaning... */
 		if (pue == 0) {
 			pull = 3;
@@ -233,7 +234,8 @@ static int _imxrt_getIOpad(int pad, char *sre, char *dse, char *pue, char *pus, 
 
 	t = (*reg);
 
-	if ((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15)) {
+	if (((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_emc_b2_20)) ||
+			((pad >= pctl_pad_gpio_sd_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15))) {
 		pull = (t >> 2) & 3;
 
 		if (pull == 3) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
properly set the ranges of gpio pad registers that are controlled differently to the rest

## Motivation and Context
Needed for platformctl to work as intended on iMX RT1170-evk.
related change: https://github.com/phoenix-rtos/plo/pull/364

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt1170-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
