### PR TITLE
pmap: allow removing multiple pages in one call

### DIFF
--- a/hal/armv7m/pmap.c
+++ b/hal/armv7m/pmap.c
@@ -110,7 +110,7 @@ int pmap_enter(pmap_t *pmap, addr_t pa, void *vaddr, int attr, page_t *alloc)
 }
 
 
-int pmap_remove(pmap_t *pmap, void *vaddr)
+int pmap_remove(pmap_t *pmap, void *vstart, void *vend)
 {
 	return 0;
 }

--- a/hal/armv7r/pmap.c
+++ b/hal/armv7r/pmap.c
@@ -164,7 +164,7 @@ int pmap_enter(pmap_t *pmap, addr_t pa, void *vaddr, int attr, page_t *alloc)
 }
 
 
-int pmap_remove(pmap_t *pmap, void *vaddr)
+int pmap_remove(pmap_t *pmap, void *vstart, void *vend)
 {
 	return 0;
 }

--- a/hal/armv8m/pmap.c
+++ b/hal/armv8m/pmap.c
@@ -53,7 +53,7 @@ int pmap_enter(pmap_t *pmap, addr_t pa, void *vaddr, int attr, page_t *alloc)
 }
 
 
-int pmap_remove(pmap_t *pmap, void *vaddr)
+int pmap_remove(pmap_t *pmap, void *vstart, void *vend)
 {
 	return 0;
 }

--- a/hal/armv8r/pmap.c
+++ b/hal/armv8r/pmap.c
@@ -62,7 +62,7 @@ int pmap_enter(pmap_t *pmap, addr_t pa, void *vaddr, int attr, page_t *alloc)
 }
 
 
-int pmap_remove(pmap_t *pmap, void *vaddr)
+int pmap_remove(pmap_t *pmap, void *vstart, void *vend)
 {
 	return 0;
 }

--- a/hal/pmap.h
+++ b/hal/pmap.h
@@ -45,8 +45,8 @@ extern void pmap_switch(pmap_t *pmap);
 extern int pmap_enter(pmap_t *pmap, addr_t addr, void *vaddr, int attrs, page_t *alloc);
 
 
-/* Function removes mapping for given address */
-extern int pmap_remove(pmap_t *pmap, void *vaddr);
+/* Function removes mapping in range [vstart, vend) */
+extern int pmap_remove(pmap_t *pmap, void *vaddr, void *vend);
 
 
 extern addr_t pmap_resolve(pmap_t *pmap, void *vaddr);

--- a/hal/sparcv8leon/pmap-nommu.c
+++ b/hal/sparcv8leon/pmap-nommu.c
@@ -55,7 +55,7 @@ int pmap_enter(pmap_t *pmap, addr_t pa, void *vaddr, int attr, page_t *alloc)
 }
 
 
-int pmap_remove(pmap_t *pmap, void *vaddr)
+int pmap_remove(pmap_t *pmap, void *vstart, void *vend)
 {
 	return 0;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This change targets performance optimization on multicore targets. Previously, `pmap_remove` had to be called for each page to be removed, which resulted in overhead in TLB shootdowns - one for each page. With this change, a single TLB shootdown can be issued to remove multiple pages, which limits the number of IPIs sent to other cores.

The drawback is that `pmap_common` spinlock is held longer - for the duration of multiple page unmap.

The behaviour on `aarch64` remains unchanged - the flush is done in every loop.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `sparcv8leon-gr740-mini`, `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
