### PR TITLE
process: terminate threads on exec

### DIFF
--- a/proc/threads.h
+++ b/proc/threads.h
@@ -139,7 +139,7 @@ extern int proc_threadJoin(unsigned int id);
 extern void proc_threadDestroy(thread_t *t);
 
 
-extern void proc_threadsDestroy(thread_t **threads);
+extern void proc_threadsDestroy(thread_t **threads, const thread_t *except);
 
 
 extern int proc_waitpid(int pid, int *stat, int options);
@@ -152,6 +152,9 @@ extern void proc_changeMap(process_t *proc, vm_map_t *map, vm_map_t *imap, pmap_
 
 
 extern int proc_threadsList(int n, threadinfo_t *info);
+
+
+extern int proc_threadsOther(thread_t *t);
 
 
 extern void proc_zombie(process_t *proc);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Fixes a bug with multithreaded process call an exec leaving other threads running with new process memory map.

Fixes phoenix-rtos/phoenix-rtos-project#1393

JIRA: RTOS-1111

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug with kernel panic was detected when added alarm thread spawning in forked process to keep alarm working.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: phoenix-rtos/phoenix-rtos-tests#420
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
