### PR TITLE
lib/cbuffer: assert size is a power of 2 in _cbuffer_init

### DIFF
--- a/lib/cbuffer.c
+++ b/lib/cbuffer.c
@@ -20,6 +20,8 @@
 
 void _cbuffer_init(cbuffer_t *buf, void *data, size_t sz)
 {
+	LIB_ASSERT_ALWAYS(((sz == 0U) || ((sz & (sz - 1U)) == 0U)), "cbuffer's size has to be either 0 or a power of 2");
+
 	hal_memset(buf, 0, sizeof(cbuffer_t));
 	buf->sz = sz;
 	buf->data = data;

--- a/posix/unix.c
+++ b/posix/unix.c
@@ -1099,11 +1099,10 @@ int unix_shutdown(unsigned int socket, int how)
 static int unix_bufferSetSize(unixsock_t *s, int sz)
 {
 	void *v[2] = { NULL, NULL };
-	size_t size = (size_t)sz;
-
-	if (size < US_MIN_BUFFER_SIZE || size > US_MAX_BUFFER_SIZE) {
-		return -EINVAL;
-	}
+	/* cut requested buffer size to [US_MIN_BUFFER_SIZE, US_MAX_BUFFER_SIZE] range */
+	size_t size = min(max((size_t)sz, US_MIN_BUFFER_SIZE), US_MAX_BUFFER_SIZE);
+	/* round size to the next power of 2 */
+	size = (size_t)1U << (hal_cpuGetLastBit(size - 1U) + 1U);
 
 	(void)proc_lockSet(&s->lock);
 


### PR DESCRIPTION
cbuffer's size is used as a bitmask in read and write, which only works if it's a power of 2.

YT: RTOS-1294

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
