### PR TITLE
hal/arm: optimize register usage

### DIFF
--- a/hal/armv7a/_armv7a.S
+++ b/hal/armv7a/_armv7a.S
@@ -289,37 +289,35 @@ _hal_cpuSetKernelStack:
 .type hal_jmp, %function
 hal_jmp:
 	cpsid if
-	mov r4, r0
-	mov r5, r1
-	mov r6, r2
-	mov r7, r3
-	ldr r8, [sp]
 	/* ustack != NULL means that the jump is to user */
-	cmp r6, #NULL
+	cmp r2, #NULL
 	bne 2f
-	mov sp, r5
+	/* kargs are passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	/* pass args */
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:	cpsie if
 	blx r4
 	/* Handle userspace jump */
-2:	mov sp, r6
+2:	mov sp, r2
 	cps #IRQ_MODE
-	mov r5, #0x10
-	tst r4, #1
-	orrne r5, r5, #THUMB_STATE
-	push {r4, r5}
+	mov r1, #0x10
+	tst r0, #1
+	orrne r1, r1, #THUMB_STATE
+	push {r0, r1}
 	rfefd sp!
 .size hal_jmp, .-hal_jmp
 .ltorg

--- a/hal/armv7m/imxrt/_init.S
+++ b/hal/armv7m/imxrt/_init.S
@@ -327,26 +327,26 @@ hal_jmp:
 	cpsid if
 	isb
 
-	push {r0-r3}
-	pop {r4-r8} /* kargs has been passed on the stack */
-
-	cmp r6, #NULL
+	cmp r2, #NULL
 	bne hal_jmp_user
 
-	mov sp, r5
+	/* kargs has been passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	isb
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:
 	cpsie if
 	isb
@@ -356,16 +356,16 @@ hal_jmp:
 hal_jmp_user:
 	cpsid if
 	isb
-	msr msp, r5
+	msr msp, r1
 	isb
-	msr psp, r6
+	msr psp, r2
 	cpsie if
 	isb
-	mov r5, USERCONTROL
-	msr control, r5
+	mov r1, USERCONTROL
+	msr control, r1
 	isb
 	dmb
-	bx r4
+	bx r0
 
 .size hal_jmp, .-hal_jmp
 .ltorg

--- a/hal/armv7m/stm32/_init.S
+++ b/hal/armv7m/stm32/_init.S
@@ -294,26 +294,26 @@ hal_jmp:
 	cpsid if
 	isb
 
-	push {r0-r3}
-	pop {r4-r8} /* kargs has been passed on the stack */
-
-	cmp r6, #NULL
+	cmp r2, #NULL
 	bne hal_jmp_user
 
-	mov sp, r5
+	/* kargs has been passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	isb
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:
 	cpsie if
 	isb
@@ -323,16 +323,16 @@ hal_jmp:
 hal_jmp_user:
 	cpsid if
 	isb
-	msr msp, r5
+	msr msp, r1
 	isb
-	msr psp, r6
+	msr psp, r2
 	cpsie if
 	isb
-	mov r5, USERCONTROL
-	msr control, r5
+	mov r1, USERCONTROL
+	msr control, r1
 	isb
 	dmb
-	bx r4
+	bx r0
 
 .size hal_jmp, .-hal_jmp
 .ltorg

--- a/hal/armv8m/mcx/_init.S
+++ b/hal/armv8m/mcx/_init.S
@@ -288,26 +288,26 @@ hal_jmp:
 	cpsid if
 	isb
 
-	push {r0-r3}
-	pop {r4-r8} /* kargs has been passed on the stack */
-
-	cmp r6, #NULL
+	cmp r2, #NULL
 	bne hal_jmp_user
 
-	mov sp, r5
+	/* kargs has been passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	isb
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:
 	cpsie if
 	isb
@@ -317,16 +317,16 @@ hal_jmp:
 hal_jmp_user:
 	cpsid if
 	isb
-	msr msp, r5
+	msr msp, r1
 	isb
-	msr psp, r6
+	msr psp, r2
 	cpsie if
 	isb
-	mov r5, USERCONTROL
-	msr control, r5
+	mov r1, USERCONTROL
+	msr control, r1
 	isb
 	dmb
-	bx r4
+	bx r0
 
 .size hal_jmp, .-hal_jmp
 .ltorg

--- a/hal/armv8m/nrf/_init.S
+++ b/hal/armv8m/nrf/_init.S
@@ -292,26 +292,26 @@ hal_jmp:
 	cpsid if
 	isb
 
-	push {r0-r3}
-	pop {r4-r8} /* kargs has been passed on the stack */
-
-	cmp r6, #NULL
+	cmp r2, #NULL
 	bne hal_jmp_user
 
-	mov sp, r5
+	/* kargs has been passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	isb
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:
 	cpsie if
 	isb
@@ -321,16 +321,16 @@ hal_jmp:
 hal_jmp_user:
 	cpsid if
 	isb
-	msr msp, r5
+	msr msp, r1
 	isb
-	msr psp, r6
+	msr psp, r2
 	cpsie if
 	isb
-	mov r5, USERCONTROL
-	msr control, r5
+	mov r1, USERCONTROL
+	msr control, r1
 	isb
 	dmb
-	bx r4
+	bx r0
 
 .size hal_jmp, .-hal_jmp
 .ltorg

--- a/hal/armv8r/_armv8r.S
+++ b/hal/armv8r/_armv8r.S
@@ -167,37 +167,35 @@ _hal_cpuSetKernelStack:
 .type hal_jmp, %function
 hal_jmp:
 	cpsid if
-	mov r4, r0
-	mov r5, r1
-	mov r6, r2
-	mov r7, r3
-	ldr r8, [sp]
 	/* ustack != NULL means that the jump is to user */
-	cmp r6, #0
+	cmp r2, #0
 	bne 2f
-	mov sp, r5
+	/* kargs are passed on the stack */
+	ldr r5, [sp]
+	mov r4, r0
+	mov sp, r1
 	/* pass args */
-	subs r7, #1
+	subs r3, #1
 	bmi 1f
-	ldr r0, [r8]
-	subs r7, #1
+	ldr r0, [r5]
+	subs r3, #1
 	bmi 1f
-	ldr r1, [r8, #4]
-	subs r7, #1
+	ldr r1, [r5, #4]
+	subs r3, #1
 	bmi 1f
-	ldr r2, [r8, #8]
-	subs r7, #1
+	ldr r2, [r5, #8]
+	subs r3, #1
 	bmi 1f
-	ldr r3, [r8, #12]
+	ldr r3, [r5, #12]
 1:	cpsie if
 	blx r4
 	/* Handle userspace jump */
-2:	mov sp, r6
+2:	mov sp, r2
 	cps #MODE_IRQ
-	mov r5, #0x10
-	tst r4, #1
-	orrne r5, r5, #THUMB_STATE
-	push {r4, r5}
+	mov r1, #0x10
+	tst r0, #1
+	orrne r1, r1, #THUMB_STATE
+	push {r0, r1}
 	rfefd sp!
 .size hal_jmp, .-hal_jmp
 .ltorg


### PR DESCRIPTION
JIRA: RTOS-962

<!--- Provide a general summary of your changes in the Title above -->

## Description
In FDPIC format at process startup r7-r9 registers need to store specific value. Thus they must not be used in `hal_jmp`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
