### PR TITLE
hal: compile hal_timerSetWakeup only when implemented

### DIFF
--- a/hal/aarch64/zynqmp/config.h
+++ b/hal/aarch64/zynqmp/config.h
@@ -26,6 +26,8 @@
 #define SIZE_INTERRUPTS 188U
 #define TIMER_IRQ_ID    68U
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "Xilinx Zynq Ultrascale+ "

--- a/hal/aarch64/zynqmp/timer.c
+++ b/hal/aarch64/zynqmp/timer.c
@@ -101,11 +101,6 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
 time_t hal_timerGetUs(void)
 {
 	time_t ret = hal_timerGetCyc();

--- a/hal/armv7a/imx6ull/config.h
+++ b/hal/armv7a/imx6ull/config.h
@@ -23,6 +23,8 @@
 
 #define TIMER_IRQ_ID 88U
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "NXP i.MX 6ULL "

--- a/hal/armv7a/zynq7000/config.h
+++ b/hal/armv7a/zynq7000/config.h
@@ -31,6 +31,8 @@
 
 #define TIMER_IRQ_ID 42U
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "Xilinx Zynq-7000 "

--- a/hal/armv7a/zynq7000/timer.c
+++ b/hal/armv7a/zynq7000/timer.c
@@ -101,11 +101,6 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
 time_t hal_timerGetUs(void)
 {
 	time_t ret = hal_timerGetCyc();

--- a/hal/armv7m/imxrt/10xx/config.h
+++ b/hal/armv7m/imxrt/10xx/config.h
@@ -21,6 +21,8 @@
 #define TIMER_US2CYC(x) (x)
 #define TIMER_CYC2US(x) (x)
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 #include "hal/types.h"
 #include "include/arch/armv7m/imxrt/syspage.h"

--- a/hal/armv7m/imxrt/117x/config.h
+++ b/hal/armv7m/imxrt/117x/config.h
@@ -21,6 +21,8 @@
 #define TIMER_US2CYC(x) (x)
 #define TIMER_CYC2US(x) (x)
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 #include "hal/types.h"
 #include "include/arch/armv7m/imxrt/syspage.h"

--- a/hal/armv7m/stm32/config.h
+++ b/hal/armv7m/stm32/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 #include "hal/types.h"
 #include "include/arch/armv7m/stm32/syspage.h"

--- a/hal/armv7m/stm32/l4/timer.c
+++ b/hal/armv7m/stm32/l4/timer.c
@@ -194,10 +194,6 @@ void timer_setAlarm(time_t us)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
 /* Interface functions */
 
 time_t hal_timerGetUs(void)

--- a/hal/armv7r/tda4vm/config.h
+++ b/hal/armv7r/tda4vm/config.h
@@ -19,6 +19,8 @@
 
 #define NUM_CPUS 1
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "TI K3 J721e SoC "

--- a/hal/armv7r/tda4vm/timer.c
+++ b/hal/armv7r/tda4vm/timer.c
@@ -137,12 +137,6 @@ static u64 hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-	/* Sleep mode not implemented on this platform */
-}
-
-
 static void timer_setPrescaler(u32 freq)
 {
 	u64 ticks;

--- a/hal/armv7r/zynqmp/config.h
+++ b/hal/armv7r/zynqmp/config.h
@@ -21,6 +21,8 @@
 #define SIZE_INTERRUPTS 188U
 #define TIMER_IRQ_ID    68U
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "Xilinx Zynq Ultrascale+ "

--- a/hal/armv7r/zynqmp/timer.c
+++ b/hal/armv7r/zynqmp/timer.c
@@ -96,11 +96,6 @@ static time_t hal_timerGetCyc(void)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
 time_t hal_timerGetUs(void)
 {
 	time_t ret = hal_timerGetCyc();

--- a/hal/armv8m/mcx/n94x/config.h
+++ b/hal/armv8m/mcx/n94x/config.h
@@ -18,6 +18,8 @@
 
 #define SIZE_INTERRUPTS (171U + 16U)
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/armv8m/mcx/syspage.h"

--- a/hal/armv8m/nrf/91/config.h
+++ b/hal/armv8m/nrf/91/config.h
@@ -16,6 +16,8 @@
 #ifndef _PH_HAL_CONFIG_H_
 #define _PH_HAL_CONFIG_H_
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/armv8m/nrf/syspage.h"

--- a/hal/armv8m/nrf/91/timer.c
+++ b/hal/armv8m/nrf/91/timer.c
@@ -68,11 +68,6 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 /* Interface functions */
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
 time_t hal_timerGetUs(void)
 {
 	return timer_common.timeUs;

--- a/hal/armv8m/stm32/n6/config.h
+++ b/hal/armv8m/stm32/n6/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 #include "hal/types.h"
 #include "include/arch/armv8m/stm32/syspage.h"

--- a/hal/armv8m/stm32/n6/timer.c
+++ b/hal/armv8m/stm32/n6/timer.c
@@ -133,12 +133,6 @@ int hal_timerRegister(intrFn_t f, void *data, intr_handler_t *h)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-	/* Not implemented yet */
-}
-
-
 /* interval: microseconds between timer interrupts */
 void _hal_timerInit(u32 interval)
 {

--- a/hal/armv8r/mps3an536/config.h
+++ b/hal/armv8r/mps3an536/config.h
@@ -18,6 +18,8 @@
 
 #define NUM_CPUS 1
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 0 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #define HAL_NAME_PLATFORM "MPS3 AN536 "

--- a/hal/armv8r/mps3an536/timer.c
+++ b/hal/armv8r/mps3an536/timer.c
@@ -86,11 +86,6 @@ time_t hal_timerGetUs(void)
 }
 
 
-void hal_timerSetWakeup(u32 waitUs)
-{
-}
-
-
 int hal_timerRegister(intrFn_t f, void *data, intr_handler_t *h)
 {
 	h->f = f;

--- a/hal/ia32/config.h
+++ b/hal/ia32/config.h
@@ -16,6 +16,8 @@
 #ifndef _PH_HAL_CONFIG_H_
 #define _PH_HAL_CONFIG_H_
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/ia32/syspage.h"

--- a/hal/riscv64/gaisler/gr765/config.h
+++ b/hal/riscv64/gaisler/gr765/config.h
@@ -16,6 +16,8 @@
 #ifndef _PH_HAL_CONFIG_H_
 #define _PH_HAL_CONFIG_H_
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/riscv64/syspage.h"

--- a/hal/riscv64/gaisler/grfpga/config.h
+++ b/hal/riscv64/gaisler/grfpga/config.h
@@ -16,6 +16,8 @@
 #ifndef _PH_HAL_CONFIG_H_
 #define _PH_HAL_CONFIG_H_
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/riscv64/syspage.h"

--- a/hal/riscv64/generic/config.h
+++ b/hal/riscv64/generic/config.h
@@ -16,6 +16,8 @@
 #ifndef _PH_HAL_CONFIG_H_
 #define _PH_HAL_CONFIG_H_
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 #include "include/arch/riscv64/syspage.h"

--- a/hal/sparcv8leon/gaisler/generic/config.h
+++ b/hal/sparcv8leon/gaisler/generic/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 

--- a/hal/sparcv8leon/gaisler/gr712rc/config.h
+++ b/hal/sparcv8leon/gaisler/gr712rc/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 

--- a/hal/sparcv8leon/gaisler/gr716/config.h
+++ b/hal/sparcv8leon/gaisler/gr716/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 

--- a/hal/sparcv8leon/gaisler/gr740/config.h
+++ b/hal/sparcv8leon/gaisler/gr740/config.h
@@ -17,6 +17,8 @@
 #define _PH_HAL_CONFIG_H_
 
 
+#define CPU_SUPPORTS_TIMER_WAKEUP 1 /* if the function hal_timerSetWakeup is supported on this architecture */
+
 #ifndef __ASSEMBLY__
 
 

--- a/hal/timer.h
+++ b/hal/timer.h
@@ -18,11 +18,14 @@
 
 
 #include "interrupts.h"
+#include "config.h"
 
 time_t hal_timerGetUs(void);
 
 
+#if CPU_SUPPORTS_TIMER_WAKEUP
 void hal_timerSetWakeup(u32 waitUs);
+#endif
 
 
 int hal_timerRegister(intrFn_t f, void *data, intr_handler_t *h);

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -165,6 +165,7 @@ static void _threads_waking(thread_t *t)
  */
 
 
+#if CPU_SUPPORTS_TIMER_WAKEUP
 static void _threads_updateWakeup(time_t now, thread_t *minimum)
 {
 	thread_t *t;
@@ -195,6 +196,11 @@ static void _threads_updateWakeup(time_t now, thread_t *minimum)
 
 	hal_timerSetWakeup((unsigned int)wakeup);
 }
+#else
+static void _threads_updateWakeup(time_t now, thread_t *minimum)
+{
+}
+#endif
 
 
 static int threads_timeintr(unsigned int n, cpu_context_t *context, void *arg)


### PR DESCRIPTION
_threads_updateWakeup (the only user of hal_timerSetWakeup) does anything only if hal_timerSetWakeup is implemented to do anything. Else, it just queries the tree for no reason. This commit introduces CPU_SUPPORTS_TIMER_WAKEUP symbol to define _threads_updateWakeup only if the wakeup is suppored to eliminate unnecessary tree searches

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
