### PR TITLE
hal/arm: pmap_switch full MPU reconfiguration

### DIFF
--- a/hal/aarch64/pmap.c
+++ b/hal/aarch64/pmap.c
@@ -273,7 +273,7 @@ static void _pmap_cacheOpAfterChange(descr_t newEntry, ptr_t vaddr, unsigned int
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	pmap->ttl1 = vaddr;
 	pmap->addr = p->addr;

--- a/hal/armv7a/pmap.c
+++ b/hal/armv7a/pmap.c
@@ -187,7 +187,7 @@ static void _pmap_asidDealloc(pmap_t *pmap)
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	pmap->pdir = vaddr;
 	pmap->addr = p->addr;

--- a/hal/armv7m/arch/pmap.h
+++ b/hal/armv7m/arch/pmap.h
@@ -17,6 +17,7 @@
 #define _PH_HAL_PMAP_ARMV7M_H_
 
 #include "hal/types.h"
+#include "syspage.h"
 
 /* Architecture dependent page attributes - used for mapping */
 #define PGHD_PRESENT    0x01U
@@ -55,7 +56,7 @@ typedef struct _page_t {
 typedef struct _pmap_t {
 	void *start;
 	void *end;
-	u32 regions;
+	const hal_syspage_prog_t *hal;
 } pmap_t;
 
 #endif

--- a/hal/armv7r/arch/pmap.h
+++ b/hal/armv7r/arch/pmap.h
@@ -17,6 +17,7 @@
 #define _PH_HAL_PMAP_ARMV7R_H_
 
 #include "hal/types.h"
+#include "syspage.h"
 
 #define PGHD_PRESENT    0x01U
 #define PGHD_USER       0x04U
@@ -54,7 +55,7 @@ typedef struct _page_t {
 typedef struct _pmap_t {
 	void *start;
 	void *end;
-	u32 regions;
+	const hal_syspage_prog_t *hal;
 } pmap_t;
 
 #endif

--- a/hal/armv8m/arch/pmap.h
+++ b/hal/armv8m/arch/pmap.h
@@ -17,6 +17,7 @@
 #define _PH_HAL_PMAP_ARMV8M_H_
 
 #include "hal/types.h"
+#include "syspage.h"
 
 #define PGHD_PRESENT    0x01U
 #define PGHD_USER       0x04U
@@ -54,7 +55,7 @@ typedef struct _page_t {
 typedef struct _pmap_t {
 	void *start;
 	void *end;
-	u32 regions;
+	const hal_syspage_prog_t *hal;
 } pmap_t;
 
 #endif

--- a/hal/armv8m/mcx/n94x/config.h
+++ b/hal/armv8m/mcx/n94x/config.h
@@ -20,7 +20,9 @@
 
 #ifndef __ASSEMBLY__
 
+#include "hal/types.h"
 #include "include/arch/armv8m/mcx/syspage.h"
+#include "include/syspage.h"
 #include "mcxn94x.h"
 
 #define HAL_NAME_PLATFORM "MCX N94x "

--- a/hal/armv8m/pmap.c
+++ b/hal/armv8m/pmap.c
@@ -15,6 +15,7 @@
 
 #include "hal/pmap.h"
 #include "config.h"
+#include "lib/lib.h"
 #include "syspage.h"
 #include "halsyspage.h"
 #include <arch/cpu.h>
@@ -43,16 +44,21 @@ extern void *_init_vectors;
 
 static struct {
 	volatile u32 *mpu;
-	unsigned int kernelCodeRegion;
 	spinlock_t lock;
 	int mpu_enabled;
+	unsigned int last_mpu_count;
 } pmap_common;
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
-	pmap->regions = pmap_common.kernelCodeRegion;
+	if (prog != NULL) {
+		pmap->hal = &prog->hal;
+	}
+	else {
+		pmap->hal = NULL;
+	}
 	return 0;
 }
 
@@ -63,67 +69,46 @@ addr_t pmap_destroy(pmap_t *pmap, unsigned int *i)
 }
 
 
-static unsigned int pmap_map2region(unsigned int map)
-{
-	unsigned int i;
-	unsigned int mask = 0;
-
-	if (pmap_common.mpu_enabled == 0) {
-		return 1;
-	}
-
-	for (i = 0; i < sizeof(syspage->hs.mpu.map) / sizeof(*syspage->hs.mpu.map); ++i) {
-		if (map == syspage->hs.mpu.map[i]) {
-			mask |= (1UL << i);
-		}
-	}
-
-	return mask;
-}
-
-
-int pmap_addMap(pmap_t *pmap, unsigned int map)
-{
-	unsigned int rmask;
-	if (pmap_common.mpu_enabled == 0) {
-		return 0;
-	}
-
-	rmask = pmap_map2region(map);
-	if (rmask == 0U) {
-		return -1;
-	}
-
-	pmap->regions |= rmask;
-
-	return 0;
-}
-
-
+/* parasoft-suppress-next-line MISRAC2012-DIR_4_3-a "Optimized context switching code" */
 void pmap_switch(pmap_t *pmap)
 {
-	unsigned int i, cnt = syspage->hs.mpu.allocCnt;
+	static const volatile u32 *RBAR_ADDR = MPU_BASE + mpu_rbar;
+	unsigned int allocCnt;
 	spinlock_ctx_t sc;
+	unsigned int i;
+	const u32 *tableCurrent;
+
 	if (pmap_common.mpu_enabled == 0) {
 		return;
 	}
 
-	if (pmap != NULL) {
+	if (pmap != NULL && pmap->hal != NULL) {
 		hal_spinlockSet(&pmap_common.lock, &sc);
-		for (i = 0; i < cnt; ++i) {
-			/* Select region */
-			*(pmap_common.mpu + mpu_rnr) = i;
-			hal_cpuDataMemoryBarrier();
 
-			/* Enable/disable region according to the mask */
-			if ((pmap->regions & (1UL << i)) != 0UL) {
-				*(pmap_common.mpu + mpu_rlar) |= 1U;
-			}
-			else {
-				*(pmap_common.mpu + mpu_rlar) &= ~1U;
-			}
-			hal_cpuDataMemoryBarrier();
+		allocCnt = pmap->hal->mpu.allocCnt;
+		tableCurrent = &pmap->hal->mpu.table[0].rbar;
+
+		/* Disable MPU */
+		hal_cpuDataMemoryBarrier();
+		*(pmap_common.mpu + mpu_ctrl) &= ~1U;
+
+		for (i = 0; i < max(allocCnt, pmap_common.last_mpu_count); i += 4U) {
+			*(pmap_common.mpu + mpu_rnr) = i;
+			__asm__ volatile(
+					"ldmia %[tableCurrent]!, {r3-r8, r10, r11} \n\t" /* Load 4 regions (rbar/rlar pairs) from table, update table pointer */
+					"stmia %[mpu_rbar], {r3-r8, r10, r11}      \n\t" /* Write 4 regions via RBAR/RLAR and aliases */
+					: [tableCurrent] "+r"(tableCurrent)
+					: [mpu_rbar] "r"(RBAR_ADDR)
+					: "r3", "r4", "r5", "r6", "r7", "r8", "r10", "r11");
 		}
+
+		/* Enable MPU */
+		*(pmap_common.mpu + mpu_ctrl) |= 1U;
+		hal_cpuDataSyncBarrier();
+		hal_cpuInstrBarrier();
+
+		pmap_common.last_mpu_count = allocCnt;
+
 		hal_spinlockClear(&pmap_common.lock, &sc);
 	}
 }
@@ -149,8 +134,8 @@ addr_t pmap_resolve(pmap_t *pmap, void *vaddr)
 
 int pmap_isAllowed(pmap_t *pmap, const void *vaddr, size_t size)
 {
+	unsigned int i;
 	const syspage_map_t *map = syspage_mapAddrResolve((addr_t)vaddr);
-	unsigned int rmask;
 	addr_t addr_end = (addr_t)vaddr + size;
 	/* Check for potential arithmetic overflow. `addr_end` is allowed to be 0,
 	 * as it represents the top of memory. */
@@ -162,9 +147,17 @@ int pmap_isAllowed(pmap_t *pmap, const void *vaddr, size_t size)
 		return 1;
 	}
 
-	rmask = pmap_map2region(map->id);
+	if (pmap->hal == NULL) {
+		/* Kernel pmap has access to everything */
+		return 1;
+	}
 
-	return ((pmap->regions & rmask) != 0U) ? 1 : 0;
+	for (i = 0; i < pmap->hal->mpu.allocCnt; ++i) {
+		if (pmap->hal->mpu.map[i] == map->id) {
+			return 1;
+		}
+	}
+	return 0;
 }
 
 
@@ -202,9 +195,10 @@ int pmap_segment(unsigned int i, void **vaddr, size_t *size, vm_prot_t *prot, vo
 
 void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 {
-	const syspage_map_t *ikmap;
-	unsigned int ikregion;
-	unsigned int i, cnt = syspage->hs.mpu.allocCnt;
+	unsigned int cnt = min(
+			(syspage->hs.mpuType >> 8U) & 0xffU,
+			sizeof(pmap->hal->mpu.table) / sizeof(pmap->hal->mpu.table[0]));
+	unsigned int i;
 
 	(*vstart) = (void *)(((ptr_t)_init_vectors + 7U) & ~7U);
 	(*vend) = (*((char **)vstart)) + SIZE_PAGE;
@@ -214,8 +208,8 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	/* Initial size of kernel map */
 	pmap->end = (void *)((addr_t)&__bss_start + 32U * 1024U);
 
-	/* Enable all regions for kernel */
-	pmap->regions = (1UL << cnt) - 1UL;
+	pmap->hal = NULL;
+	pmap_common.last_mpu_count = cnt;
 
 	/* Configure MPU */
 	pmap_common.mpu = MPU_BASE;
@@ -223,7 +217,6 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	hal_spinlockCreate(&pmap_common.lock, "pmap");
 	if (cnt == 0U) {
 		pmap_common.mpu_enabled = 0;
-		pmap_common.kernelCodeRegion = 0;
 		return;
 	}
 
@@ -241,42 +234,12 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	for (i = 0; i < cnt; ++i) {
 		/* Select MPU region to configure */
 		*(pmap_common.mpu + mpu_rnr) = i;
-		hal_cpuDataMemoryBarrier();
 
-		*(pmap_common.mpu + mpu_rbar) = syspage->hs.mpu.table[i].rbar;
-		hal_cpuDataMemoryBarrier();
-
-		/* Disable regions for now */
-		*(pmap_common.mpu + mpu_rlar) = syspage->hs.mpu.table[i].rlar & ~1U;
-		hal_cpuDataMemoryBarrier();
+		/* Disable all regions for now */
+		*(pmap_common.mpu + mpu_rlar) = 0U;
 	}
 
 	/* Enable MPU */
 	*(pmap_common.mpu + mpu_ctrl) |= 1U;
-	hal_cpuDataMemoryBarrier();
-
-	/* FIXME HACK
-	 * allow all programs to execute (and read) kernel code map.
-	 * Needed because of hal_jmp, syscalls handler and signals handler.
-	 * In these functions we need to switch to the user mode when still
-	 * executing kernel code. This will cause memory management fault
-	 * if the application does not have access to the kernel instruction
-	 * map. Possible fix - place return to the user code in the separate
-	 * region and allow this region instead. */
-
-	/* Find kernel code region */
-	/* parasoft-suppress-next-line MISRAC2012-RULE_11_1 "We need address of this function in numeric type" */
-	ikmap = syspage_mapAddrResolve((addr_t)_pmap_init);
-	if (ikmap != NULL) {
-		ikregion = pmap_map2region(ikmap->id);
-	}
-
-	if ((ikmap == NULL) || (ikregion == 0U)) {
-		hal_consolePrint(ATTR_BOLD, "pmap: Kernel code map not found or has no regions. Bad system config\n");
-		for (;;) {
-			hal_cpuHalt();
-		}
-	}
-
-	pmap_common.kernelCodeRegion = ikregion;
+	hal_cpuDataSyncBarrier();
 }

--- a/hal/armv8r/pmap.c
+++ b/hal/armv8r/pmap.c
@@ -29,7 +29,7 @@ u8 _init_stack[NUM_CPUS][SIZE_INITIAL_KSTACK] __attribute__((aligned(8)));
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	return 0;
 }

--- a/hal/ia32/pmap.c
+++ b/hal/ia32/pmap.c
@@ -39,7 +39,7 @@ static struct {
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	u32 i, pages;
 	pmap->pdir = vaddr;

--- a/hal/pmap.h
+++ b/hal/pmap.h
@@ -20,6 +20,7 @@
 #include "lib/attrs.h"
 
 #include <arch/pmap.h>
+#include "syspage.h"
 
 
 #ifndef NOMMU
@@ -31,14 +32,12 @@ MAYBE_UNUSED static inline int pmap_belongs(pmap_t *pmap, void *addr)
 
 #else
 
-int pmap_addMap(pmap_t *pmap, unsigned int map);
-
 int pmap_isAllowed(pmap_t *pmap, const void *vaddr, size_t size);
 
 #endif
 
 
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr);
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr);
 
 
 addr_t pmap_destroy(pmap_t *pmap, unsigned int *i);

--- a/hal/riscv64/pmap.c
+++ b/hal/riscv64/pmap.c
@@ -101,7 +101,7 @@ addr_t pmap_getKernelStart(void)
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	unsigned int i, pages;
 	ptr_t va;

--- a/hal/sparcv8leon/pmap-nommu.c
+++ b/hal/sparcv8leon/pmap-nommu.c
@@ -28,19 +28,13 @@ extern void *_init_stack;
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	return 0;
 }
 
 
 addr_t pmap_destroy(pmap_t *pmap, unsigned int *i)
-{
-	return 0;
-}
-
-
-int pmap_addMap(pmap_t *pmap, unsigned int map)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/pmap.c
+++ b/hal/sparcv8leon/pmap.c
@@ -198,7 +198,7 @@ static void _pmap_contextDealloc(pmap_t *pmap)
 
 
 /* Function creates empty page table */
-int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
+int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, const syspage_prog_t *prog, void *vaddr)
 {
 	pmap->pdir1 = vaddr;
 	pmap->context = CONTEXT_INVALID;

--- a/include/arch/aarch64/zynqmp/syspage.h
+++ b/include/arch/aarch64/zynqmp/syspage.h
@@ -21,4 +21,7 @@ typedef struct {
 } __attribute__((packed)) hal_syspage_t;
 
 
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/arch/armv7a/imx6ull/syspage.h
+++ b/include/arch/armv7a/imx6ull/syspage.h
@@ -21,4 +21,8 @@ typedef struct {
 	int dummy;
 } __attribute__((packed)) hal_syspage_t;
 
+
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/arch/armv7a/zynq7000/syspage.h
+++ b/include/arch/armv7a/zynq7000/syspage.h
@@ -21,4 +21,7 @@ typedef struct {
 } __attribute__((packed)) hal_syspage_t;
 
 
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/arch/armv7m/imxrt/syspage.h
+++ b/include/arch/armv7m/imxrt/syspage.h
@@ -20,14 +20,18 @@
 
 typedef struct {
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rasr;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
-	} __attribute__((packed)) mpu;
+		unsigned int allocCnt;
+	} mpu;
+} hal_syspage_prog_t;
+
+
+typedef struct {
+	unsigned int mpuType;
 	unsigned int bootReason;
 } __attribute__((packed)) hal_syspage_t;
 

--- a/include/arch/armv7m/stm32/syspage.h
+++ b/include/arch/armv7m/stm32/syspage.h
@@ -20,14 +20,18 @@
 
 typedef struct {
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rasr;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
-	} __attribute__((packed)) mpu;
+		unsigned int allocCnt;
+	} mpu;
+} hal_syspage_prog_t;
+
+
+typedef struct {
+	unsigned int mpuType;
 	unsigned int bootReason;
 } __attribute__((packed)) hal_syspage_t;
 

--- a/include/arch/armv7r/tda4vm/syspage.h
+++ b/include/arch/armv7r/tda4vm/syspage.h
@@ -18,16 +18,20 @@
 
 
 typedef struct {
-	int resetReason;
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rasr;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
+		unsigned int allocCnt;
 	} __attribute__((packed)) mpu;
+} __attribute__((packed)) hal_syspage_prog_t;
+
+
+typedef struct {
+	int resetReason;
+	unsigned int mpuType;
 } __attribute__((packed)) hal_syspage_t;
 
 

--- a/include/arch/armv7r/zynqmp/syspage.h
+++ b/include/arch/armv7r/zynqmp/syspage.h
@@ -18,16 +18,20 @@
 
 
 typedef struct {
-	int resetReason;
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rasr;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
+		unsigned int allocCnt;
 	} __attribute__((packed)) mpu;
+} __attribute__((packed)) hal_syspage_prog_t;
+
+
+typedef struct {
+	int resetReason;
+	unsigned int mpuType;
 } __attribute__((packed)) hal_syspage_t;
 
 

--- a/include/arch/armv8m/mcx/syspage.h
+++ b/include/arch/armv8m/mcx/syspage.h
@@ -20,14 +20,18 @@
 
 typedef struct {
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rlar;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
-	} __attribute__((packed)) mpu;
+		unsigned int allocCnt;
+	} mpu;
+} hal_syspage_prog_t;
+
+
+typedef struct {
+	unsigned int mpuType;
 } __attribute__((packed)) hal_syspage_t;
 
 #endif

--- a/include/arch/armv8m/nrf/syspage.h
+++ b/include/arch/armv8m/nrf/syspage.h
@@ -20,14 +20,18 @@
 
 typedef struct {
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
 		struct {
 			unsigned int rbar;
 			unsigned int rlar;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
-	} __attribute__((packed)) mpu;
+		unsigned int allocCnt;
+	} mpu;
+} hal_syspage_prog_t;
+
+
+typedef struct {
+	unsigned int mpuType;
 } __attribute__((packed)) hal_syspage_t;
 
 #endif

--- a/include/arch/armv8m/stm32/syspage.h
+++ b/include/arch/armv8m/stm32/syspage.h
@@ -20,15 +20,18 @@
 
 typedef struct {
 	struct {
-		unsigned int type;
-		unsigned int allocCnt;
-		unsigned int mair[2];
 		struct {
 			unsigned int rbar;
 			unsigned int rlar;
 		} table[16] __attribute__((aligned(8)));
 		unsigned int map[16]; /* ((unsigned int)-1) = map is not assigned */
-	} __attribute__((packed)) mpu;
+		unsigned int allocCnt;
+	} mpu;
+} hal_syspage_prog_t;
+
+
+typedef struct {
+	unsigned int mpuType;
 	unsigned int bootReason;
 } __attribute__((packed)) hal_syspage_t;
 

--- a/include/arch/armv8r/mps3an536/syspage.h
+++ b/include/arch/armv8r/mps3an536/syspage.h
@@ -22,4 +22,7 @@ typedef struct {
 } __attribute__((packed)) hal_syspage_t;
 
 
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/arch/ia32/syspage.h
+++ b/include/arch/ia32/syspage.h
@@ -57,5 +57,7 @@ typedef struct {
 	} __attribute__((packed)) graphmode; /* Graphics mode info */
 } __attribute__((packed)) hal_syspage_t;
 
+typedef struct {
+} hal_syspage_prog_t;
 
 #endif

--- a/include/arch/riscv64/syspage.h
+++ b/include/arch/riscv64/syspage.h
@@ -21,4 +21,8 @@ typedef struct {
 	unsigned int boothartId;
 } __attribute__((packed)) hal_syspage_t;
 
+
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/arch/sparcv8leon/syspage.h
+++ b/include/arch/sparcv8leon/syspage.h
@@ -21,4 +21,8 @@ typedef struct {
 	int dummy;
 } __attribute__((packed)) hal_syspage_t;
 
+
+typedef struct {
+} hal_syspage_prog_t;
+
 #endif

--- a/include/syspage.h
+++ b/include/syspage.h
@@ -48,7 +48,9 @@ typedef struct _syspage_prog_t {
 
 	size_t dmapSz;
 	unsigned char *dmaps;
-} __attribute__((packed)) syspage_prog_t;
+
+	hal_syspage_prog_t hal;
+} syspage_prog_t;
 
 
 typedef struct _syspage_map_t {

--- a/vm/map.c
+++ b/vm/map.c
@@ -1009,9 +1009,9 @@ int vm_mapCreate(vm_map_t *map, void *start, void *stop)
 		return -ENOMEM;
 	}
 
-	(void)pmap_create(&map->pmap, &map_common.kmap->pmap, map->pmap.pmapp, map->pmap.pmapv);
+	(void)pmap_create(&map->pmap, &map_common.kmap->pmap, map->pmap.pmapp, NULL, map->pmap.pmapv);
 #else
-	(void)pmap_create(&map->pmap, &map_common.kmap->pmap, NULL, NULL);
+	(void)pmap_create(&map->pmap, &map_common.kmap->pmap, NULL, NULL, NULL);
 #endif
 
 	(void)proc_lockInit(&map->lock, &proc_lockAttrDefault, "map.map");


### PR DESCRIPTION
This commit introduces full MPU regions reconfiguration on context switch, allowing for more flexibile configuration of memory maps on MPU targets. Performed tests show no memory coherence problems and minor improvements in pmap_switch performance. According to ARM documentation, cache maintenance is not required, as long as memory maps are not overlapping, and that assumption is already present in Phoenix-RTOS.

Changes include
* additional hal_syspage_prog_t structure, initialized in loader, containing program configuration of MPU regions in form of ready-to-copy register values
* pmap_t structure contain pointer to above structure instead of regions bitmask
* pmap_switch disables MPU and performs full reconfiguration, optimized with LDMIA/STMIA assembly operations
* handling of process's kernel-code access is moved to loader
* hal/pmap.c functions update to the new pmap_t structure

JIRA: RTOS-1149

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change enables users to define more memory maps, allowing more flexible configuration and better spatial separation of processes, which is first stage of development of partitioning mechanism.
The unchanged restriction is that memory maps are disjoint and have fixed attributes, which allows for a quick context switch without costly cache maintenance operations (hardware tests shown it works slightly faster than before).
Note: Correctness of this change is based on observaiton, that there is no documented influence on memory attributes (caching, shareability, accessibility) by disabled MPU region. Thanks to that, if manual cache maintenance wasn't required before, it shouldn't be required here either.
The only moment of doubt, is during pmap_switch itself, when MPU is disabled and accesses to kernel memory are made to configure it. This is similar to situation in previous implementation, when switching between processes without access to kernel data map. This should not cause problems as long as kernel map has the same attributes as in the system address map (which is also used as MPU "background" map for priviliged accesses).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m33-mcxn94x-frdm, armv7m7-imxrt117x-evk

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- phoenix-rtos/plo#407
- [ ] I will merge this PR by myself when appropriate.
