### PR TITLE
hal/ia32: fix edx restoration in exceptions

### DIFF
--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -30,8 +30,8 @@ exception_pushContext:
 	/* Save error code */
 	mov 4(%esp), %edx
 	movl %edx, -(4 * CTXPUSHL - 4)(%esp)
-	addl $4, %esp
 	popl %edx
+	addl $4, %esp
 	/* Check TS flag in CR0 register */
 	pushl %eax
 	movl %cr0, %eax


### PR DESCRIPTION
JIRA: RTOS-954

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix of error introduced in https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/609.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
