### PR TITLE
hal/armv8m: allow killing processes on exceptions

### DIFF
--- a/hal/armv8m/exceptions.c
+++ b/hal/armv8m/exceptions.c
@@ -41,6 +41,14 @@ enum exceptions {
 };
 
 
+static struct {
+	excHandlerFn_t defaultHandler;
+} hal_exceptions_common;
+
+
+extern void hal_exceptionJump(unsigned int n, exc_context_t *ctx, void (*handler)(unsigned int, exc_context_t *));
+
+
 void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, unsigned int n)
 {
 	static const char *mnemonics[] = {
@@ -135,6 +143,12 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 {
 	char buff[SIZE_CTXDUMP];
 
+	/* Don't call the handler on kernel exceptions */
+	if ((ctx->excret == RET_THREAD_PSP) && hal_exceptions_common.defaultHandler != NULL) {
+		hal_exceptionJump(n, ctx, hal_exceptions_common.defaultHandler);
+		return;
+	}
+
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(ATTR_BOLD, buff);
 
@@ -181,10 +195,17 @@ void *hal_exceptionsFaultAddr(unsigned int n, exc_context_t *ctx)
 
 int hal_exceptionsSetHandler(unsigned int n, excHandlerFn_t handler)
 {
+#ifndef KERNEL_REBOOT_ON_EXCEPTION
+	if (n == EXC_DEFAULT) {
+		hal_exceptions_common.defaultHandler = handler;
+	}
+#endif
+
 	return 0;
 }
 
 
 void _hal_exceptionsInit(void)
 {
+	hal_exceptions_common.defaultHandler = NULL;
 }


### PR DESCRIPTION
TASK: PP-462

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change allows programmers to control the behavior of exceptions through the `KERNEL_REBOOT_ON_EXCEPTION` macro. Setting it will cause a reboot/halt on an exception (current behavior), while not setting it will cause the offending process to be killed and reported in the console (new behavior).
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently all exceptions either halt or reboot the CPU and lack useful context for the crash (like PID and TID of the culprit). This is making certain issues harder to debug than they need to be, thus slowing down the work in our team.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv8m-stm32n6`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
