### PR TITLE
hal/armv8m add mpu support

### DIFF
--- a/hal/armv8m/arch/pmap.h
+++ b/hal/armv8m/arch/pmap.h
@@ -52,9 +52,9 @@ typedef struct _page_t {
 
 
 typedef struct _pmap_t {
-	u32 mpr;
 	void *start;
 	void *end;
+	u32 regions;
 } pmap_t;
 
 #endif

--- a/hal/armv8m/halsyspage.h
+++ b/hal/armv8m/halsyspage.h
@@ -1,0 +1,24 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * System information page (prepared by kernel loader)
+ *
+ * Copyright 2022, 2024, 2025 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _HAL_SYSPAGE_H_
+#define _HAL_SYSPAGE_H_
+
+#include "hal/types.h"
+#include "config.h"
+
+extern syspage_t *syspage;
+
+#endif

--- a/hal/armv8m/pmap.c
+++ b/hal/armv8m/pmap.c
@@ -5,8 +5,8 @@
  *
  * pmap - machine dependent part of VM subsystem (ARMv8)
  *
- * Copyright 2017, 2020-2022 Phoenix Systems
- * Author: Pawel Pisarczyk, Aleksander Kaminski, Hubert Buczynski, Damian Loewnau
+ * Copyright 2017, 2020-2022, 2025 Phoenix Systems
+ * Author: Pawel Pisarczyk, Aleksander Kaminski, Hubert Buczynski, Damian Loewnau, Krzysztof Radzewicz
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -14,18 +14,52 @@
  */
 
 #include "hal/pmap.h"
+#include "config.h"
+#include "syspage.h"
+#include "halsyspage.h"
 #include <arch/cpu.h>
+#include <arch/spinlock.h>
+
+
+#define MPU_BASE ((void *)0xe000ed90)
+
+
+enum {
+	mpu_type,
+	mpu_ctrl,
+	mpu_rnr,
+	mpu_rbar,
+	mpu_rlar,
+	mpu_rbar_a1,
+	mpu_rlar_a1,
+	mpu_rbar_a2,
+	mpu_rlar_a2,
+	mpu_rbar_a3,
+	mpu_rlar_a3,
+	mpu_mair0 = 0xC,
+	mpu_mair1
+};
+
 
 /* Linker symbols */
 extern unsigned int _end;
 extern unsigned int __bss_start;
 
+
 extern void *_init_vectors;
+
+
+static struct {
+	volatile u32 *mpu;
+	unsigned int kernelCodeRegion;
+	spinlock_t lock;
+} pmap_common;
 
 
 /* Function creates empty page table */
 int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
 {
+	pmap->regions = pmap_common.kernelCodeRegion;
 	return 0;
 }
 
@@ -36,14 +70,57 @@ addr_t pmap_destroy(pmap_t *pmap, int *i)
 }
 
 
+static unsigned int pmap_map2region(unsigned int map)
+{
+	int i;
+	unsigned int mask = 0;
+
+	for (i = 0; i < sizeof(syspage->hs.mpu.map) / sizeof(*syspage->hs.mpu.map); ++i) {
+		if (map == syspage->hs.mpu.map[i]) {
+			mask |= (1 << i);
+		}
+	}
+
+	return mask;
+}
+
+
 int pmap_addMap(pmap_t *pmap, unsigned int map)
 {
+	unsigned int rmask = pmap_map2region(map);
+	if (rmask == 0) {
+		return -1;
+	}
+
+	pmap->regions |= rmask;
+
 	return 0;
 }
 
 
 void pmap_switch(pmap_t *pmap)
 {
+	unsigned int i, cnt = syspage->hs.mpu.allocCnt;
+	spinlock_ctx_t sc;
+
+	if (pmap != NULL) {
+		hal_spinlockSet(&pmap_common.lock, &sc);
+		for (i = 0; i < cnt; ++i) {
+			/* Select region */
+			*(pmap_common.mpu + mpu_rnr) = i;
+			hal_cpuDataMemoryBarrier();
+
+			/* Enable/disable region according to the mask */
+			if ((pmap->regions & (1 << i)) != 0) {
+				*(pmap_common.mpu + mpu_rlar) |= 1u;
+			}
+			else {
+				*(pmap_common.mpu + mpu_rlar) &= ~1u;
+			}
+			hal_cpuDataMemoryBarrier();
+		}
+		hal_spinlockClear(&pmap_common.lock, &sc);
+	}
 }
 
 
@@ -67,7 +144,18 @@ addr_t pmap_resolve(pmap_t *pmap, void *vaddr)
 
 int pmap_isAllowed(pmap_t *pmap, const void *vaddr, size_t size)
 {
-	return 1;
+	const syspage_map_t *map = syspage_mapAddrResolve((addr_t)vaddr);
+	unsigned int rmask;
+	addr_t addr_end = (addr_t)vaddr + size;
+	/* Check for potential arithmetic overflow. `addr_end` is allowed to be 0,
+	 * as it represents the top of memory. */
+	int addr_overflowed = (addr_end != 0) && (addr_end < (addr_t)vaddr);
+	if ((map == NULL) || (addr_end > map->end) || addr_overflowed) {
+		return 0;
+	}
+	rmask = pmap_map2region(map->id);
+
+	return ((pmap->regions & rmask) != 0) ? 1 : 0;
 }
 
 
@@ -105,6 +193,10 @@ int pmap_segment(unsigned int i, void **vaddr, size_t *size, int *prot, void **t
 
 void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 {
+	const syspage_map_t *ikmap;
+	unsigned int ikregion;
+	unsigned int i, cnt = syspage->hs.mpu.allocCnt;
+
 	(*vstart) = (void *)(((ptr_t)_init_vectors + 7) & ~7u);
 	(*vend) = (*((char **)vstart)) + SIZE_PAGE;
 
@@ -112,4 +204,60 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 
 	/* Initial size of kernel map */
 	pmap->end = (void *)((addr_t)&__bss_start + 32 * 1024);
+
+	/* Configure MPU */
+	pmap_common.mpu = MPU_BASE;
+
+	/* Disable MPU just in case */
+	*(pmap_common.mpu + mpu_ctrl) &= ~1;
+	hal_cpuDataMemoryBarrier();
+
+	/* Activate background region for privileged code - if an address does not belong to any enabled region,
+	 * the default memory map will be used to determine memory attributes. */
+	*(pmap_common.mpu + mpu_ctrl) |= (1 << 2);
+	hal_cpuDataMemoryBarrier();
+
+	for (i = 0; i < cnt; ++i) {
+		/* Select MPU region to configure */
+		*(pmap_common.mpu + mpu_rnr) = i;
+		hal_cpuDataMemoryBarrier();
+
+		*(pmap_common.mpu + mpu_rbar) = syspage->hs.mpu.table[i].rbar;
+		hal_cpuDataMemoryBarrier();
+
+		/* Disable regions for now */
+		*(pmap_common.mpu + mpu_rlar) = syspage->hs.mpu.table[i].rlar & ~1u;
+		hal_cpuDataMemoryBarrier();
+	}
+
+	/* Enable MPU */
+	*(pmap_common.mpu + mpu_ctrl) |= 1;
+	hal_cpuDataMemoryBarrier();
+
+	/* FIXME HACK
+	 * allow all programs to execute (and read) kernel code map.
+	 * Needed because of hal_jmp, syscalls handler and signals handler.
+	 * In these functions we need to switch to the user mode when still
+	 * executing kernel code. This will cause memory management fault
+	 * if the application does not have access to the kernel instruction
+	 * map. Possible fix - place return to the user code in the separate
+	 * region and allow this region instead. */
+
+	/* Find kernel code region */
+	/* parasoft-suppress-next-line MISRAC2012-RULE_11_1 "We need address of this function in numeric type" */
+	ikmap = syspage_mapAddrResolve((addr_t)_pmap_init);
+	if (ikmap != NULL) {
+		ikregion = pmap_map2region(ikmap->id);
+	}
+
+	if ((ikmap == NULL) || (ikregion == 0)) {
+		hal_consolePrint(ATTR_BOLD, "pmap: Kernel code map not found or has no regions. Bad system config\n");
+		for (;;) {
+			hal_cpuHalt();
+		}
+	}
+
+	pmap_common.kernelCodeRegion = ikregion;
+
+	hal_spinlockCreate(&pmap_common.lock, "pmap");
 }


### PR DESCRIPTION
JIRA: RTOS-1068

<!--- Provide a general summary of your changes in the Title above -->
Modifying hal/armv8m/pmap.c file to include mpu programming

## Motivation and Context
Part of [RTOS-1068] Port to STM32N6 processor

## Types of changes
- Programming mpu and enabling it
- Also enabling MemManage fault in SHCSR reg

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
Built the system on stm32n6-nucleo and ran it

## Special treatment
As mentioned in plo/kradzewicz/armv8m_mpu:
There are two potential issues with this implementation that should be discussed:
1. pmap api from kernel always gives priviliged mode processor rw access to all mem regions. Unpriviliged processor gets either r only or rw. However armv8m doesn't support that fully, you cannot set priviliged rw and unpriviliged r. Instead giving unpriviliged mode full rw in that case.
2. hal_syspage_t doesn't include fields for mpu_mair register that allow setting memory attributes. Currently they are programmed in plo (hal/armv8m/mpu.c)