### PR TITLE
posix: do not link semaphore to filesystem in posixsrv

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1058,12 +1058,6 @@ int posix_mkfifo(const char *pathname, mode_t mode)
 		return ret;
 	}
 
-	/* link pipe in posix server */
-	ret = proc_link(oid, oid, pathname);
-	if (ret < 0) {
-		return ret;
-	}
-
 	/* create pipe in filesystem */
 	ret = posix_create(pathname, 2 /* otDev */, mode | S_IFIFO, oid, &file);
 	if (ret < 0) {


### PR DESCRIPTION
POSIX compilant pipes should release claimed resources after the pipe is closed on both ends. Maintaining an extra link refcount requires an unlink to happen to release the resources.

Fixes github.com/https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1230

JIRA: RTOS-1282

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/phoenix-rtos-posixsrv/pull/29
- [X] I will merge this PR by myself when appropriate.
