### PR TITLE
Coredump: NOMMU, all targets

### DIFF
--- a/hal/aarch64/arch/exceptions.h
+++ b/hal/aarch64/arch/exceptions.h
@@ -50,10 +50,14 @@
 #define EXC_BKPT_AA32               0x38
 #define EXC_BRK_AA64                0x3c
 
-#define SIZE_CTXDUMP            1024 /* Size of dumped context string */
-#define SIZE_COREDUMP_GREGSET   272
-#define SIZE_COREDUMP_THREADAUX 548 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    0
+#define SIZE_CTXDUMP          1024 /* Size of dumped context string */
+#define SIZE_COREDUMP_GREGSET 272
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 548
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#endif
+#define SIZE_COREDUMP_GENAUX 0
 
 #define HAL_ELF_MACHINE 183 /* AARCH64 */
 

--- a/hal/aarch64/arch/exceptions.h
+++ b/hal/aarch64/arch/exceptions.h
@@ -50,8 +50,12 @@
 #define EXC_BKPT_AA32               0x38
 #define EXC_BRK_AA64                0x3c
 
-#define SIZE_CTXDUMP 1024 /* Size of dumped context string */
+#define SIZE_CTXDUMP            1024 /* Size of dumped context string */
+#define SIZE_COREDUMP_GREGSET   272
+#define SIZE_COREDUMP_THREADAUX 548 /* vfp context note */
+#define SIZE_COREDUMP_GENAUX    0
 
+#define HAL_ELF_MACHINE 183 /* AARCH64 */
 
 typedef struct _exc_context_t {
 	u64 esr;

--- a/hal/aarch64/exceptions.c
+++ b/hal/aarch64/exceptions.c
@@ -19,6 +19,7 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "include/mman.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 
@@ -180,6 +181,8 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/aarch64/exceptions.c
+++ b/hal/aarch64/exceptions.c
@@ -335,6 +335,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char FPREGSET_NAME[] = "CORE";
 	Elf64_Nhdr nhdr;
 	u32 tmp;
@@ -355,6 +356,7 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	tmp = ctx->fpcr;
 	hal_memcpy(buff, &tmp, sizeof(u32));
 	/* and 8 bytes of padding */
+#endif
 }
 
 

--- a/hal/armv7a/arch/exceptions.h
+++ b/hal/armv7a/arch/exceptions.h
@@ -23,10 +23,15 @@
 #define EXC_UNDEFINED 1
 #define EXC_PAGEFAULT 4
 
-#define SIZE_CTXDUMP            512 /* Size of dumped context */
-#define SIZE_COREDUMP_GREGSET   72
-#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+#define SIZE_CTXDUMP          512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 72
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 280
+#define SIZE_COREDUMP_GENAUX    36 /* auxv HWCAP note */
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#define SIZE_COREDUMP_GENAUX    0
+#endif
 
 #define HAL_ELF_MACHINE 40 /* ARM */
 

--- a/hal/armv7a/exceptions.c
+++ b/hal/armv7a/exceptions.c
@@ -274,6 +274,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char ARMVFP_NAME[] = "LINUX";
 	Elf32_Nhdr nhdr;
 	nhdr.n_namesz = sizeof(ARMVFP_NAME);
@@ -286,11 +287,13 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	hal_memcpy(buff, ctx->freg, sizeof(ctx->freg));
 	buff = (char *)buff + sizeof(ctx->freg);
 	hal_memcpy(buff, &ctx->fpsr, sizeof(ctx->fpsr));
+#endif
 }
 
 
 void hal_coredumpGeneralAux(void *buff)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char AUXV_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 	struct {
@@ -311,4 +314,5 @@ void hal_coredumpGeneralAux(void *buff)
 	auxv[1].a_type = AT_NULL;
 	auxv[1].a_val = 0;
 	hal_memcpy(buff, auxv, sizeof(auxv));
+#endif
 }

--- a/hal/armv7a/exceptions.c
+++ b/hal/armv7a/exceptions.c
@@ -286,15 +286,6 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 }
 
 
-#define COMPAT_HWCAP_VFP   (1 << 6)
-#define COMPAT_HWCAP_NEON  (1 << 12)
-#define COMPAT_HWCAP_VFPv3 (1 << 13)
-#define HWCAP_VFPv3        (COMPAT_HWCAP_VFP | COMPAT_HWCAP_NEON | COMPAT_HWCAP_VFPv3)
-
-#define AT_HWCAP 16
-#define AT_NULL  0
-
-
 void hal_coredumpGeneralAux(void *buff)
 {
 	static const char AUXV_NAME[] = "CORE";

--- a/hal/armv7a/exceptions.c
+++ b/hal/armv7a/exceptions.c
@@ -19,6 +19,7 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "include/mman.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 
@@ -111,6 +112,8 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/armv7m/arch/exceptions.h
+++ b/hal/armv7m/arch/exceptions.h
@@ -11,21 +11,6 @@
 #define SIZE_CTXDUMP 320 /* Size of dumped context */
 
 
-typedef struct _exc_context_t {
-	/* Saved by ISR */
-	u32 psp;
-	u32 r4;
-	u32 r5;
-	u32 r6;
-	u32 r7;
-	u32 r8;
-	u32 r9;
-	u32 r10;
-	u32 r11;
-	u32 excret;
-
-	/* Saved by hardware */
-	cpu_hwContext_t mspctx;
-} exc_context_t;
+typedef cpu_context_t exc_context_t;
 
 #endif

--- a/hal/armv7m/arch/exceptions.h
+++ b/hal/armv7m/arch/exceptions.h
@@ -8,8 +8,17 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP 320 /* Size of dumped context */
+#define SIZE_CTXDUMP          320 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 72
+#ifdef CPU_IMXRT
+#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
+#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#define SIZE_COREDUMP_GENAUX    0
+#endif
 
+#define HAL_ELF_MACHINE 40 /* ARM */
 
 typedef cpu_context_t exc_context_t;
 

--- a/hal/armv7m/arch/exceptions.h
+++ b/hal/armv7m/arch/exceptions.h
@@ -10,9 +10,9 @@
 
 #define SIZE_CTXDUMP          320 /* Size of dumped context */
 #define SIZE_COREDUMP_GREGSET 72
-#ifdef CPU_IMXRT
-#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+#if defined(CPU_IMXRT) && defined(PROC_COREDUMP_FPUCTX)
+#define SIZE_COREDUMP_THREADAUX 280
+#define SIZE_COREDUMP_GENAUX    36 /* auxv HWCAP note */
 #else
 #define SIZE_COREDUMP_THREADAUX 0
 #define SIZE_COREDUMP_GENAUX    0

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -45,7 +45,7 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	cpu_hwContext_t *hwctx;
 
 	/* If we came from userspace HW ctx in on psp stack */
-	if (ctx->excret == RET_THREAD_PSP) {
+	if (ctx->irq_ret == RET_THREAD_PSP) {
 		hwctx = (void *)ctx->psp;
 		msp -= sizeof(cpu_hwContext_t);
 		psp += sizeof(cpu_hwContext_t);
@@ -54,7 +54,7 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 #endif
 	}
 	else {
-		hwctx = &ctx->mspctx;
+		hwctx = &ctx->hwctx;
 #ifdef CPU_IMXRT
 		msp += SIZE_FPUCTX;
 #endif
@@ -89,7 +89,7 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 
 	i += hal_i2s("\npsp=", &buff[i], psp, 16, 1);
 	i += hal_i2s(" msp=", &buff[i], msp, 16, 1);
-	i += hal_i2s(" exr=", &buff[i], ctx->excret, 16, 1);
+	i += hal_i2s(" exr=", &buff[i], ctx->irq_ret, 16, 1);
 	i += hal_i2s(" bfa=", &buff[i], *(u32 *)0xe000ed38, 16, 1);
 
 	i += hal_i2s("\ncfs=", &buff[i], *(u32 *)0xe000ed28, 16, 1);
@@ -123,7 +123,7 @@ __attribute__((noreturn)) static void exceptions_fatal(unsigned int n, exc_conte
 void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 {
 	if ((hal_exception_common.handler != NULL) &&
-			((ctx->excret & (1 << 2)) != 0)) {
+			((ctx->irq_ret & (1 << 2)) != 0)) {
 
 		/* Need to enter the kernel by returning to the
 		 * thread mode. Otherwise we won't be able to
@@ -142,11 +142,11 @@ ptr_t hal_exceptionsPC(exc_context_t *ctx)
 {
 	cpu_hwContext_t *hwctx;
 
-	if (ctx->excret == RET_THREAD_PSP) {
+	if (ctx->irq_ret == RET_THREAD_PSP) {
 		hwctx = (void *)ctx->psp;
 	}
 	else {
-		hwctx = &ctx->mspctx;
+		hwctx = &ctx->hwctx;
 	}
 
 	return hwctx->pc;

--- a/hal/armv7m/imxrt/_init.S
+++ b/hal/armv7m/imxrt/_init.S
@@ -193,11 +193,16 @@ _syscallend:
 _exceptions_dispatch:
 	cpsid if
 
-	mrs r0, psp
-	stmdb sp!, {r0, r4-r11, lr}
-
+	vstmdb sp!, {s16-s31}
+	mov r0, sp
+	str r0, [sp, #-8]!
+	isb
 	mrs r0, ipsr
-	mov r1, sp
+	mrs r3, psp
+	sub r1, sp, #48
+	ldr r2, =0xe000ef38
+	ldr r2, [r2]
+	stmdb sp!, {r1-r11, lr}
 
 	b exceptions_dispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch

--- a/hal/armv7m/stm32/_init.S
+++ b/hal/armv7m/stm32/_init.S
@@ -172,11 +172,13 @@ _syscallend:
 _exceptions_dispatch:
 	cpsid if
 
-	mrs r0, psp
-	stmdb sp!, {r0, r4-r11, lr}
+	mov r0, sp
+	str r0, [sp, #-8]!
 
 	mrs r0, ipsr
-	mov r1, sp
+	mrs r3, psp
+	sub r1, sp, #48
+	stmdb sp!, {r1-r11, lr}
 
 	b exceptions_dispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch

--- a/hal/armv7r/arch/exceptions.h
+++ b/hal/armv7r/arch/exceptions.h
@@ -22,7 +22,12 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP 512 /* Size of dumped context */
+#define SIZE_CTXDUMP            512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET   72
+#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
+#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+
+#define HAL_ELF_MACHINE 40 /* ARM */
 
 typedef struct _exc_context_t {
 	u32 dfsr;

--- a/hal/armv7r/arch/exceptions.h
+++ b/hal/armv7r/arch/exceptions.h
@@ -22,10 +22,15 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP            512 /* Size of dumped context */
-#define SIZE_COREDUMP_GREGSET   72
-#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+#define SIZE_CTXDUMP          512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 72
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 280
+#define SIZE_COREDUMP_GENAUX    36 /* auxv HWCAP note */
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#define SIZE_COREDUMP_GENAUX    0
+#endif
 
 #define HAL_ELF_MACHINE 40 /* ARM */
 

--- a/hal/armv7r/exceptions.c
+++ b/hal/armv7r/exceptions.c
@@ -112,9 +112,10 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_cpuDisableInterrupts();
 
-	coredump_dump(n, ctx);
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/armv7r/exceptions.c
+++ b/hal/armv7r/exceptions.c
@@ -277,6 +277,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char ARMVFP_NAME[] = "LINUX";
 	Elf32_Nhdr nhdr;
 	nhdr.n_namesz = sizeof(ARMVFP_NAME);
@@ -290,11 +291,13 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	buff = (char *)buff + sizeof(ctx->freg);
 	buff = (char *)buff + sizeof(ctx->freg); /* padding to match full VFPv3 */
 	hal_memcpy(buff, &ctx->fpsr, sizeof(ctx->fpsr));
+#endif
 }
 
 
 void hal_coredumpGeneralAux(void *buff)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char AUXV_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 	struct {
@@ -315,4 +318,5 @@ void hal_coredumpGeneralAux(void *buff)
 	auxv[1].a_type = AT_NULL;
 	auxv[1].a_val = 0;
 	hal_memcpy(buff, auxv, sizeof(auxv));
+#endif
 }

--- a/hal/armv8m/arch/exceptions.h
+++ b/hal/armv8m/arch/exceptions.h
@@ -25,21 +25,6 @@
 #define SIZE_CTXDUMP 512 /* Size of dumped context */
 
 
-typedef struct _exc_context_t {
-	/* Saved by ISR */
-	u32 psp;
-	u32 r4;
-	u32 r5;
-	u32 r6;
-	u32 r7;
-	u32 r8;
-	u32 r9;
-	u32 r10;
-	u32 r11;
-	u32 excret;
-
-	/* Saved by hardware */
-	cpu_hwContext_t mspctx;
-} exc_context_t;
+typedef cpu_context_t exc_context_t;
 
 #endif

--- a/hal/armv8m/arch/exceptions.h
+++ b/hal/armv8m/arch/exceptions.h
@@ -22,8 +22,12 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP 512 /* Size of dumped context */
+#define SIZE_CTXDUMP            512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET   72
+#define SIZE_COREDUMP_THREADAUX 0
+#define SIZE_COREDUMP_GENAUX    0
 
+#define HAL_ELF_MACHINE 40 /* ARM */
 
 typedef cpu_context_t exc_context_t;
 

--- a/hal/armv8m/exceptions.c
+++ b/hal/armv8m/exceptions.c
@@ -34,13 +34,13 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 	cpu_hwContext_t *hwctx;
 
 	/* If we came from userspace HW ctx in on psp stack (according to EXC_RETURN) */
-	if ((ctx->excret & (1u << 2)) != 0) {
+	if ((ctx->irq_ret & (1u << 2)) != 0) {
 		hwctx = (void *)ctx->psp;
 		msp -= sizeof(cpu_hwContext_t);
 		psp += sizeof(cpu_hwContext_t);
 	}
 	else {
-		hwctx = &ctx->mspctx;
+		hwctx = &ctx->hwctx;
 	}
 
 	n &= 0xf;
@@ -72,7 +72,7 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 
 	i += hal_i2s("\npsp=", &buff[i], psp, 16, 1);
 	i += hal_i2s(" msp=", &buff[i], msp, 16, 1);
-	i += hal_i2s(" exr=", &buff[i], ctx->excret, 16, 1);
+	i += hal_i2s(" exr=", &buff[i], ctx->irq_ret, 16, 1);
 	i += hal_i2s(" bfa=", &buff[i], *(u32 *)0xe000ed38, 16, 1);
 
 	i += hal_i2s("\ncfs=", &buff[i], *(u32 *)0xe000ed28, 16, 1);
@@ -104,11 +104,11 @@ ptr_t hal_exceptionsPC(exc_context_t *ctx)
 {
 	cpu_hwContext_t *hwctx;
 
-	if ((ctx->excret & (1u << 2)) != 0) {
+	if ((ctx->irq_ret & (1u << 2)) != 0) {
 		hwctx = (void *)ctx->psp;
 	}
 	else {
-		hwctx = &ctx->mspctx;
+		hwctx = &ctx->hwctx;
 	}
 
 	return hwctx->pc;

--- a/hal/armv8m/exceptions.c
+++ b/hal/armv8m/exceptions.c
@@ -18,6 +18,7 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "config.h"
+#include "proc/coredump.h"
 
 
 const char *hal_exceptionMnemonic(int n)
@@ -94,6 +95,8 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/armv8m/mcx/_init.S
+++ b/hal/armv8m/mcx/_init.S
@@ -170,11 +170,13 @@ _exceptions_dispatch:
 	cpsid if
 	isb
 
-	mrs r0, psp
-	stmdb sp!, {r0, r4-r11, lr}
+	mov r0, sp
+	str r0, [sp, #-8]!
 
 	mrs r0, ipsr
-	mov r1, sp
+	mrs r3, psp
+	sub r1, sp, #48
+	stmdb sp!, {r1-r11, lr}
 
 	b exceptions_dispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch

--- a/hal/armv8m/nrf/_init.S
+++ b/hal/armv8m/nrf/_init.S
@@ -171,11 +171,13 @@ _exceptions_dispatch:
 	cpsid if
 	isb
 
-	mrs r0, psp
-	stmdb sp!, {r0, r4-r11, lr}
+	mov r0, sp
+	str r0, [sp, #-8]!
 
 	mrs r0, ipsr
-	mov r1, sp
+	mrs r3, psp
+	sub r1, sp, #48
+	stmdb sp!, {r1-r11, lr}
 
 	b exceptions_dispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch

--- a/hal/armv8r/arch/exceptions.h
+++ b/hal/armv8r/arch/exceptions.h
@@ -22,7 +22,12 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP 512 /* Size of dumped context */
+#define SIZE_CTXDUMP            512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET   72
+#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
+#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+
+#define HAL_ELF_MACHINE 40 /* ARM */
 
 typedef struct _exc_context_t {
 	u32 dfsr;

--- a/hal/armv8r/arch/exceptions.h
+++ b/hal/armv8r/arch/exceptions.h
@@ -22,10 +22,15 @@
 
 #define EXC_UNDEFINED 3
 
-#define SIZE_CTXDUMP            512 /* Size of dumped context */
-#define SIZE_COREDUMP_GREGSET   72
-#define SIZE_COREDUMP_THREADAUX 280 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    36  /* auxv HWCAP note */
+#define SIZE_CTXDUMP          512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 72
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 280
+#define SIZE_COREDUMP_GENAUX    36 /* auxv HWCAP note */
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#define SIZE_COREDUMP_GENAUX    0
+#endif
 
 #define HAL_ELF_MACHINE 40 /* ARM */
 

--- a/hal/armv8r/exceptions.c
+++ b/hal/armv8r/exceptions.c
@@ -277,6 +277,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char ARMVFP_NAME[] = "LINUX";
 	Elf32_Nhdr nhdr;
 	nhdr.n_namesz = sizeof(ARMVFP_NAME);
@@ -289,11 +290,13 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	hal_memcpy(buff, ctx->freg, sizeof(ctx->freg));
 	buff = (char *)buff + sizeof(ctx->freg);
 	hal_memcpy(buff, &ctx->fpsr, sizeof(ctx->fpsr));
+#endif
 }
 
 
 void hal_coredumpGeneralAux(void *buff)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char AUXV_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 	struct {
@@ -314,4 +317,5 @@ void hal_coredumpGeneralAux(void *buff)
 	auxv[1].a_type = AT_NULL;
 	auxv[1].a_val = 0;
 	hal_memcpy(buff, auxv, sizeof(auxv));
+#endif
 }

--- a/hal/armv8r/exceptions.c
+++ b/hal/armv8r/exceptions.c
@@ -19,6 +19,8 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "include/mman.h"
+#include "proc/coredump.h"
+#include "proc/elf.h"
 
 
 #define EXC_ASYNC_EXTERNAL      0x16
@@ -51,18 +53,23 @@ enum { exc_reset = 0, exc_undef, exc_svc, exc_prefetch, exc_abort };
 /* clang-format on */
 
 
-void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
+const char *hal_exceptionMnemonic(int n)
 {
 	static const char *const mnemonics[] = {
 		"0 #Reset", "1 #Undef", "2 #Syscall", "3 #Prefetch",
 		"4 #Abort", "5 #Reserved", "6 #FIRQ", "7 #IRQ"
 	};
+
+	return mnemonics[n & 0x7];
+}
+
+
+void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
+{
 	size_t i = 0;
 
-	n &= 0x7;
-
 	hal_strcpy(buff, "\nException: ");
-	hal_strcpy(buff += hal_strlen(buff), mnemonics[n]);
+	hal_strcpy(buff += hal_strlen(buff), hal_exceptionMnemonic(n));
 	hal_strcpy(buff += hal_strlen(buff), "\n");
 	buff += hal_strlen(buff);
 
@@ -107,6 +114,8 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();
@@ -240,4 +249,69 @@ void _hal_exceptionsInit(void)
 cpu_context_t *hal_excToCpuCtx(exc_context_t *ctx)
 {
 	return &ctx->cpuCtx;
+}
+
+
+void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
+{
+	u32 *regs = (u32 *)buff;
+	*(regs++) = ctx->r0;
+	*(regs++) = ctx->r1;
+	*(regs++) = ctx->r2;
+	*(regs++) = ctx->r3;
+	*(regs++) = ctx->r4;
+	*(regs++) = ctx->r5;
+	*(regs++) = ctx->r6;
+	*(regs++) = ctx->r7;
+	*(regs++) = ctx->r8;
+	*(regs++) = ctx->r9;
+	*(regs++) = ctx->r10;
+	*(regs++) = ctx->fp;
+	*(regs++) = ctx->ip;
+	*(regs++) = ctx->sp;
+	*(regs++) = ctx->lr;
+	*(regs++) = ctx->pc;
+	*(regs++) = ctx->psr;
+}
+
+
+void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
+{
+	static const char ARMVFP_NAME[] = "LINUX";
+	Elf32_Nhdr nhdr;
+	nhdr.n_namesz = sizeof(ARMVFP_NAME);
+	nhdr.n_descsz = sizeof(ctx->freg) + sizeof(ctx->fpsr);
+	nhdr.n_type = NT_ARM_VFP;
+	hal_memcpy(buff, &nhdr, sizeof(nhdr));
+	buff = (char *)buff + sizeof(nhdr);
+	hal_memcpy(buff, ARMVFP_NAME, sizeof(ARMVFP_NAME));
+	buff = (char *)buff + ((sizeof(ARMVFP_NAME) + 3) & ~3);
+	hal_memcpy(buff, ctx->freg, sizeof(ctx->freg));
+	buff = (char *)buff + sizeof(ctx->freg);
+	hal_memcpy(buff, &ctx->fpsr, sizeof(ctx->fpsr));
+}
+
+
+void hal_coredumpGeneralAux(void *buff)
+{
+	static const char AUXV_NAME[] = "CORE";
+	Elf32_Nhdr nhdr;
+	struct {
+		u32 a_type;
+		u32 a_val;
+	} auxv[2];
+
+	nhdr.n_namesz = sizeof(AUXV_NAME);
+	nhdr.n_descsz = sizeof(auxv);
+	nhdr.n_type = NT_AUXV;
+	hal_memcpy(buff, &nhdr, sizeof(nhdr));
+	buff = (char *)buff + sizeof(nhdr);
+	hal_memcpy(buff, AUXV_NAME, sizeof(AUXV_NAME));
+	buff = (char *)buff + ((sizeof(AUXV_NAME) + 3) & ~3);
+
+	auxv[0].a_type = AT_HWCAP;
+	auxv[0].a_val = HWCAP_VFPv3;
+	auxv[1].a_type = AT_NULL;
+	auxv[1].a_val = 0;
+	hal_memcpy(buff, auxv, sizeof(auxv));
 }

--- a/hal/ia32/arch/exceptions.h
+++ b/hal/ia32/arch/exceptions.h
@@ -24,10 +24,14 @@
 #define EXC_UNDEFINED 6
 #define EXC_PAGEFAULT 14
 
-#define SIZE_CTXDUMP            512 /* Size of dumped context */
-#define SIZE_COREDUMP_GREGSET   68
-#define SIZE_COREDUMP_THREADAUX 128 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    0
+#define SIZE_CTXDUMP          512 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 68
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 128
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#endif
+#define SIZE_COREDUMP_GENAUX 0
 
 #define HAL_ELF_MACHINE 3 /* IA32 */
 

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -23,6 +23,7 @@
 
 #include "include/mman.h"
 #include "include/errno.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 
@@ -197,6 +198,8 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -343,6 +343,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char FPREGSET_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 	nhdr.n_namesz = sizeof(FPREGSET_NAME);
@@ -353,6 +354,7 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	hal_memcpy(buff, FPREGSET_NAME, sizeof(FPREGSET_NAME));
 	buff = (char *)buff + ((sizeof(FPREGSET_NAME) + 3) & ~3);
 	hal_memcpy(buff, &ctx->fpuContext, sizeof(ctx->fpuContext));
+#endif
 }
 
 

--- a/hal/riscv64/arch/exceptions.h
+++ b/hal/riscv64/arch/exceptions.h
@@ -23,10 +23,14 @@
 #define EXC_UNDEFINED 2
 #define EXC_PAGEFAULT 127
 
-#define SIZE_CTXDUMP            1024 /* Size of dumped context */
-#define SIZE_COREDUMP_GREGSET   256
-#define SIZE_COREDUMP_THREADAUX 284 /* vfp context note */
-#define SIZE_COREDUMP_GENAUX    0
+#define SIZE_CTXDUMP          1024 /* Size of dumped context */
+#define SIZE_COREDUMP_GREGSET 256
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 284
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#endif
+#define SIZE_COREDUMP_GENAUX 0
 
 #define HAL_ELF_MACHINE 243 /* RISC-V 64-bit */
 

--- a/hal/riscv64/exceptions.c
+++ b/hal/riscv64/exceptions.c
@@ -20,6 +20,7 @@
 #include "hal/string.h"
 
 #include "include/mman.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 #define SIZE_EXCEPTIONS 16
@@ -124,6 +125,8 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/riscv64/exceptions.c
+++ b/hal/riscv64/exceptions.c
@@ -303,6 +303,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char FPREGSET_NAME[] = "CORE";
 	Elf64_Nhdr nhdr;
 	nhdr.n_namesz = sizeof(FPREGSET_NAME);
@@ -314,6 +315,7 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	buff = (char *)buff + ((sizeof(FPREGSET_NAME) + 3) & ~3);
 
 	hal_memcpy(buff, &ctx->fpCtx, sizeof(ctx->fpCtx));
+#endif
 }
 
 

--- a/hal/sparcv8leon/arch/exceptions.h
+++ b/hal/sparcv8leon/arch/exceptions.h
@@ -27,7 +27,12 @@
 #define EXC_PAGEFAULT_DATA 9
 #endif
 
-#define SIZE_CTXDUMP 550
+#define SIZE_CTXDUMP            550
+#define SIZE_COREDUMP_GREGSET   432
+#define SIZE_COREDUMP_THREADAUX 416 /* fp context note */
+#define SIZE_COREDUMP_GENAUX    0
+
+#define HAL_ELF_MACHINE 2 /* SPARC */
 
 #pragma pack(push, 1)
 

--- a/hal/sparcv8leon/arch/exceptions.h
+++ b/hal/sparcv8leon/arch/exceptions.h
@@ -27,10 +27,14 @@
 #define EXC_PAGEFAULT_DATA 9
 #endif
 
-#define SIZE_CTXDUMP            550
-#define SIZE_COREDUMP_GREGSET   432
-#define SIZE_COREDUMP_THREADAUX 416 /* fp context note */
-#define SIZE_COREDUMP_GENAUX    0
+#define SIZE_CTXDUMP          550
+#define SIZE_COREDUMP_GREGSET 432
+#ifdef PROC_COREDUMP_FPUCTX
+#define SIZE_COREDUMP_THREADAUX 416
+#else
+#define SIZE_COREDUMP_THREADAUX 0
+#endif
+#define SIZE_COREDUMP_GENAUX 0
 
 #define HAL_ELF_MACHINE 2 /* SPARC */
 

--- a/hal/sparcv8leon/exceptions-nommu.c
+++ b/hal/sparcv8leon/exceptions-nommu.c
@@ -19,6 +19,7 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "include/mman.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 
@@ -133,6 +134,8 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/hal/sparcv8leon/exceptions-nommu.c
+++ b/hal/sparcv8leon/exceptions-nommu.c
@@ -19,9 +19,10 @@
 #include "hal/console.h"
 #include "hal/string.h"
 #include "include/mman.h"
+#include "proc/elf.h"
 
 
-static const char *const hal_exceptionsType(int n)
+const char *const hal_exceptionMnemonic(int n)
 {
 	switch (n) {
 		case 0x0:
@@ -174,4 +175,87 @@ void _hal_exceptionsInit(void)
 cpu_context_t *hal_excToCpuCtx(exc_context_t *ctx)
 {
 	return &ctx->cpuCtx;
+}
+
+
+void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
+{
+	cpu_winContext_t *win = (cpu_winContext_t *)ctx->sp;
+
+	/* GDB support for sparc linux is limited. It's better to imitate Solaris.
+	   This padding is for Solaris prstatus structures */
+	hal_memset(buff, 0, 284);
+	buff = (char *)buff + 284;
+
+	u32 *regs = (u32 *)buff;
+	*(regs++) = 0;
+	*(regs++) = ctx->g1;
+	*(regs++) = ctx->g2;
+	*(regs++) = ctx->g3;
+	*(regs++) = ctx->g4;
+	*(regs++) = ctx->g5;
+	*(regs++) = ctx->g6;
+	*(regs++) = ctx->g7;
+	*(regs++) = ctx->o0;
+	*(regs++) = ctx->o1;
+	*(regs++) = ctx->o2;
+	*(regs++) = ctx->o3;
+	*(regs++) = ctx->o4;
+	*(regs++) = ctx->o5;
+	*(regs++) = ctx->sp;
+	*(regs++) = ctx->o7;
+
+	*(regs++) = win->l0;
+	*(regs++) = win->l1;
+	*(regs++) = win->l2;
+	*(regs++) = win->l3;
+	*(regs++) = win->l4;
+	*(regs++) = win->l5;
+	*(regs++) = win->l6;
+	*(regs++) = win->l7;
+	*(regs++) = win->i0;
+	*(regs++) = win->i1;
+	*(regs++) = win->i2;
+	*(regs++) = win->i3;
+	*(regs++) = win->i4;
+	*(regs++) = win->i5;
+	*(regs++) = win->fp;
+	*(regs++) = win->i7;
+
+	*(regs++) = ctx->psr;
+	*(regs++) = ctx->pc;
+	*(regs++) = ctx->npc;
+	*(regs++) = ctx->y;
+	*(regs++) = 0;
+	/* last byte of 152 Solaris's regset will be padded by elf_prstatus.pr_fpvalid */
+}
+
+
+void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
+{
+	static const char FPREGSET_NAME[] = "CORE";
+	Elf32_Nhdr nhdr;
+
+	nhdr.n_namesz = sizeof(FPREGSET_NAME);
+	nhdr.n_descsz = 99 * sizeof(u32);
+	nhdr.n_type = NT_FPREGSET;
+	hal_memcpy(buff, &nhdr, sizeof(nhdr));
+	buff = (char *)buff + sizeof(nhdr);
+	hal_memcpy(buff, FPREGSET_NAME, sizeof(FPREGSET_NAME));
+	buff = (char *)buff + ((sizeof(FPREGSET_NAME) + 3) & ~3);
+
+	hal_memcpy(buff, &ctx->fpCtx, 32 * sizeof(u32));
+	buff = (char *)buff + 32 * sizeof(u32);
+	*(u32 *)buff = 0;
+	buff = (char *)buff + sizeof(u32);
+	*(u32 *)buff = ctx->fpCtx.fsr;
+	buff = (char *)buff + sizeof(u32);
+	*(u32 *)buff = (u32)((1 << 8) | (8 << 16));
+	buff = (char *)buff + sizeof(u32);
+	hal_memset(buff, 0, 64 * sizeof(u32));
+}
+
+
+void hal_coredumpGeneralAux(void *buff)
+{
 }

--- a/hal/sparcv8leon/exceptions-nommu.c
+++ b/hal/sparcv8leon/exceptions-nommu.c
@@ -236,6 +236,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char FPREGSET_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 
@@ -256,6 +257,7 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	*(u32 *)buff = (u32)((1 << 8) | (8 << 16));
 	buff = (char *)buff + sizeof(u32);
 	hal_memset(buff, 0, 64 * sizeof(u32));
+#endif
 }
 
 

--- a/hal/sparcv8leon/exceptions.c
+++ b/hal/sparcv8leon/exceptions.c
@@ -280,6 +280,7 @@ void hal_coredumpGRegset(void *buff, cpu_context_t *ctx)
 
 void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 {
+#ifdef PROC_COREDUMP_FPUCTX
 	static const char FPREGSET_NAME[] = "CORE";
 	Elf32_Nhdr nhdr;
 
@@ -300,6 +301,7 @@ void hal_coredumpThreadAux(void *buff, cpu_context_t *ctx)
 	*(u32 *)buff = (u32)((1 << 8) | (8 << 16));
 	buff = (char *)buff + sizeof(u32);
 	hal_memset(buff, 0, 64 * sizeof(u32));
+#endif
 }
 
 

--- a/hal/sparcv8leon/exceptions.c
+++ b/hal/sparcv8leon/exceptions.c
@@ -20,6 +20,7 @@
 #include "hal/string.h"
 #include "hal/sparcv8leon/srmmu.h"
 #include "include/mman.h"
+#include "proc/coredump.h"
 #include "proc/elf.h"
 
 
@@ -141,6 +142,8 @@ __attribute__((noreturn)) static void exceptions_defaultHandler(unsigned int n, 
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
+
+	coredump_dump(n, ctx);
 
 #ifdef NDEBUG
 	hal_cpuReboot();

--- a/proc/coredump.c
+++ b/proc/coredump.c
@@ -361,6 +361,9 @@ static size_t coredump_findStack(void **currentSP, void *ustack, process_t *proc
 		*currentSP = e->vaddr;
 	}
 	stackSize = (char *)e->vaddr + e->size - (char *)*currentSP;
+#ifdef PROC_COREDUMP_MAX_STACK_BYTES
+	stackSize = min(stackSize, PROC_COREDUMP_MAX_STACK_BYTES);
+#endif
 
 	proc_lockClear(&process->mapp->lock);
 

--- a/proc/elf.h
+++ b/proc/elf.h
@@ -107,6 +107,16 @@ typedef u64 Elf64_Xword;
 #define NT_AUXV     6
 #define NT_ARM_VFP  0x400
 
+#define AT_HWCAP 16
+#define AT_NULL  0
+
+#define COMPAT_HWCAP_VFP      (1 << 6)
+#define COMPAT_HWCAP_NEON     (1 << 12)
+#define COMPAT_HWCAP_VFPv3    (1 << 13)
+#define COMPAT_HWCAP_VFPv3D16 (1 << 14)
+#define HWCAP_VFPv3           (COMPAT_HWCAP_VFP | COMPAT_HWCAP_NEON | COMPAT_HWCAP_VFPv3)
+#define HWCAP_VFPv3D16        (COMPAT_HWCAP_VFP | COMPAT_HWCAP_VFPv3 | COMPAT_HWCAP_VFPv3D16)
+
 #pragma pack(push, 1)
 
 typedef struct {

--- a/proc/process.h
+++ b/proc/process.h
@@ -26,6 +26,15 @@
 
 #define MAX_PID MAX_ID
 
+#ifdef NOMMU
+typedef struct _reloc {
+	void *vbase;
+	void *pbase;
+	size_t size;
+	unsigned int misalign;
+} reloc_t;
+#endif
+
 typedef struct _process_t {
 	lock_t lock;
 
@@ -38,6 +47,11 @@ typedef struct _process_t {
 	char **argv;
 	char **envp;
 	idnode_t idlinkage;
+
+#ifdef NOMMU
+	reloc_t reloc[8];
+	int relocsz;
+#endif
 
 	vm_map_t map;
 	map_entry_t *entries;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Save reloc table on NOMMU targets and include virtual <-> load memory address mapping in coredump.
Implement coredumping on all targets.
NOTE: sparcv8leon target requires patching GDB to load correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[RTOS-1043](https://jira.phoenix-rtos.com/browse/RTOS-1043) Research core dump and backtrace techniques
[RTOS-1049](https://jira.phoenix-rtos.com/browse/RTOS-1049) Implement core dump on MMU targets
[RTOS-1049](https://jira.phoenix-rtos.com/browse/RTOS-1062) Implement core dump on NO MMU targets

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
