### PR TITLE
!posix/ioctl: handle posix-defined requests

### DIFF
--- a/include/ioctl.h
+++ b/include/ioctl.h
@@ -30,6 +30,10 @@
 
 #define _IOC(inout, group, num, len) ((unsigned long)((inout) | (((len) & IOCPARM_MASK) << 16) | ((group) << 8) | (num)))
 
+#define TTY_IOC_TYPE  't'
+#define SOCK_IOC_TYPE 'S'
+
+
 typedef struct {
 	unsigned long request;
 	unsigned long size;

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -1755,6 +1755,28 @@ static int ioctl_processResponse(const msg_t *msg, unsigned long request, void *
 }
 
 
+static int ioctl_checkPosixDefinedRequests(open_file_t *f, unsigned long request)
+{
+	unsigned long group = IOCGROUP(request);
+
+	switch (group) {
+		case (unsigned long)TTY_IOC_TYPE:
+			/*
+			 * FIXME: for now, every character device is treated as a TTY.
+			 * Find a way to change this behavior.
+			 */
+			return (f->type == ftTty) ? EOK : -ENOTTY;
+
+		/* not required by POSIX, but nice to have */
+		case (unsigned long)SOCK_IOC_TYPE:
+			return ((f->type == ftUnixSocket) || (f->type == ftInetSocket)) ? EOK : -ENOTSOCK;
+
+		default:
+			return EOK;
+	}
+}
+
+
 int posix_ioctl(int fildes, unsigned long request, u8 *ustack)
 {
 	TRACE("ioctl(%d, %d)", fildes, request);
@@ -1767,21 +1789,16 @@ int posix_ioctl(int fildes, unsigned long request, u8 *ustack)
 
 	err = posix_getOpenFile(fildes, &f);
 	if (err == EOK) {
-		/* TODO: handle POSIX defined requests */
-		if (size > 0U) {
+		err = ioctl_checkPosixDefinedRequests(f, request);
+
+		if (err == EOK && size > 0U) {
 			GETFROMSTACK(ustack, void *, data, 2);
 			/* the actual size of the pointed-to structure: >= IOCPARM_LEN(request) */
 			GETFROMSTACK(ustack, size_t, size, 3);
 
 			if ((request & IOC_INOUT) != 0U) {
-				if (data == NULL) {
+				if (data == NULL || vm_mapBelongs(proc_current()->process, data, size) < 0) {
 					err = -EFAULT;
-				}
-				else if (vm_mapBelongs(proc_current()->process, data, size) < 0) {
-					err = -EFAULT;
-				}
-				else {
-					/* Nothing to do */
 				}
 			}
 		}

--- a/posix/posix.c
+++ b/posix/posix.c
@@ -556,19 +556,42 @@ int posix_statvfs(const char *path, int fildes, struct statvfs *buf)
 }
 
 
+static int posix_getAttr(oid_t oid, int type, long long *attr)
+{
+	int err;
+	msg_t msg;
+
+	hal_memset(&msg, 0, sizeof(msg));
+	msg.type = mtGetAttr;
+	msg.oid = oid;
+	msg.i.attr.type = type;
+
+	err = proc_send(oid.port, &msg);
+	if (err < 0) {
+		return err;
+	}
+
+	err = msg.o.err;
+	if (err < 0) {
+		return err;
+	}
+
+	*attr = msg.o.attr.val;
+
+	return EOK;
+}
+
+
 /* TODO: handle O_CREAT and O_EXCL */
 int posix_open(const char *filename, int oflag, u8 *ustack)
 {
 	TRACE("open(%s, %d, %d)", filename, oflag);
-	oid_t ln, oid, dev, pipesrv;
+	oid_t ln, oid, dev, srv;
 	int fd = 0, err = 0;
 	process_info_t *p;
 	open_file_t *f;
 	mode_t mode;
-
-	if (proc_lookup("/dev/posix/pipes", NULL, &pipesrv) < 0) {
-		hal_memset(&pipesrv, 0xff, sizeof(oid_t));
-	}
+	long long attr;
 
 	p = pinfo_find(process_getPid(proc_current()->process));
 	if (p == NULL) {
@@ -638,16 +661,48 @@ int posix_open(const char *filename, int oflag, u8 *ustack)
 
 			f->refs = 1;
 
-			/* TODO: check for other types */
-			if (oid.port == US_PORT) {
-				f->type = ftUnixSocket;
-			}
-			else if (oid.port == pipesrv.port) {
-				f->type = ftPipe;
-			}
-			else {
-				f->type = ftRegular;
-			}
+			do {
+				if (oid.port == US_PORT) {
+					f->type = ftUnixSocket;
+					break;
+				}
+
+				if (proc_lookup("/dev/posix/pipes", NULL, &srv) >= 0) {
+					if (oid.port == srv.port) {
+						f->type = ftPipe;
+						break;
+					}
+				}
+
+				if (posix_getAttr(f->ln, atMode, &attr) < 0) {
+					/* report files that don't report attr as regular files */
+					f->type = ftRegular;
+					break;
+				}
+				else {
+					mode = (mode_t)attr;
+					if (S_ISCHR(mode)) {
+						/*
+						 * FIXME: for now, we treat every character device as
+						 * a TTY. This behavior should be fixed as it changes
+						 * the behavior of e.g. posix_fstat() and ioctl().
+						 */
+						f->type = ftTty;
+					}
+					else if (S_ISFIFO(mode)) {
+						f->type = ftFifo;
+					}
+					else {
+						/*
+						 * FIXME: add new types to ft* enum as for now we treat
+						 * all other entities, e.g. links, block devices,
+						 * directories as regular files.
+						 */
+						f->type = ftRegular;
+					}
+					break;
+				}
+			} while (0);
 
 			if (((unsigned int)oflag & O_APPEND) != 0U) {
 				f->offset = proc_size(f->oid);
@@ -1404,6 +1459,10 @@ int posix_fstat(int fd, struct stat *buf)
 				buf->st_mode = S_IFSOCK;
 				break;
 			case ftTty:
+				/*
+				 * FIXME: for now, every character device is treated as a TTY.
+				 * Find a way to change this behavior.
+				 */
 				buf->st_mode = S_IFCHR;
 				break;
 			default:

--- a/posix/posix_private.h
+++ b/posix/posix_private.h
@@ -68,7 +68,7 @@
 #define HOST_NAME_MAX 255U
 
 
-enum { ftRegular,
+enum { ftRegular, /* FIXME: currently encompasses block devices, links and directories */
 	ftPipe,
 	ftFifo,
 	ftInetSocket,


### PR DESCRIPTION
Return ENOTTY or ENOTSOCK on file type mismatch
between the open file and the request.

Fixes: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1435

This is breaking as SOCK_IOC_TYPE was transferred to kernel and TTY_IOC_TYPE was defined in kernel.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/libphoenix/pull/468
    - https://github.com/phoenix-rtos/phoenix-rtos-build/pull/273 - *armv8r target doesn't build without this so all tests fail immediatelly* 
- [ ] I will merge this PR by myself when appropriate.
