### PR TITLE
lib/rb: Fix rbtree assuming no NULL at the leaf

### DIFF
--- a/lib/rb.c
+++ b/lib/rb.c
@@ -147,7 +147,7 @@ static void lib_rbRemoveBalance(rbtree_t *tree, rbnode_t *parent, rbnode_t *node
 
 	while (x != tree->root && x->color == RB_BLACK) {
 		if (x == x->parent->left || (x == &nil && x->parent->left == NULL)) {
-			w = x->parent->right;
+			w = (x->parent->right == NULL) ? &nil : x->parent->right;
 
 			if (w->color == RB_RED) {
 				w->color = RB_BLACK;
@@ -176,7 +176,7 @@ static void lib_rbRemoveBalance(rbtree_t *tree, rbnode_t *parent, rbnode_t *node
 			}
 		}
 		else {
-			w = x->parent->left;
+			w = (x->parent->left == NULL) ? &nil : x->parent->left;
 
 			if (w->color == RB_RED) {
 				w->color = RB_BLACK;


### PR DESCRIPTION
Fix remants of an old implementation that used global nil node instead of NULLs.

JIRA: RTOS-1127

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
