### PR TITLE
Fix -Wundef warnings with a few macros in imxrt hal

### DIFF
--- a/hal/armv7m/imxrt/10xx/console.c
+++ b/hal/armv7m/imxrt/10xx/console.c
@@ -30,6 +30,10 @@
 #endif
 #endif
 
+#ifndef RTT_ENABLED
+#define RTT_ENABLED 0
+#endif
+
 #ifndef RTT_CONSOLE_KERNEL
 #if RTT_ENABLED
 #define RTT_CONSOLE_KERNEL 0

--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -30,6 +30,10 @@
 #endif
 #endif
 
+#ifndef RTT_ENABLED
+#define RTT_ENABLED 0
+#endif
+
 #ifndef RTT_CONSOLE_KERNEL
 #if RTT_ENABLED
 #define RTT_CONSOLE_KERNEL 0

--- a/hal/armv7m/imxrt/117x/imxrt117x.c
+++ b/hal/armv7m/imxrt/117x/imxrt117x.c
@@ -29,14 +29,15 @@
 
 #define RTWDOG_UNLOCK_KEY  0xd928c520u
 #define RTWDOG_REFRESH_KEY 0xb480a602u
-#if WATCHDOG && !defined(WATCHDOG_TIMEOUT_MS)
+
+#if defined(WATCHDOG) && !defined(WATCHDOG_TIMEOUT_MS)
 #define WATCHDOG_TIMEOUT_MS (30000)
 #warning "WATCHDOG_TIMEOUT_MS not defined, defaulting to 30000 ms"
 #endif
 
 /* 1500 ms is the sum of the minimum sensible watchdog timeout (500 ms) and time for WICT interrupt
 to fire before watchdog times out (1000 ms) */
-#if WATCHDOG && (WATCHDOG_TIMEOUT_MS < 1500 || WATCHDOG_TIMEOUT_MS > 128000)
+#if defined(WATCHDOG) && (WATCHDOG_TIMEOUT_MS < 1500 || WATCHDOG_TIMEOUT_MS > 128000)
 #error "Watchdog timeout out of bounds!"
 #endif
 
@@ -788,7 +789,7 @@ void _imxrt_init(void)
 	*(imxrt_common.wdog1 + wdog_wcr) = tmp | (((WATCHDOG_TIMEOUT_MS - 500u) / 500u) << 8);
 	hal_cpuDataMemoryBarrier();
 #endif
-#if WATCHDOG
+#if defined(WATCHDOG)
 	/* Enable the watchdog */
 	*(imxrt_common.wdog1 + wdog_wcr) |= (1u << 2);
 	hal_cpuDataMemoryBarrier();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There are some useful warning flags, which are enabled in internal projects, like `-Wundef` and `-Wshadow`.

This commit allow phoenix-rtos-kernel to be build with `-Wundef` without warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To enable `-Wundef` flag in the future

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: Build on every target, not tested really.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
