### PR TITLE
vm/zone: Fix bad arg check in _vm_zoneCreate

### DIFF
--- a/vm/zone.c
+++ b/vm/zone.c
@@ -32,11 +32,8 @@ int _vm_zoneCreate(vm_zone_t *zone, size_t blocksz, unsigned int blocks)
 {
 	size_t i;
 
-	if ((blocksz == 0U) || (blocks == 0U)) {
-		return -EINVAL;
-	}
-
-	if ((blocksz & ~(blocksz - 1U)) == 0U) {
+	/* blocksz has to be a power of 2 */
+	if ((blocksz == 0UL) || (blocks == 0U) || ((blocksz & (blocksz - 1UL)) != 0UL)) {
 		return -EINVAL;
 	}
 

--- a/vm/zone.c
+++ b/vm/zone.c
@@ -114,10 +114,6 @@ void _vm_zfree(vm_zone_t *zone, void *block)
 		return;
 	}
 
-	if (((unsigned long)block & ~(zone->blocksz - 1U)) == 0U) {
-		return;
-	}
-
 	*((void **)block) = zone->first;
 	zone->first = block;
 	zone->used--;


### PR DESCRIPTION
Intend was to check if blocksz is a power of 2, one extra ~ caused the check to become not equal to zero instead.

TASK: RTOS-1288

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
