### PR TITLE
proc/threads: implement force unlocking of locks

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -30,6 +30,12 @@
 enum { event_scheduling, event_enqueued, event_waking, event_preempted };
 /* clang-format on */
 
+#define UNLOCK_DONT_YIELD 0
+#define UNLOCK_DO_YIELD   1
+#define UNLOCK_TRY        0
+#define UNLOCK_FORCE      1
+
+
 const struct lockAttr proc_lockAttrDefault = { .type = PH_LOCK_NORMAL };
 
 /* Special empty queue value used to wakeup next enqueued thread. This is used to implement sticky conditions */
@@ -239,7 +245,7 @@ static int threads_timeintr(unsigned int n, cpu_context_t *context, void *arg)
  */
 
 
-static void proc_lockUnlock(lock_t *lock);
+static void proc_lockForceUnlock(lock_t *lock, int doYield);
 
 
 static void thread_destroy(thread_t *thread)
@@ -252,7 +258,7 @@ static void thread_destroy(thread_t *thread)
 	/* No need to protect thread->locks access with threads_common.spinlock */
 	/* The destroyed thread is a ghost and no thread (except for the current one) can access it */
 	while (thread->locks != NULL) {
-		proc_lockUnlock(thread->locks);
+		proc_lockForceUnlock(thread->locks, UNLOCK_DO_YIELD);
 	}
 	vm_kfree(thread->kstack);
 
@@ -1610,7 +1616,7 @@ int proc_lockSetInterruptible(lock_t *lock)
 }
 
 
-static int _proc_lockUnlock(lock_t *lock)
+static int _proc_lockUnlock(lock_t *lock, int doForceUnlock)
 {
 	thread_t *owner = lock->owner, *current;
 	spinlock_ctx_t sc;
@@ -1626,18 +1632,25 @@ static int _proc_lockUnlock(lock_t *lock)
 	LIB_ASSERT(LIST_BELONGS(&owner->locks, lock) != 0, "lock: %s, owner pid: %d, owner tid: %d, lock is not on the list",
 			lock->name, (owner->process != NULL) ? process_getPid(owner->process) : 0, proc_getTid(owner));
 
-	if ((lock->attr.type == PH_LOCK_ERRORCHECK) || (lock->attr.type == PH_LOCK_RECURSIVE)) {
-		if (lock->owner != current) {
-			hal_spinlockClear(&threads_common.spinlock, &sc);
-			return -EPERM;
+	if (doForceUnlock == UNLOCK_TRY) {
+		if ((lock->attr.type == PH_LOCK_ERRORCHECK) || (lock->attr.type == PH_LOCK_RECURSIVE)) {
+			if (lock->owner != current) {
+				hal_spinlockClear(&threads_common.spinlock, &sc);
+				return -EPERM;
+			}
 		}
 	}
 
 	if ((lock->attr.type == PH_LOCK_RECURSIVE) && (lock->depth > 0U)) {
-		lock->depth--;
-		if (lock->depth != 0U) {
-			hal_spinlockClear(&threads_common.spinlock, &sc);
-			return 0;
+		if (doForceUnlock == UNLOCK_TRY) {
+			lock->depth--;
+			if (lock->depth != 0U) {
+				hal_spinlockClear(&threads_common.spinlock, &sc);
+				return 0;
+			}
+		}
+		else {
+			lock->depth = 0U;
 		}
 	}
 
@@ -1670,19 +1683,22 @@ static int _proc_lockUnlock(lock_t *lock)
 }
 
 
-static void proc_lockUnlock(lock_t *lock)
+static void proc_lockForceUnlock(lock_t *lock, int doYield)
 {
 	spinlock_ctx_t sc;
+	int ret = 0;
 
 	hal_spinlockSet(&lock->spinlock, &sc);
+	if (lock->owner != NULL) {
+		ret = _proc_lockUnlock(lock, UNLOCK_FORCE);
+	}
 
-	if (_proc_lockUnlock(lock) > 0) {
-		hal_spinlockClear(&lock->spinlock, &sc);
+	hal_spinlockClear(&lock->spinlock, &sc);
+	if ((ret > 0) && (doYield != UNLOCK_DONT_YIELD)) {
 		(void)hal_cpuReschedule(NULL, NULL);
 	}
-	else {
-		hal_spinlockClear(&lock->spinlock, &sc);
-	}
+
+	LIB_ASSERT(ret >= 0, "lock: %s, force unlocking failed (%d)", lock->name, ret);
 }
 
 
@@ -1703,7 +1719,7 @@ static int _proc_lockClear(lock_t *lock)
 		return -EPERM;
 	}
 
-	return _proc_lockUnlock(lock);
+	return _proc_lockUnlock(lock, UNLOCK_TRY);
 }
 
 
@@ -1780,17 +1796,8 @@ int proc_lockWait(thread_t **queue, lock_t *lock, time_t timeout)
 
 int proc_lockDone(lock_t *lock)
 {
-	spinlock_ctx_t sc;
-
-	hal_spinlockSet(&lock->spinlock, &sc);
-
-	if (lock->owner != NULL) {
-		(void)_proc_lockUnlock(lock);
-	}
-
-	hal_spinlockClear(&lock->spinlock, &sc);
+	proc_lockForceUnlock(lock, UNLOCK_DONT_YIELD);
 	hal_spinlockDestroy(&lock->spinlock);
-
 	return EOK;
 }
 


### PR DESCRIPTION
TODO: build fails on sparcv8leon-gr716-mimas because kernel is now too big
```
/opt/phoenix/sparc-phoenix/bin/../lib/gcc/sparc-phoenix/14.2.0/../../../../sparc-phoenix/bin/ld: section .got VMA [40001a08,40001a0f] overlaps section .bss VMA [40001a00,40002bef]
```

Fix infinite loop that could have occurred in `thread_destroy()` function if trying to unlock a lock held by a thread failed. 
Fix possible use-after-free after `proc_lockDone()` if unlocking a lock failed.

## Description
Unlocking of locks held by a process is subject to error checking, e.g. if the process unlocking the lock actually held it. This is only for locks of type `PH_LOCK_ERRORCHECK` and `PH_LOCK_RECURSIVE`, which is perhaps the reason why the issue below went unnoticed for some time now.

Problems arise when you consider the `init` process which reaps threads that have ended. If a userspace thread held any such locks, they wouldn't be closed because of error checking (`init` process doesn't actually own any of the userspace locks). The error wasn't propagated and the loop in `thread_destroy()` would spin forever - preventing any other threads from being reaped and possibly deadlocking the system.

Another subtle problem was in `proc_lockDone()`. Code in that function assumed that after calling `_proc_lockUnlock` the lock would be unlocked, removed from the list of locks held by a thread and could be freed. To that end it called `hal_spinlockDestroy()`. However, this could fail not only because of error checking mentioned above, but also when unlocking a recursive mutex held with a depth of > 1. When destroying such a mutex, a use-after-free could occur with hard to predict consequences. 

To fix this, `_proc_lockUnlock` was modified to allow force unlocking a lock, which omits error checks and always succeeds in removing the lock from the list of held locks. To protect against future mistakes, an assertion was added to make it clear the function must succeed at force unlocking.

`thread_destroy()` now force-unlocks all locks that a thread holds and so does `proc_lockDone()`. The latter function does return `int`, so in theory it could try unlocking and return a retcode if failed. However, every single call of that function ignores the retcode, so I chose force unlocking as safer.

## Motivation and Context
Closes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1535
JIRA: RTOS-1322

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6-nucleo, ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
