### PR TITLE
proc/unix: fix poll events on closed unix socket connection

### DIFF
--- a/posix/unix.c
+++ b/posix/unix.c
@@ -1233,9 +1233,15 @@ int unix_poll(unsigned int socket, unsigned short events)
 		err = POLLNVAL;
 	}
 	else {
+		if (s->type != SOCK_DGRAM && (s->state & US_PEER_CLOSED) != 0U) {
+			err |= POLLHUP; /* connection-wise socket - peer closed: report POLLHUP always */
+		}
+
 		if ((events & (POLLIN | POLLRDNORM | POLLRDBAND)) != 0U) {
 			(void)proc_lockSet(&s->lock);
-			if (_cbuffer_avail(&s->buffer) > 0U || (s->connecting != NULL && (s->state & US_LISTENING) != 0U)) {
+			if (_cbuffer_avail(&s->buffer) > 0U ||
+					(s->connecting != NULL && (s->state & US_LISTENING) != 0U) ||   /* listening socket with pending connection */
+					(s->type != SOCK_DGRAM && (s->state & US_PEER_CLOSED) != 0U)) { /* connection-wise socket disconnected (EOF readable) */
 				err |= (unsigned int)events & (POLLIN | POLLRDNORM | POLLRDBAND);
 			}
 			(void)proc_lockClear(&s->lock);


### PR DESCRIPTION
## Description

For connected unix socket pair, the socket peer was correctly marked as closed, but poll() never returned the POLLHUP event. Also POLLIN should be returned if requested (EOF readable).

This fixes libevent-based multi-process programs graceful shutdown and error paths (e.g. openiked).


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

TASK: SEN-151


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
