### PR TITLE
ia32/timer: Fix HPET working for only 5 hours

### DIFF
--- a/hal/ia32/timer.c
+++ b/hal/ia32/timer.c
@@ -345,10 +345,8 @@ static inline void _hal_hpetSetCounter(u64 val)
 
 static time_t _hal_hpetGetUs(void)
 {
-	u64 ret = _hal_hpetGetCounter();
-	ret *= (u64)timer_common.hpetData.period;
-	ret /= 1000000000ULL;
-	return ret;
+	/* Convert period from femtoseconds to nanoseconds and scale the counter */
+	return (_hal_hpetGetCounter() * (u64)((timer_common.hpetData.period + (500 * 1000)) / (1000 * 1000))) / 1000;
 }
 
 


### PR DESCRIPTION
DONE: RTOS-973

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Should now work just fine for about 585 years

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
