### PR TITLE
posix: fix SIGCHLD interrupt during waitpid

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2748,7 +2748,7 @@ int posix_waitpid(pid_t child, int *status, unsigned int options)
 void posix_died(pid_t pid, int exit)
 {
 	process_info_t *pinfo, *ppinfo, *init, *cinfo, *zinfo, *zombies;
-	int waited, adopted = 1;
+	int adopted = 1;
 
 	pinfo = pinfo_find(pid);
 	LIB_ASSERT_ALWAYS(pinfo != NULL, "pinfo not found, pid: %d", pid);
@@ -2768,7 +2768,10 @@ void posix_died(pid_t pid, int exit)
 		if ((ppinfo != init) && (LIST_BELONGS(&ppinfo->children, pinfo) != 0)) {
 			LIST_REMOVE(&ppinfo->children, pinfo);
 			LIST_ADD(&ppinfo->zombies, pinfo);
-			waited = proc_threadBroadcast(&ppinfo->wait);
+			if (proc_threadBroadcast(&ppinfo->wait) == 0) {
+				/* Signal parent because no one was waiting in waitpid() */
+				posix_sigchild(pinfo->parent);
+			}
 			adopted = 0;
 		}
 		(void)proc_lockClear(&ppinfo->lock);
@@ -2795,7 +2798,6 @@ void posix_died(pid_t pid, int exit)
 		/* We were adopted by the init at some point */
 		LIST_REMOVE(&init->children, pinfo);
 		LIST_ADD(&zombies, pinfo);
-		waited = 1;
 	}
 	(void)proc_lockClear(&pinfo->lock);
 	(void)proc_lockClear(&init->lock);
@@ -2806,11 +2808,6 @@ void posix_died(pid_t pid, int exit)
 		zinfo = zombies;
 		LIST_REMOVE(&zombies, zinfo);
 		pinfo_put(zinfo);
-	}
-
-	/* Signal parent if no one was waiting in waitpid() */
-	if (waited == 0) {
-		posix_sigchild(pinfo->parent);
 	}
 
 	pinfo_put(pinfo);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There was a possibility of parent performing waitpid between posix_died waited check and actual signal post when waited == 0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Recent CI failure seems to be related to this problem.

Can be reproduced often by bulk-forking (1000 processes) and then bulk-waiting for all of them.
Rare reproduction is also possible with simple 1 fork, 1 wait() loop.

aarch64-qemu seems to trigger reproduction faster than ia32, even with smp enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: ia32-generic-qemu, aarch64a53-zynqmp-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
