### PR TITLE
posix: make posix access modes enum fields

### DIFF
--- a/include/posix-fcntl.h
+++ b/include/posix-fcntl.h
@@ -19,9 +19,18 @@
 
 #define FD_CLOEXEC 0x1U
 
-#define O_RDONLY   0x00001U
-#define O_WRONLY   0x00002U
-#define O_RDWR     0x00004U
+/*
+ * These are enum values, not a bitfields, because POSIX requires access modes
+ * to be mutually exclusive. It does not specify the format or values for those
+ * definitions, however, most POSIX conformant operating systems treat those
+ * values as enumerations.
+ */
+#define O_RDONLY 0x00000U
+#define O_WRONLY 0x00001U
+#define O_RDWR   0x00002U
+
+#define O_ACCMODE 0x00003U
+
 #define O_APPEND   0x00008U
 #define O_CREAT    0x00100U
 #define O_TRUNC    0x00200U
@@ -33,8 +42,6 @@
 #define O_CLOEXEC  0x04000U
 #define O_RSYNC    0x08000U
 #define O_DSYNC    0x10000U
-
-#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
 
 /* clang-format off */
 

--- a/log/log.c
+++ b/log/log.c
@@ -336,11 +336,11 @@ void log_msgHandler(msg_t *msg, oid_t oid, msg_rid_t rid)
 
 	switch (msg->type) {
 		case mtOpen:
-			if ((msg->i.openclose.flags & O_WRONLY) != 0U) {
-				msg->o.err = EOK;
+			if ((msg->i.openclose.flags & O_ACCMODE) == O_RDONLY) {
+				msg->o.err = log_readerAdd(msg->pid, msg->i.openclose.flags & O_NONBLOCK);
 			}
 			else {
-				msg->o.err = log_readerAdd(msg->pid, msg->i.openclose.flags & O_NONBLOCK);
+				msg->o.err = EOK;
 			}
 			break;
 		case mtRead:

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -731,7 +731,7 @@ ssize_t posix_read(int fildes, void *buf, size_t nbyte, off_t offset)
 		return err;
 	}
 
-	if ((f->status & O_WRONLY) != 0U) {
+	if ((f->status & O_ACCMODE) == O_WRONLY) {
 		(void)posix_fileDeref(f);
 		return -EBADF;
 	}
@@ -783,7 +783,7 @@ ssize_t posix_write(int fildes, void *buf, size_t nbyte, off_t offset)
 		return err;
 	}
 
-	if ((f->status & O_RDONLY) != 0U) {
+	if ((f->status & O_ACCMODE) == O_RDONLY) {
 		(void)posix_fileDeref(f);
 		return -EBADF;
 	}
@@ -978,7 +978,7 @@ int posix_pipe(int fildes[2])
 		return (res == -EINTR) ? res : -ENOSYS;
 	}
 
-	res = proc_create(pipesrv.port, pxBufferedPipe, O_RDONLY | O_WRONLY, oid, pipesrv, NULL, &oid);
+	res = proc_create(pipesrv.port, pxBufferedPipe, O_RDWR, oid, pipesrv, NULL, &oid);
 	if (res < 0) {
 		pinfo_put(p);
 		return res;
@@ -1275,11 +1275,11 @@ int posix_ftruncate(int fildes, off_t length)
 
 	err = posix_getOpenFile(fildes, &f);
 	if (err >= 0) {
-		if ((f->status & O_RDONLY) == 0U) {
-			err = posix_truncate(&f->oid, length);
+		if ((f->status & O_ACCMODE) == O_RDONLY) {
+			err = -EBADF;
 		}
 		else {
-			err = -EBADF;
+			err = posix_truncate(&f->oid, length);
 		}
 		(void)posix_fileDeref(f);
 	}
@@ -1543,7 +1543,7 @@ static int posix_fcntlSetFl(int fd, unsigned int val)
 	open_file_t *f;
 	int err;
 	/* Creation and access mode flags shall be ignored */
-	unsigned int ignorefl = O_CREAT | O_EXCL | O_NOCTTY | O_TRUNC | O_RDONLY | O_RDWR | O_WRONLY;
+	unsigned int ignorefl = O_CREAT | O_EXCL | O_NOCTTY | O_TRUNC | O_ACCMODE;
 
 	err = posix_getOpenFile(fd, &f);
 	if (err == 0) {


### PR DESCRIPTION
Most POSIX conformant/compilant systems treat O_ACCMODE fields as enum fields, not bitfields, which carries on to their usage semantics, making it impossible to repesent states when modes are not mutually exclusive.

JIRA: RTOS-1088

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: `ia32-generic-qemu`, `armv7a9-zynq7000-qemu`.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
