### PR TITLE
hal/stm32n6: fix mistake in cache operations

### DIFF
--- a/hal/armv8m/stm32/n6/stm32n6.c
+++ b/hal/armv8m/stm32/n6/stm32n6.c
@@ -180,19 +180,19 @@ int hal_platformctl(void *ptr)
 			break;
 		case pctl_cleanInvalDCache:
 			if (data->action == pctl_set) {
-				_hal_scsDCacheCleanInvalAddr(data->cleanInvalDCache.addr, data->cleanInvalDCache.sz);
+				_hal_scsDCacheCleanInvalAddr(data->opDCache.addr, data->opDCache.sz);
 				ret = EOK;
 			}
 			break;
 		case pctl_cleanDCache:
 			if (data->action == pctl_set) {
-				_hal_scsDCacheCleanAddr(data->cleanInvalDCache.addr, data->cleanInvalDCache.sz);
+				_hal_scsDCacheCleanAddr(data->opDCache.addr, data->opDCache.sz);
 				ret = EOK;
 			}
 			break;
 		case pctl_invalDCache:
 			if (data->action == pctl_set) {
-				_hal_scsDCacheInvalAddr(data->cleanInvalDCache.addr, data->cleanInvalDCache.sz);
+				_hal_scsDCacheInvalAddr(data->opDCache.addr, data->opDCache.sz);
 				ret = EOK;
 			}
 			break;


### PR DESCRIPTION
I renamed a member in `platformctl_t` but forgot to rename its uses...

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
