### PR TITLE
ia32/exceptions: fix FPU exceptions

### DIFF
--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -156,8 +156,7 @@ sym:
 	call *%eax;\
 	addl $8, %esp;\
 	/* cpu_context_t */;\
-	movl %esp, %eax;\
-	addl $28, %eax;\
+	leal 28(%esp), %eax;\
 	pushl %eax;\
 	call hal_cpuSupervisorMode;\
 	addl $4, %esp;\

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -50,9 +50,7 @@ exception_pushContext:
 	pushl %ebp
 	pushl %esi
 	pushl %edi
-	movl %esp, %eax
-	subl $4, %eax
-	pushl %eax
+	pushl %esp
 
 	movl %dr7, %eax
 	pushl %eax

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -91,27 +91,24 @@ exception_popContext:
 	popl %edx
 	popl %ecx
 	popl %ebx
+	/* FPU context */
+	testl $CR0_TS_BIT, (12 + FPU_CONTEXT_SIZE)(%esp)
+	jz .Linterrupts_popFPU
+	movl %cr0, %eax
+	orl $CR0_TS_BIT, %eax
+	movl %eax, %cr0
+	jmp .Linterrupts_popFPUend
+.Linterrupts_popFPU:
+	clts
+	frstor 12(%esp)
+.Linterrupts_popFPUend:
 	popl %eax
 	popw %gs
 	popw %fs
 	popw %es
 	popw %ds
-	/* FPU context */
-	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
-	movl %eax, FPU_CONTEXT_SIZE(%esp)
-	movl %cr0, %eax
-	jz .exception_popFPU
-	orl $CR0_TS_BIT, %eax
-	movl %eax, %cr0
-	addl $FPU_CONTEXT_SIZE, %esp
-	popl %eax
-	iret
-	.exception_popFPU:
-	andl $~CR0_TS_BIT, %eax
-	mov %eax, %cr0
-	frstor (%esp)
-	addl $FPU_CONTEXT_SIZE, %esp
-	popl %eax
+	/* Skip over FPU context and cr0Bits. */
+	addl $FPU_CONTEXT_SIZE + 4, %esp
 	iret
 .size exception_popContext, .-exception_popContext
 

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -141,7 +141,6 @@ sym:
 
 /* Exception handling macro */
 #define EXCSTUB(exc)\
-	cli;\
 	call exception_pushContext;\
 	movl $SEL_KDATA, %eax;\
 	movw %ax, %ds;\

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -30,10 +30,10 @@ exception_pushContext:
 	/* Save return address for ret */
 	movl (%esp), %eax
 	movl %eax, -(4 * CTXPUSHL)(%esp)
+	subl $FPU_CONTEXT_SIZE - 4, %esp
 	/* Check TS flag in CR0 register */
 	movl %cr0, %eax
 	andl $CR0_TS_BIT, %eax
-	subl $FPU_CONTEXT_SIZE - 4, %esp
 	xchgl FPU_CONTEXT_SIZE(%esp), %eax
 	jnz .exception_pushRegisters
 	/* Save FPU context */

--- a/hal/ia32/_exceptions.S
+++ b/hal/ia32/_exceptions.S
@@ -37,7 +37,7 @@ exception_pushContext:
 	xchgl FPU_CONTEXT_SIZE(%esp), %eax
 	jnz .exception_pushRegisters
 	/* Save FPU context */
-	fsave (%esp)
+	fnsave (%esp)
 .exception_pushRegisters:
 	pushw %ds
 	pushw %es
@@ -129,7 +129,7 @@ exceptions_exc7_handler:
 	movl %ecx, 176(%eax)
 	/* Init FPU */
 	fninit
-	fsave 68(%eax) /* Set ctx->fpuContext */
+	fnsave 68(%eax) /* Set ctx->fpuContext */
 	ret
 
 .size exceptions_exc7_handler, .-exceptions_exc7_handler

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -57,13 +57,12 @@ hal_lockScheduler:
 .global interrupts_pushContext
 .align 4, 0x90
 interrupts_pushContext:
-	xchgl (%esp), %edx
-	movl %edx, -(4 * CTXPUSHL)(%esp)
-	popl %edx
-	/* Check TS flag in CR0 register */
-	pushl %eax
-	movl %cr0, %eax
+	/* Save return address. */
+	xchgl (%esp), %eax
+	movl %eax, -(4 * CTXPUSHL)(%esp)
 	subl $FPU_CONTEXT_SIZE, %esp
+	/* Check TS flag in CR0 register */
+	movl %cr0, %eax
 	andl $CR0_TS_BIT, %eax
 	xchgl FPU_CONTEXT_SIZE(%esp), %eax
 	jnz .Linterrupts_pushRegisters

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -68,7 +68,7 @@ interrupts_pushContext:
 	xchgl FPU_CONTEXT_SIZE(%esp), %eax
 	jnz .Linterrupts_pushRegisters
 	/* Save FPU context */
-	fsave (%esp)
+	fnsave (%esp)
 .Linterrupts_pushRegisters:
 	pushw %ds
 	pushw %es

--- a/hal/ia32/_interrupts.S
+++ b/hal/ia32/_interrupts.S
@@ -108,27 +108,24 @@ interrupts_popContext:
 	popl %edx
 	popl %ecx
 	popl %ebx
+	/* FPU context */
+	testl $CR0_TS_BIT, (12 + FPU_CONTEXT_SIZE)(%esp)
+	jz .Linterrupts_popFPU
+	movl %cr0, %eax
+	orl $CR0_TS_BIT, %eax
+	movl %eax, %cr0
+	jmp .Linterrupts_popFPUend
+.Linterrupts_popFPU:
+	clts
+	frstor 12(%esp)
+.Linterrupts_popFPUend:
 	popl %eax
 	popw %gs
 	popw %fs
 	popw %es
 	popw %ds
-	/* FPU context */
-	testl $CR0_TS_BIT, FPU_CONTEXT_SIZE(%esp)
-	movl %eax, FPU_CONTEXT_SIZE(%esp)
-	movl %cr0, %eax
-	jz .Linterrupts_popFPU
-	orl $CR0_TS_BIT, %eax
-	movl %eax, %cr0
-	addl $FPU_CONTEXT_SIZE, %esp
-	popl %eax
-	iret
-.Linterrupts_popFPU:
-	andl $~CR0_TS_BIT, %eax
-	mov %eax, %cr0
-	frstor (%esp)
-	addl $FPU_CONTEXT_SIZE, %esp
-	popl %eax
+	/* Skip over FPU context and cr0Bits. */
+	addl $FPU_CONTEXT_SIZE + 4, %esp
 	iret
 interrupts_popContextUnlocked:
 	popl %esp

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -493,7 +493,6 @@ void _hal_interruptsInit(void)
 	}
 
 	/* Set stub for syscall */
-/*	_interrupts_setIDTEntry(0x80, _interrupts_syscall, IGBITS_TRAP); */
 	_interrupts_setIDTEntry(SYSCALL_IRQ, _interrupts_syscall, flags | IGBITS_DPL3);
 	_interrupts_setIDTEntry(TLB_IRQ, _interrupts_TLBShootdown, flags);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to resolve situation with exceptions caused by FPU on Intel.

First commit resolves issue where recently instead of a triple fault on FPU error exception 16 got presented on the screen, due to wrong instruction setting flag.

Second, commit fixes saving context in exceptions.

Third commit changes `fsave` in context saving procedure to `fnsave` to prevent infinite recursion on FPU exception causing a triple fault. Due to this change exception 16 is reported correctly as exception 16 not as tripple fault. Thus, exception 16 is excepted to appear not Triple fault.

Fourth, commit fixes the root cause of the intermittent error. The `cr0Bits` were overwritten by eax during context restoration. We may restore twice from the same context in case of a signal pushed during `_threads_schedule`. Then we restore once from the context to go to the signal handler, after the signal is handled the context is modified to have original `eip` and `esp` and we longjump to it resulting in second restoration from the context with overwritten `cr0Bits`. This resulted in `TS` flag being removed without proper FPU initialization on next restore.  

The following commits are optimizations.

Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1012

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
