### PR TITLE
hal/armv7r/pmap: remove hack that always enables kernel MPU region

### DIFF
--- a/hal/armv7r/pmap.c
+++ b/hal/armv7r/pmap.c
@@ -33,7 +33,6 @@ u8 _init_stack[NUM_CPUS][SIZE_INITIAL_KSTACK] __attribute__((aligned(8)));
 
 
 static struct {
-	unsigned int kernelCodeRegion;
 	spinlock_t lock;
 	int mpu_enabled;
 } pmap_common;
@@ -106,7 +105,7 @@ static void pmap_mpu_disable(void)
 /* Function creates empty page table */
 int pmap_create(pmap_t *pmap, pmap_t *kpmap, page_t *p, void *vaddr)
 {
-	pmap->regions = pmap_common.kernelCodeRegion;
+	pmap->regions = 0U;
 	return 0;
 }
 
@@ -246,8 +245,6 @@ int pmap_segment(unsigned int i, void **vaddr, size_t *size, vm_prot_t *prot, vo
 
 void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 {
-	const syspage_map_t *ikmap;
-	unsigned int ikregion;
 	u32 t;
 	unsigned int i;
 	unsigned int cnt = syspage->hs.mpu.allocCnt;
@@ -266,7 +263,6 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	if (cnt == 0U) {
 		hal_spinlockCreate(&pmap_common.lock, "pmap");
 		pmap_common.mpu_enabled = 0;
-		pmap_common.kernelCodeRegion = 0;
 		return;
 	}
 
@@ -288,35 +284,6 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 
 	/* Enable MPU */
 	pmap_mpu_enable();
-
-	/* FIXME HACK
-	 * allow all programs to execute (and read) kernel code map.
-	 * Needed because of hal_jmp, syscalls handler and signals handler.
-	 * In these functions we need to switch to the user mode when still
-	 * executing kernel code. This will cause memory management fault
-	 * if the application does not have access to the kernel instruction
-	 * map. Possible fix - place return to the user code in the separate
-	 * region and allow this region instead. */
-
-	/* Find kernel code region */
-	/* parasoft-suppress-next-line MISRAC2012-RULE_11_1 "We need address of this function in numeric type" */
-	ikmap = syspage_mapAddrResolve((addr_t)_pmap_init);
-	if (ikmap == NULL) {
-		hal_consolePrint(ATTR_BOLD, "pmap: Kernel code map not found. Bad system config\n");
-		for (;;) {
-			hal_cpuHalt();
-		}
-	}
-
-	ikregion = pmap_map2region(ikmap->id);
-	if (ikregion == 0U) {
-		hal_consolePrint(ATTR_BOLD, "pmap: Kernel code map has no assigned region. Bad system config\n");
-		for (;;) {
-			hal_cpuHalt();
-		}
-	}
-
-	pmap_common.kernelCodeRegion = ikregion;
 
 	hal_spinlockCreate(&pmap_common.lock, "pmap");
 }


### PR DESCRIPTION
Remove code that was deemed unnecessary.

## Description

This workaround is not necessary on current ARMv7-R platforms because armv7r kernel code is never executed in user mode. Because we use the MPU with `SCTLR.BR` == 1, privileged mode execution always has access to kernel code regardless of whether the corresponding MPU region is enabled or not.

The "FIXME HACK" only exists because the MPU handling code was copied and pasted from ARMv7-M implementation where kernel code in `hal_jmp` is sometimes executed in user mode.

In the future we should create a more universal solution to convey which MPU regions need to always be enabled. There are certain platforms where the default memory map doesn't allow kernel data access, which the current "hack" isn't good enough to handle - it only concerns kernel code access.

In other words - this hack is not necessary for currently supported platforms and not good enough for potential future platforms.

## Motivation and Context

JIRA: RTOS-1325

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7r5f-zynqmp-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
