### PR TITLE
syscalls: implement getThreadCpuTime syscall

### DIFF
--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -126,7 +126,10 @@
 	ID(sys_mprotect) \
 	\
 	ID(sys_statvfs) \
-	ID(sys_uname)
+	ID(sys_uname) \
+	\
+	ID(getThreadCpuTime)
+
 /* parasoft-end-suppress MISRAC2012-RULE_20_7-a */
 /* clang-format on */
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -2222,6 +2222,12 @@ int proc_threadsOther(thread_t *t)
 }
 
 
+time_t threads_getCpuTime(thread_t *t)
+{
+	return t->cpuTime;
+}
+
+
 int _threads_init(vm_map_t *kmap, vm_object_t *kernel)
 {
 	unsigned int i;

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -177,6 +177,9 @@ time_t proc_uptime(void);
 void proc_gettime(time_t *raw, time_t *offs);
 
 
+extern time_t threads_getCpuTime(thread_t *t);
+
+
 int proc_settime(time_t offs);
 
 

--- a/syscalls.c
+++ b/syscalls.c
@@ -372,6 +372,12 @@ int syscalls_priority(u8 *ustack)
 }
 
 
+time_t syscalls_getThreadCpuTime(void *ustack)
+{
+	return threads_getCpuTime(proc_current());
+}
+
+
 /*
  * System state info
  */


### PR DESCRIPTION
Implement syscall based on declared getCpuTime function

JIRA: RTOS-1088

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add syscall allowing us to get information on how much time did actual thread spend on CPU.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See: https://github.com/phoenix-rtos/libphoenix/pull/431
Added due to performance reasons, existing syscalls (threadsinfo) give info on first n threads on threads tree which would make us search for our thread on the list

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic-qemu, armv7a9-zynq7000-qemu)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work 
    - https://github.com/phoenix-rtos/libphoenix/pull/431
- [ ] I will merge this PR by myself when appropriate.
