### PR TITLE
posix: ensure waitpid target is alive

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2635,6 +2635,21 @@ pid_t posix_setsid(void)
 }
 
 
+static int waitpid_isWaitValid(pid_t pid, process_info_t *parent, process_info_t *child)
+{
+	if (pid == -1) {
+		return 1;
+	}
+	if ((pid == 0) && (child->pgid == parent->pgid)) {
+		return 1;
+	}
+	if ((pid < 0) && (child->pgid == -pid)) {
+		return 1;
+	}
+	return (pid == child->process) ? 1 : 0;
+}
+
+
 int posix_waitpid(pid_t child, int *status, unsigned int options)
 {
 	process_info_t *pinfo, *c;
@@ -2662,16 +2677,12 @@ int posix_waitpid(pid_t child, int *status, unsigned int options)
 	(void)proc_lockSet(&pinfo->lock);
 	for (;;) {
 		/* Do this in the loop in case someone has a bad idea of doing multithreaded waitpid */
-		if ((pinfo->children == NULL) && (pinfo->zombies == NULL)) {
-			err = -ECHILD;
-			break;
-		}
+		err = -ECHILD;
 
 		if (pinfo->zombies != NULL) {
 			c = pinfo->zombies;
 			do {
-				if ((child == -1) || ((child == 0) && (c->pgid == pinfo->pgid)) ||
-						((child < 0) && (c->pgid == -child)) || (child == c->process)) {
+				if (waitpid_isWaitValid(child, pinfo, c) != 0) {
 					LIST_REMOVE(&pinfo->zombies, c);
 					err = c->process;
 					if (status != NULL) {
@@ -2688,7 +2699,18 @@ int posix_waitpid(pid_t child, int *status, unsigned int options)
 			} while (c != pinfo->zombies);
 		}
 
-		if (wnohang != 0) {
+		if (pinfo->children != NULL) {
+			c = pinfo->children;
+			do {
+				if (waitpid_isWaitValid(child, pinfo, c) != 0) {
+					err = EOK;
+					break;
+				}
+				c = c->next;
+			} while (c != pinfo->children);
+		}
+
+		if ((err < 0) || (wnohang != 0)) {
 			break;
 		}
 


### PR DESCRIPTION
Prior, double waitpid() on same killed child pid would block forever - first call would remove the child from zombies list and a second call would go straight into proc_lockWait().

This change adds additional sweep through the children list before lockWaiting, to ensure the pid to be waited is alive.

Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1436

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [X] New test added: https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/481
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
