### PR TITLE
hal/imx6ull: improve value sanitization in pctl_iopad set

### DIFF
--- a/hal/armv7a/imx6ull/imx6ull.c
+++ b/hal/armv7a/imx6ull/imx6ull.c
@@ -226,7 +226,7 @@ static int _imx6ull_setIOpad(int pad, u8 hys, u8 pus, u8 pue, u8 pke, u8 ode, u8
 		/* No action required*/
 	}
 
-	t = (((u32)hys & 0x1U) << 16) | (((u32)pus & 0x3U) << 14) | (((u32)pue & 0x1U) << 13) | ((u32)pke << 12);
+	t = (((u32)hys & 0x1U) << 16) | (((u32)pus & 0x3U) << 14) | (((u32)pue & 0x1U) << 13) | (((u32)pke & 0x1U) << 12);
 	t |= (((u32)ode & 0x1U) << 11) | (((u32)speed & 0x3U) << 6) | (((u32)dse & 0x7U) << 3) | ((u32)sre & 0x1U);
 	*(base + pad) = t;
 


### PR DESCRIPTION
Now `pke` values outside of valid range <0,1> are not impacting other fields.

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
