### PR TITLE
ioctl: serialize special ioctls outside of kernel

### DIFF
--- a/include/ioctl.h
+++ b/include/ioctl.h
@@ -19,6 +19,7 @@
 
 typedef struct {
 	unsigned long request;
+	unsigned long size;
 	char data[];
 } ioctl_in_t;
 

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1617,19 +1617,11 @@ int posix_fcntl(int fd, unsigned int cmd, char *ustack)
 #define IOC_OUT                      0x40000000
 #define IOC_IN                       0x80000000
 #define IOC_INOUT                    (IOC_IN | IOC_OUT)
-#define _IOC(inout, group, num, len) ((unsigned long)(inout | ((len & IOCPARM_MASK) << 16) | ((group) << 8) | (num)))
-
-#define SIOCGIFCONF _IOC(IOC_INOUT, 'S', 0x12, sizeof(struct ifconf))
-#define SIOCADDRT   _IOC(IOC_IN, 'S', 0x44, sizeof(struct rtentry))
-#define SIOCDELRT   _IOC(IOC_IN, 'S', 0x45, sizeof(struct rtentry))
 
 
-static void ioctl_pack(msg_t *msg, unsigned long request, void *data, oid_t *oid)
+static void ioctl_pack(msg_t *msg, unsigned long request, void *data, size_t size, oid_t *oid)
 {
-	size_t size = IOCPARM_LEN(request);
 	ioctl_in_t *ioctl = (ioctl_in_t *)msg->i.raw;
-	struct ifconf *ifc;
-	struct rtentry *rt;
 
 	hal_memcpy(&msg->oid, oid, sizeof(*oid));
 	msg->type = mtDevCtl;
@@ -1639,6 +1631,7 @@ static void ioctl_pack(msg_t *msg, unsigned long request, void *data, oid_t *oid
 	msg->o.size = 0;
 
 	ioctl->request = request;
+	ioctl->size = size;
 
 	if ((request & IOC_INOUT) != 0) {
 		if ((request & IOC_IN) != 0) {
@@ -1661,38 +1654,17 @@ static void ioctl_pack(msg_t *msg, unsigned long request, void *data, oid_t *oid
 		size = min(size, sizeof(void *));
 		hal_memcpy(ioctl->data, &data, size);
 	}
-
-	/* ioctl special case: arg is structure with pointer - has to be custom-packed into message */
-	if (request == SIOCGIFCONF) {
-		ifc = (struct ifconf *)data;
-		msg->o.data = ifc->ifc_buf;
-		msg->o.size = ifc->ifc_len;
-	}
-	else if ((request == SIOCADDRT) || (request == SIOCDELRT)) {
-		rt = (struct rtentry *)data;
-		if (rt->rt_dev != NULL) {
-			msg->o.data = rt->rt_dev;
-			msg->o.size = hal_strlen(rt->rt_dev) + 1;
-		}
-	}
 }
 
 
-int ioctl_processResponse(const msg_t *msg, unsigned long request, void *data)
+int ioctl_processResponse(const msg_t *msg, unsigned long request, void *data, size_t size)
 {
-	size_t size = IOCPARM_LEN(request);
 	int err;
-	struct ifconf *ifc;
 
 	err = msg->o.err;
 
 	if (((request & IOC_OUT) != 0) && (size <= sizeof(msg->o.raw))) {
 		hal_memcpy(data, msg->o.raw, size);
-	}
-
-	if (request == SIOCGIFCONF) { /* restore overridden userspace pointer */
-		ifc = (struct ifconf *)data;
-		ifc->ifc_buf = msg->o.data;
 	}
 
 	return err;
@@ -1707,6 +1679,7 @@ int posix_ioctl(int fildes, unsigned long request, char *ustack)
 	int err;
 	msg_t msg;
 	void *data = NULL;
+	size_t size = IOCPARM_LEN(request);
 
 	err = posix_getOpenFile(fildes, &f);
 	if (err == 0) {
@@ -1715,14 +1688,16 @@ int posix_ioctl(int fildes, unsigned long request, char *ustack)
 			default:
 				if (((request & IOC_INOUT) != 0) || (IOCPARM_LEN(request) > 0)) {
 					GETFROMSTACK(ustack, void *, data, 2);
+					GETFROMSTACK(ustack, size_t, size, 3);
 				}
 
-				ioctl_pack(&msg, request, data, &f->oid);
+				ioctl_pack(&msg, request, data, size, &f->oid);
 
 				err = proc_send(f->oid.port, &msg);
 				if (err == EOK) {
-					err = ioctl_processResponse(&msg, request, data);
+					err = ioctl_processResponse(&msg, request, data, size);
 				}
+				break;
 		}
 
 		posix_fileDeref(f);

--- a/posix/posix_private.h
+++ b/posix/posix_private.h
@@ -111,27 +111,6 @@ typedef struct _process_info_t {
 } process_info_t;
 
 
-/* SIOCGIFCONF ioctl special case: arg is structure with pointer */
-struct ifconf {
-	int ifc_len;   /* size of buffer */
-	char *ifc_buf; /* buffer address */
-};
-
-/* SIOADDRT and SIOCDELRT ioctls special case: arg is structure with pointer */
-struct rtentry
-{
-	struct sockaddr rt_dst;
-	struct sockaddr rt_gateway;
-	struct sockaddr rt_genmask;
-	short rt_flags;
-	short rt_metric;
-	char *rt_dev;
-	unsigned long rt_mss;
-	unsigned long rt_window;
-	unsigned short rt_irtt;
-};
-
-
 extern int posix_fileDeref(open_file_t *f);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For the kernel, the ioctl syscall data should be transparent, so special ioctls (e.g. ones containing a pointer in the input structure) should be serialized/deserialized in userspace. Additional size parameter is passed to allow for not-const sized ioctl payloads (e.g. for SIOCGIFCONF).
Related (serialization in userspace): https://github.com/phoenix-rtos/libphoenix/pull/414

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change):
    - change signature of ioctl syscall proxy function: `int sys_ioctl(int fildes, unsigned long request, void *val, size_t size)`
    This was done to pass the size of the size of the whole structure to the kernel without affecting the `request` variable, so we can still match on it in the device server handling the ioctl. This eliminates the need to handle special cases in the kernel: userspace serializes the ioctl, and device server unpacks it.
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt106x-evk`, `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
    - requires change to documentation regarding ioctl syscall (accepting 4th argument `size`)
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - TODO
- [ ] I will merge this PR by myself when appropriate.
