### PR TITLE
process_destroy: destroy resources before memory map

### DIFF
--- a/proc/process.c
+++ b/proc/process.c
@@ -84,6 +84,9 @@ static void process_destroy(process_t *p)
 
 	posix_died(process_getPid(p), p->exit);
 
+	/* Destroy resources (especially rtInth) before changing map to prevent race */
+	proc_resourcesDestroy(p);
+
 	proc_changeMap(p, NULL, NULL, NULL);
 
 	if (mapp != NULL) {
@@ -94,7 +97,6 @@ static void process_destroy(process_t *p)
 		vm_mapDestroy(p, imapp);
 	}
 
-	proc_resourcesDestroy(p);
 	proc_portsDestroy(p);
 	proc_lockDone(&p->lock);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

`process_destroy` first destroyed the memory map and then the resources. If an interrupt arrived after `proc_changeMap` to `NULL`, but before handler deregistration, the handler was called with `pmapp = NULL`. This lead to page fault in the handler. Moving the resource destruction before the memory map destruction fixes the issue.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-gr765-vcu118`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
