### PR TITLE
hal/armv7a: Adding IO mapping functionality in HAL initialization

### DIFF
--- a/hal/aarch64/pmap.c
+++ b/hal/aarch64/pmap.c
@@ -890,21 +890,22 @@ void _pmap_preinit(addr_t dtbStart, addr_t dtbEnd)
 /* parasoft-begin-suppress MISRAC2012-RULE_17_1 "stdarg.h required for custom functions that are like printf" */
 void *_pmap_halMapDevice(addr_t paddr, size_t pageOffs, size_t size)
 {
+	size_t maxIdx = TTL_IDX(3U, VADDR_DTB);
 	descr_t attrs = DESCR_VALID | DESCR_TABLE | DESCR_AF | DESCR_ISH | DESCR_PXN | DESCR_UXN | DESCR_ATTR(MAIR_IDX_DEVICE);
-	ptr_t va_start = ((VADDR_MAX - (SIZE_PAGE << 9)) + 1U) + (pmap_common.dev_i * SIZE_PAGE);
+	ptr_t vaStart = ((VADDR_MAX - (SIZE_PAGE << 9)) + 1U) + (pmap_common.dev_i * SIZE_PAGE);
+	size_t span = pageOffs + size;
 	size_t offs;
 
-	if ((pmap_common.dev_i + (size / SIZE_PAGE)) > TTL_IDX(3U, VADDR_DTB)) {
-		return NULL;
-	}
+	LIB_ASSERT(size > 0U, "Attempted to map device of size 0");
+	LIB_ASSERT_ALWAYS((pmap_common.dev_i + ((span + SIZE_PAGE - 1U) / SIZE_PAGE)) < maxIdx, "Out of device address space");
 
-	for (offs = 0; offs < size; offs += SIZE_PAGE) {
-		pmap_common.devices_ttl3[TTL_IDX(3U, va_start + offs)] = DESCR_PA(paddr + offs) | attrs;
+	for (offs = 0U; offs < span; offs += SIZE_PAGE) {
+		pmap_common.devices_ttl3[pmap_common.dev_i] = DESCR_PA(paddr + offs) | attrs;
 		pmap_common.dev_i++;
 	}
 
 	hal_cpuDataSyncBarrier();
-	return (void *)va_start + pageOffs;
+	return (void *)(vaStart + pageOffs);
 }
 
 /* parasoft-end-suppress MISRAC2012-RULE_17_1 */

--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -251,6 +251,16 @@ MAYBE_UNUSED static inline void hal_cpuAtomicInc(volatile u32 *dst)
 }
 
 
+/* Read Configuration Base Address Register - contents are implementation-defined, typically base address of GIC */
+/* parasoft-suppress-next-line MISRAC2012-DIR_4_3 "Assembly is required for low-level operations" */
+static inline u32 hal_cpuGetCBAR(void)
+{
+	u32 ret;
+	__asm__ volatile("mrc p15, 4, %0, c15, c0, 0" : "=r"(ret));
+	return ret;
+}
+
+
 #endif
 
 #endif

--- a/hal/armv7a/arch/pmap.h
+++ b/hal/armv7a/arch/pmap.h
@@ -75,6 +75,13 @@ typedef struct _pmap_t {
 	page_t *pmapp;
 } pmap_t;
 
+
+void _pmap_preinit(void);
+
+
+void *_pmap_halMapDevice(addr_t paddr, size_t pageOffs, size_t size);
+
+
 #endif
 
 #endif

--- a/hal/armv7a/hal.c
+++ b/hal/armv7a/hal.c
@@ -86,6 +86,7 @@ void hal_lockScheduler(void)
 __attribute__((section(".init"))) void _hal_init(void)
 {
 	schedulerLocked = 0;
+	_pmap_preinit();
 	_hal_spinlockInit();
 	_hal_platformInit();
 	_hal_consoleInit();

--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -34,7 +34,6 @@
 
 #define ADDR_PROGS_BEGIN (_end + 4 * 1024 * 1024 - VADDR_KERNEL + ADDR_DDR)
 
-#define VADDR_SYSPAGE (_end + SIZE_PAGE - 1)
 #define SWAP(x)       (((x >> 24) & 0xff) | ((x << 8) & (0xff << 16)) | ((x >> 8) & (0xff << 8)) | ((x << 24) & (0xff << 24)))
 
 
@@ -352,10 +351,7 @@ _start:
 
 #ifdef KERNEL_PLO_BOOT
 	ldr r0, =(relOffs - VADDR_KERNEL + ADDR_DDR)
-	ldr r1, =VADDR_SYSPAGE
-	lsr r1, #12
-	lsl r1, #12
-
+	ldr r1, =_hal_syspageCopied
 	sub r2, r1, r9
 	str r2, [r0]
 
@@ -707,3 +703,12 @@ kernel_ttl2:
 
 #include "hal/armv7a/_interrupts.S"
 #include "hal/armv7a/_armv7a.S"
+
+
+#ifdef KERNEL_PLO_BOOT
+.section ".bss"
+.align 4
+_hal_syspageCopied:
+	.zero SIZE_PAGE
+.size _hal_syspageCopied, . - _hal_syspageCopied
+#endif

--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -35,11 +35,6 @@
 #define ADDR_PROGS_BEGIN (_end + 4 * 1024 * 1024 - VADDR_KERNEL + ADDR_DDR)
 
 #define VADDR_SYSPAGE (_end + SIZE_PAGE - 1)
-#define VADDR_UART1   (VADDR_SYSPAGE + 2 * SIZE_PAGE)
-#define VADDR_UART2   (VADDR_UART1 + SIZE_PAGE)
-#define VADDR_GIC     (VADDR_UART2 + SIZE_PAGE)
-#define VADDR_GPT     (VADDR_GIC + 4 * SIZE_PAGE)
-#define VADDR_CCM     (VADDR_GPT + SIZE_PAGE)
 #define SWAP(x)       (((x >> 24) & 0xff) | ((x << 8) & (0xff << 16)) | ((x >> 8) & (0xff << 8)) | ((x << 24) & (0xff << 24)))
 
 
@@ -626,64 +621,6 @@ kernel_ttl2:
 
 	/* Kernel page tables */
 	bl _cpy4
-
-	/* Map UART1 4 KB P 0x02020000 -> V CEIL(_end + 3 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r0, =(VADDR_UART1 - VADDR_KERNEL)
-	lsr r0, #12
-	lsl r0, #2
-	ldr r1, =ADDR_TTL2_K
-	add r0, r0, r1
-	ldr r1, =0x02020012
-	str r1, [r0], #4
-
-	/* Map UART2 4KB P 0x021e8000 -> V CEIL(_end + 4 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x021e8012
-	str r1, [r0], #4
-
-	/* Map GIC 16 KB after UARTs */
-	mrc p15, 4, r1, c15, c0, 0 /* Get GIC paddr */
-	lsr r1, #16
-	lsl r1, #16
-	orr r1, r1, #0x12
-	mov r2, #(1 << 12)
-	bl _cpy4
-
-	/* Map EPIT1 after GIC */
-	ldr r1, =0x020d0012
-	str r1, [r0], #4
-
-	/* Map GPT1 after EPIT1 */
-	ldr r1, =0x02098012
-	str r1, [r0], #4
-
-	/* Map CCM registers 4KB P 0x020c4000 -> V CEIL(_end + 11 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020c4012
-	str r1, [r0], #4
-
-	/* Map CCM_ANALOG registers 4KB P 0x020c8000 -> V CEIL(_end + 12 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020c8012
-	str r1, [r0], #4
-
-	/* Map IOMUX_SNVS registers 4KB P 0x02290000 -> V CEIL(_end + 13 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x02290012
-	str r1, [r0], #4
-
-	/* Map IOMUX registers 4KB P 0x020e0000 -> V CEIL(_end + 14 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020e0012
-	str r1, [r0], #4
-
-	/* Map IOMUXC_GPR registers 4KB P 0x020e4000 -> V CEIL(_end + 15 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020e4012
-	str r1, [r0], #4
-
-	/* Map WDOG1 registers 4KB P 0x020bc000 -> V CEIL(_end + 16 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020bc012
-	str r1, [r0], #4
-
-	/* Map SRC registers 4KB P 0x020d8000 -> V CEIL(_end + 17 * SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =0x020d8012
-	str r1, [r0]
-
 
 	/* IOMUX for UART1*/
 	ldr r0, =0x20e0084

--- a/hal/armv7a/imx6ull/config.h
+++ b/hal/armv7a/imx6ull/config.h
@@ -21,7 +21,18 @@
 
 #define NUM_CPUS 1
 
-#define TIMER_IRQ_ID 88U
+#define EPIT1_BASE 0x020d0000U
+#define EPIT1_IRQ  88U
+#define EPIT2_BASE 0x020d4000U
+#define EPIT2_IRQ  89U
+
+#define GPT1_BASE 0x02098000U
+#define GPT1_IRQ  87U
+
+#define GPT_BASE     GPT1_BASE
+#define GPT_IRQ      GPT1_IRQ
+#define EPIT_BASE    EPIT1_BASE
+#define TIMER_IRQ_ID EPIT1_IRQ
 
 #ifndef __ASSEMBLY__
 

--- a/hal/armv7a/imx6ull/console.c
+++ b/hal/armv7a/imx6ull/console.c
@@ -15,15 +15,31 @@
 
 #include "hal/console.h"
 #include "hal/cpu.h"
+#include "hal/pmap.h"
 
-#define UART uart1
+#include <board_config.h>
+
+#ifndef UART_CONSOLE_KERNEL
+#define UART_CONSOLE_KERNEL 1
+#endif
+
 
 static struct {
-	volatile u32 *uart1;
-	volatile u32 *uart2;
+	volatile u32 *base;
 	u8 type;
 	u32 speed;
 } console_common;
+
+
+/* TODO: add more UARTs - they may require extra configuration, e.g. IOMUX or clock initialization */
+static const addr_t console_baseAddr[] = {
+	0x02020000U,
+	0x021e8000U,
+};
+
+#define N_UARTS (sizeof(console_baseAddr) / sizeof(console_baseAddr[0]))
+
+_Static_assert((UART_CONSOLE_KERNEL > 0) && ((size_t)UART_CONSOLE_KERNEL <= N_UARTS), "Invalid UART number selected");
 
 
 /* clang-format off */
@@ -32,17 +48,13 @@ enum { urxd = 0, utxd = 16, ucr1 = 32, ucr2, ucr3, ucr4, ufcr, usr1, usr2,
 /* clang-format on */
 
 
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
-
-
 static void _hal_consolePrint(const char *s)
 {
 	for (; *s != '\0'; s++) {
 		hal_consolePutch(*s);
 	}
 
-	while ((*(console_common.UART + usr1) & 0x2000U) == 0U) {
+	while ((*(console_common.base + usr1) & 0x2000U) == 0U) {
 		;
 	}
 }
@@ -68,32 +80,31 @@ void hal_consolePrint(int attr, const char *s)
 void hal_consolePutch(char c)
 {
 	/* Wait for transmitter readiness */
-	while ((*(console_common.UART + usr1) & 0x2000U) == 0U) {
+	while ((*(console_common.base + usr1) & 0x2000U) == 0U) {
 		;
 	}
 
-	*(console_common.UART + utxd) = (unsigned int)c;
+	*(console_common.base + utxd) = (unsigned int)c;
 }
 
 
 __attribute__((section(".init"))) void _hal_consoleInit(void)
 {
-	console_common.uart1 = (void *)(((u32)&_end + (3U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	console_common.uart2 = (void *)(((u32)&_end + (4U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
+	console_common.base = _pmap_halMapDevice(console_baseAddr[UART_CONSOLE_KERNEL - 1], 0, SIZE_PAGE);
 	console_common.speed = 115200;
 
-	*(console_common.UART + ucr2) &= ~0x1U;
-	while ((*(console_common.UART + uts) & 0x1U) != 0U) {
+	*(console_common.base + ucr2) &= ~0x1U;
+	while ((*(console_common.base + uts) & 0x1U) != 0U) {
 		;
 	}
 
-	*(console_common.UART + ucr1) = 0x1U;
-	*(console_common.UART + ucr2) = 0x4026U;
-	*(console_common.UART + ucr3) = 0x704U;
-	*(console_common.UART + ucr4) = 0x8000U;
-	*(console_common.UART + ufcr) = 0x901U;
-	*(console_common.UART + uesc) = 0x2bU;
-	*(console_common.UART + utim) = 0x0U;
-	*(console_common.UART + ubir) = 0x11ffU;
-	*(console_common.UART + ubmr) = 0xc34fU;
+	*(console_common.base + ucr1) = 0x1U;
+	*(console_common.base + ucr2) = 0x4026U;
+	*(console_common.base + ucr3) = 0x704U;
+	*(console_common.base + ucr4) = 0x8000U;
+	*(console_common.base + ufcr) = 0x901U;
+	*(console_common.base + uesc) = 0x2bU;
+	*(console_common.base + utim) = 0x0U;
+	*(console_common.base + ubir) = 0x11ffU;
+	*(console_common.base + ubmr) = 0xc34fU;
 }

--- a/hal/armv7a/imx6ull/imx6ull.c
+++ b/hal/armv7a/imx6ull/imx6ull.c
@@ -19,6 +19,15 @@
 #include "hal/spinlock.h"
 #include "include/arch/armv7a/imx6ull/imx6ull.h"
 
+#define CCM_BASE        0x020c4000U
+#define CCM_ANALOG_BASE 0x020c8000U
+#define IOMUX_SNVS_BASE 0x02290000U
+#define IOMUX_BASE      0x020e0000U
+#define IOMUX_GPR_BASE  0x020e4000U
+#define WDOG_BASE       0x020bc000U
+#define SRC_BASE        0x020d8000U
+
+
 /* clang-format off */
 /* CCM registers */
 enum { ccm_ccr = 0, ccm_ccdr, ccm_csr, ccm_ccsr, ccm_cacrr, ccm_cbcdr, ccm_cbcmr,
@@ -70,10 +79,6 @@ static struct {
 /* saved in _init_imx6ull.S */
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_4 "Definition in assembly" */
 u32 imx6ull_bootReason;
-
-
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
 
 
 static int _imx6ull_isValidDev(int dev)
@@ -474,13 +479,13 @@ void _hal_platformInit(void)
 	unsigned int reg, tmp;
 
 	hal_spinlockCreate(&imx6ull_common.pltctlSp, "pltctl");
-	imx6ull_common.ccm = (void *)(((u32)&_end + (11U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.ccm_analog = (void *)(((u32)&_end + (12U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.iomux_snvs = (void *)(((u32)&_end + (13U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.iomux = (void *)(((u32)&_end + (14U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.iomux_gpr = (void *)(((u32)&_end + (15U * SIZE_PAGE) - 1u) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.wdog = (void *)(((u32)&_end + (16U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	imx6ull_common.src = (void *)(((u32)&_end + (17U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
+	imx6ull_common.ccm = _pmap_halMapDevice(CCM_BASE, 0, SIZE_PAGE);
+	imx6ull_common.ccm_analog = _pmap_halMapDevice(CCM_ANALOG_BASE, 0, SIZE_PAGE);
+	imx6ull_common.iomux_snvs = _pmap_halMapDevice(IOMUX_SNVS_BASE, 0, SIZE_PAGE);
+	imx6ull_common.iomux = _pmap_halMapDevice(IOMUX_BASE, 0, SIZE_PAGE);
+	imx6ull_common.iomux_gpr = _pmap_halMapDevice(IOMUX_GPR_BASE, 0, SIZE_PAGE);
+	imx6ull_common.wdog = _pmap_halMapDevice(WDOG_BASE, 0, SIZE_PAGE);
+	imx6ull_common.src = _pmap_halMapDevice(SRC_BASE, 0, SIZE_PAGE);
 
 	/* remain in run mode in low power */
 	*(imx6ull_common.ccm + ccm_clpcr) &= ~0x3U;

--- a/hal/armv7a/imx6ull/interrupts.c
+++ b/hal/armv7a/imx6ull/interrupts.c
@@ -16,6 +16,7 @@
 #include "hal/cpu.h"
 #include "hal/interrupts.h"
 #include "hal/list.h"
+#include "hal/pmap.h"
 #include "config.h"
 
 #include "proc/userintr.h"
@@ -47,10 +48,6 @@ static struct {
 
 
 int threads_schedule(unsigned int n, cpu_context_t *context, void *arg);
-
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
-
 
 /* parasoft-suppress-next-line MISRAC2012-RULE_2_2 MISRAC2012-RULE_8_4 "Function is used externally within assembler code" */
 int interrupts_dispatch(unsigned int n, cpu_context_t *ctx)
@@ -206,7 +203,7 @@ void _hal_interruptsInit(void)
 		hal_spinlockCreate(&interrupts.spinlock[i], "interrupts");
 	}
 
-	interrupts.gic = (void *)(((u32)&_end + (5U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
+	interrupts.gic = _pmap_halMapDevice(hal_cpuGetCBAR(), 0, 4U * SIZE_PAGE);
 
 	*(interrupts.gic + ctlr) &= ~1U;
 

--- a/hal/armv7a/imx6ull/timer.c
+++ b/hal/armv7a/imx6ull/timer.c
@@ -17,6 +17,7 @@
 #include "hal/timer.h"
 #include "hal/spinlock.h"
 #include "hal/string.h"
+#include "hal/pmap.h"
 #include "config.h"
 
 static struct {
@@ -37,10 +38,6 @@ enum { epit_cr = 0, epit_sr, epit_lr, epit_cmpr, epit_cnr };
 
 enum { gpt_cr = 0, gpt_pr, gpt_sr, gpt_ir, gpt_ocr1, gpt_ocr2, gpt_ocr3, gpt_icr1, gpt_icr2, gpt_cnt };
 /* clang-format on */
-
-
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
 
 
 static int timer_wakeupIrqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
@@ -137,8 +134,8 @@ char *hal_timerFeatures(char *features, size_t len)
 
 void _hal_timerInit(u32 interval)
 {
-	timer_common.epit1 = (void *)(((u32)&_end + (9U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
-	timer_common.gpt1 = (void *)(((u32)&_end + (10U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
+	timer_common.epit1 = _pmap_halMapDevice(EPIT_BASE, 0, SIZE_PAGE);
+	timer_common.gpt1 = _pmap_halMapDevice(GPT_BASE, 0, SIZE_PAGE);
 	timer_common.timerhi = 0;
 
 	hal_spinlockCreate(&timer_common.lock, "timer");
@@ -150,7 +147,7 @@ void _hal_timerInit(u32 interval)
 	(void)hal_interruptsSetHandler(&timer_common.wakeuph);
 
 	timer_common.timerh.data = NULL;
-	timer_common.timerh.n = 87;
+	timer_common.timerh.n = GPT_IRQ;
 	timer_common.timerh.f = timer_overflowIrqHandler;
 
 	(void)hal_interruptsSetHandler(&timer_common.timerh);

--- a/hal/armv7a/pmap.c
+++ b/hal/armv7a/pmap.c
@@ -41,9 +41,6 @@ extern unsigned int _end;
 extern unsigned int _etext;
 /* parasoft-end-suppress MISRAC2012-RULE_8_6 */
 
-/* TODO: this should be removed once we are sure that no target maps data past .bss anymore */
-#define SIZE_EXTEND_BSS 18U * SIZE_PAGE
-
 #define TT2S_ATTR_MASK 0xfffU
 #define TT2S_NOTGLOBAL 0x800U
 #define TT2S_SHAREABLE 0x400U
@@ -501,7 +498,6 @@ int pmap_getPage(page_t *page, addr_t *addr)
 	}
 
 	end = ((addr_t)&_end + SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U);
-	end += SIZE_EXTEND_BSS;
 	if (page->addr >= end - VADDR_KERNEL + min) {
 		page->flags |= PAGE_FREE;
 		return EOK;
@@ -610,10 +606,6 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 
 	/* Initialize kernel heap start address */
 	(*vstart) = (void *)(((u32)&_end + SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
-
-	/* First 17 pages after bss are mapped for controllers */
-	/* TODO: this size should depend on platform */
-	(*vstart) += SIZE_EXTEND_BSS;
 	(*vend) = (*vstart) + SIZE_PAGE;
 
 	/* Create initial heap */

--- a/hal/armv7a/pmap.c
+++ b/hal/armv7a/pmap.c
@@ -29,9 +29,11 @@
 #if NUM_CPUS != 1
 #define hal_cpuInvalVAAll   hal_cpuInvalVA_IS
 #define hal_cpuInvalASIDAll hal_cpuInvalASID_IS
+#define hal_cpuInvalTLBAll  hal_cpuInvalTLB_IS
 #else
 #define hal_cpuInvalVAAll   hal_cpuInvalVA
 #define hal_cpuInvalASIDAll hal_cpuInvalASID
+#define hal_cpuInvalTLBAll  hal_cpuInvalTLB
 #endif
 
 /* parasoft-begin-suppress MISRAC2012-RULE_8_6 "Provided by toolchain" */
@@ -39,6 +41,7 @@ extern unsigned int _end;
 extern unsigned int _etext;
 /* parasoft-end-suppress MISRAC2012-RULE_8_6 */
 
+/* TODO: this should be removed once we are sure that no target maps data past .bss anymore */
 #define SIZE_EXTEND_BSS 18U * SIZE_PAGE
 
 #define TT2S_ATTR_MASK 0xfffU
@@ -72,11 +75,14 @@ extern unsigned int _etext;
 
 #define SCRATCH_ATTRS (PGHD_PRESENT | PGHD_READ | PGHD_WRITE)
 
+/* Reserve the last 64KB for vector table for targets that don't implement VBAR */
+#define VADDR_VECTOR_TABLE 0xffff0000UL
+
 struct {
-	u32 kpdir[0x1000]; /* Has to be first in the structure */
-	u32 kptab[0x400];
-	u32 excptab[0x400];
-	u32 sptab[0x400];
+	u32 kpdir[0x1000];  /* Kernel's page directory, has to be first in the structure */
+	u32 kptab[0x400];   /* Page table containing kernel code and initial data */
+	u32 excptab[0x400]; /* Page table containing exception vectors, initial stacks and devices */
+	u32 sptab[0x400];   /* Scratch page table for temporary use */
 	u8 heap[SIZE_PAGE];
 	pmap_t *asid_map[256];
 	u8 asids[256];
@@ -86,6 +92,7 @@ struct {
 	u32 end;
 	spinlock_t lock;
 	u8 asidptr;
+	u32 dev_i;
 	/* parasoft-suppress-next-line MISRAC2012-RULE_8_4 MISRAC2012-RULE_1_1 "Symbol used in assembly, theres no limits" */
 } __attribute__((aligned(0x4000))) pmap_common;
 
@@ -584,19 +591,8 @@ int pmap_segment(unsigned int i, void **vaddr, size_t *size, vm_prot_t *prot, vo
 void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 {
 	unsigned int i;
-
-	pmap_common.asidptr = 0;
 	pmap->asid_ix = 0;
-
-	for (i = 0; i < sizeof(pmap_common.asid_map) / sizeof(pmap_common.asid_map[0]); ++i) {
-		pmap_common.asid_map[i] = NULL;
-		pmap_common.asids[i] = (u8)i;
-	}
-
 	hal_spinlockCreate(&pmap_common.lock, "pmap_common.lock");
-
-	pmap_common.minAddr = ADDR_DDR;
-	pmap_common.maxAddr = ADDR_DDR + SIZE_DDR;
 
 	/* Initialize kernel page table */
 	pmap->pdir = pmap_common.kpdir;
@@ -604,9 +600,10 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 
 	/* Remove initial kernel mapping */
 	for (i = 0; i < 4U; ++i) {
-		pmap->pdir[ID_PDIR(pmap_common.minAddr) + i] = 0;
-		hal_cpuInvalVAAll(pmap_common.minAddr + i * (1U << 2));
+		pmap_common.kpdir[ID_PDIR(pmap_common.minAddr) + i] = 0;
 	}
+
+	hal_cpuInvalTLBAll();
 
 	pmap->start = (void *)VADDR_KERNEL;
 	pmap->end = (void *)VADDR_MAX;
@@ -619,11 +616,56 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	(*vstart) += SIZE_EXTEND_BSS;
 	(*vend) = (*vstart) + SIZE_PAGE;
 
-	pmap_common.start = (u32)pmap_common.heap - VADDR_KERNEL + pmap_common.minAddr;
-	pmap_common.end = pmap_common.start + SIZE_PAGE;
-
 	/* Create initial heap */
 	LIB_ASSERT_ALWAYS(pmap_enter(pmap, pmap_common.start, (*vstart), PGHD_WRITE | PGHD_READ | PGHD_PRESENT, NULL) == EOK, "failed to create initial heap");
 
 	(void)pmap_remove(pmap, *vend, (void *)(VADDR_KERNEL + (4U * 1024U * 1024U)));
+}
+
+
+void _pmap_preinit(void)
+{
+	size_t maxIdx = ID_PTABLE(VADDR_VECTOR_TABLE);
+	unsigned int i;
+
+	pmap_common.dev_i = 0;
+	pmap_common.asidptr = 0;
+
+	for (i = 0; i < sizeof(pmap_common.asid_map) / sizeof(pmap_common.asid_map[0]); ++i) {
+		pmap_common.asid_map[i] = NULL;
+		pmap_common.asids[i] = (u8)i;
+	}
+
+	for (i = pmap_common.dev_i; i < maxIdx; ++i) {
+		pmap_common.excptab[i] = 0;
+	}
+
+	pmap_common.minAddr = ADDR_DDR;
+	pmap_common.maxAddr = ADDR_DDR + SIZE_DDR;
+
+	pmap_common.start = (u32)pmap_common.heap - VADDR_KERNEL + pmap_common.minAddr;
+	pmap_common.end = pmap_common.start + SIZE_PAGE;
+
+	hal_cpuInvalTLBAll();
+}
+
+
+void *_pmap_halMapDevice(addr_t paddr, size_t pageOffs, size_t size)
+{
+	size_t maxIdx = ID_PTABLE(VADDR_VECTOR_TABLE);
+	u32 attrs = attrMap[PGHD_WRITE | PGHD_DEV];
+	ptr_t vaStart = ((VADDR_MAX - (1024U * SIZE_PAGE)) + 1U) + (pmap_common.dev_i * SIZE_PAGE);
+	size_t span = pageOffs + size;
+	size_t offs;
+
+	LIB_ASSERT(size > 0U, "Attempted to map device of size 0");
+	LIB_ASSERT_ALWAYS((pmap_common.dev_i + ((span + SIZE_PAGE - 1U) / SIZE_PAGE)) < maxIdx, "Out of device address space");
+
+	for (offs = 0U; offs < span; offs += SIZE_PAGE) {
+		pmap_common.excptab[pmap_common.dev_i] = ((paddr + offs) & ~(SIZE_PAGE - 1U)) | attrs;
+		pmap_common.dev_i++;
+	}
+
+	hal_cpuDataSyncBarrier();
+	return (void *)(vaStart + pageOffs);
 }

--- a/hal/armv7a/zynq7000/_init.S
+++ b/hal/armv7a/zynq7000/_init.S
@@ -36,25 +36,11 @@
 #define PA_STACK    (ADDR_DDR + 4 * 1024 * 1024 - SIZE_PAGE)
 
 #define VA_SYSPAGE (_end + SIZE_PAGE - 1)
-#define VA_UART0   (VA_SYSPAGE + 2 * SIZE_PAGE)
-#define VA_UART1   (VA_UART0 + SIZE_PAGE)
-#define VA_GIC     (VA_UART1 + SIZE_PAGE)
-#define VA_TTC     (VA_GIC + 4 * SIZE_PAGE)
-
-#define PA_UART0 0xe0000000
-#define PA_UART1 0xe0001000
-#define PA_SLCR  0xf8000000
-#define PA_TTC   0xf8001000
 
 /* Attributes for kernel pages:
  * Small page, XN = 0 (allow Execute), TEX = 1 C = 1 B = 1 (Outer and Inner Write-Back, Write-Allocate),
  * AP = 0x1 (R/W from PL1 only), S = 1 (Shareable), nG = 0 (Global) */
 #define KERNEL_PAGE_ATTR 0x45E
-
-/* Attributes for device pages:
- * Small page, XN = 1 (Execute Never), TEX = 0 C = 0 B = 1 (Shared Device),
- * AP = 0x1 (R/W from PL1 only), S = 0 (unused), nG = 0 (Global) */
-#define DEVICE_PAGE_ATTR 0x17
 
 .arm
 
@@ -263,36 +249,6 @@ kernel_ttl2:
 
 	/* Also change attributes of kernel page tables */
 	bl _cpy4
-
-	/* Map perpehrals addresses */
-	/* Map UART0 4 KB P 0xE0000000 -> V CEIL(_end, SIZE_PAGE) */
-	ldr r0, =(VA_UART0 - VADDR_KERNEL)
-	lsr r0, #12
-	lsl r0, #2
-	ldr r1, =PA_OF(VA_TTL2_K)
-	add r0, r0, r1
-	ldr r1, =(PA_UART0 | DEVICE_PAGE_ATTR)
-	str r1, [r0], #4
-
-	/* Map UART1 4KB P 0xE0001000 -> V CEIL(_end + SIZE_PAGE, SIZE_PAGE) */
-	ldr r1, =(PA_UART1 | DEVICE_PAGE_ATTR)
-	str r1, [r0], #4
-
-	/* Map GIC 16 KB after UARTs */
-	mrc p15, 4, r1, c15, c0, 0           /* Get GIC paddr */
-	lsr r1, #16
-	lsl r1, #16
-	orr r1, r1, #DEVICE_PAGE_ATTR
-	mov r2, #(1 << 12)
-	bl _cpy4
-
-	/* Map SLCR after GIC */
-	ldr r1, =(PA_SLCR | DEVICE_PAGE_ATTR)
-	str r1, [r0], #4
-
-	/* Map TTC after SLCR */
-	ldr r1, =(PA_TTC | DEVICE_PAGE_ATTR)
-	str r1, [r0], #4
 
 	b per_core_init
 

--- a/hal/armv7a/zynq7000/_init.S
+++ b/hal/armv7a/zynq7000/_init.S
@@ -35,8 +35,6 @@
 #define VA_TTL_END  (VA_TTL2_EXC + SIZE_PAGE)
 #define PA_STACK    (ADDR_DDR + 4 * 1024 * 1024 - SIZE_PAGE)
 
-#define VA_SYSPAGE (_end + SIZE_PAGE - 1)
-
 /* Attributes for kernel pages:
  * Small page, XN = 0 (allow Execute), TEX = 1 C = 1 B = 1 (Outer and Inner Write-Back, Write-Allocate),
  * AP = 0x1 (R/W from PL1 only), S = 1 (Shareable), nG = 0 (Global) */
@@ -147,9 +145,7 @@ set_loop:
 	bne wait_for_structs_init
 
 	/* init memory structures (relOffs, syspage, TTLs) */
-	ldr r1, =#VA_SYSPAGE
-	lsr r1, #12
-	lsl r1, #12
+	ldr r1, =_hal_syspageCopied
 	sub r2, r1, r9
 
 	ldr r0, =#PA_OF(relOffs)
@@ -202,14 +198,6 @@ clear_ttls:
 	ldr r0, =(PA_OF(VA_TTL1) + TTL1_OFFSET_OF(0xffc00000)) /* Entry address: TTL1 address + index (0xffc - 4 entries in TTL1) * 4 B*/
 	ldr r1, =(PA_OF(VA_TTL2_EXC) + 1)                      /* Ptr to exceptions' TTL2 (pmap_common.excptab); bits [1:0] = 1 defines TTL2 */
 	bl _cpy4                                               /* Fill TTL1 with 4 TTL2's addresses; pmap_common.excptab consists of 4 TTL2  */
-
-	ldr r8, =(ADDR_DDR)
-
-	/* Exceptions vectors TTL2 entry */
-	/* Map V 0xffff0000 -> P 0x00100000 */
-	ldr r0, =(PA_OF(VA_TTL2_EXC) + (0x3f0 << 2))          /* Entry address: 4 entries from the end in last TTL2 in pmap_common.excptab    */
-	orr r1, r8, #0x1a                                     /* Ptr to physical address. Attributes: XN = 0, B = 0, C = 0, AP = 0x1, TEX = 0 */
-	str r1, [r0]                                          /* Fill TTL2 entry                                                              */
 
 
 	/* Stacks TTL2 entry (one stack per CPU) */
@@ -369,3 +357,9 @@ other_core_wait:
 
 #include "hal/armv7a/_interrupts.S"
 #include "hal/armv7a/_armv7a.S"
+
+.section ".bss"
+.align 4
+_hal_syspageCopied:
+	.zero SIZE_PAGE
+.size _hal_syspageCopied, . - _hal_syspageCopied

--- a/hal/armv7a/zynq7000/console.c
+++ b/hal/armv7a/zynq7000/console.c
@@ -16,6 +16,7 @@
 
 #include "hal/console.h"
 #include "hal/cpu.h"
+#include "hal/pmap.h"
 
 #include "zynq.h"
 
@@ -23,12 +24,12 @@
 
 
 #if UART_CONSOLE_KERNEL == 0
-#define UART     uart0
+#define UART_BASE 0xe0000000U
 #define UART_RX  UART0_RX
 #define UART_TX  UART0_TX
 #define UART_CLK 20
 #else
-#define UART     uart1
+#define UART_BASE 0xe0001000U
 #define UART_RX  UART1_RX
 #define UART_TX  UART1_TX
 #define UART_CLK 21
@@ -36,8 +37,7 @@
 
 
 static struct {
-	volatile u32 *uart0;
-	volatile u32 *uart1;
+	volatile u32 *base;
 	u8 type;
 	u32 speed;
 } console_common;
@@ -51,10 +51,6 @@ enum {
 /* clang-format on */
 
 
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
-
-
 static void _hal_consolePrint(const char *s)
 {
 	for (; *s != '\0'; s++) {
@@ -62,7 +58,7 @@ static void _hal_consolePrint(const char *s)
 	}
 
 	/* Wait until TX fifo is empty */
-	while ((*(console_common.UART + sr) & (1U << 3)) == 0U) {
+	while ((*(console_common.base + sr) & (1U << 3)) == 0U) {
 		;
 	}
 }
@@ -88,18 +84,17 @@ void hal_consolePrint(int attr, const char *s)
 void hal_consolePutch(char c)
 {
 	/* Wait until TX fifo is empty */
-	while ((*(console_common.UART + sr) & (1U << 3)) == 0U) {
+	while ((*(console_common.base + sr) & (1U << 3)) == 0U) {
 		;
 	}
 
-	*(console_common.UART + fifo) = (u32)c;
+	*(console_common.base + fifo) = (u32)c;
 }
 
 
 __attribute__((section(".init"))) void _hal_consoleInit(void)
 {
-	console_common.uart0 = (void *)(((u32)&_end + 3U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
-	console_common.uart1 = (void *)(((u32)&_end + 4U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
+	console_common.base = _pmap_halMapDevice(UART_BASE, 0, SIZE_PAGE);
 	console_common.speed = 115200;
 
 	(void)_zynq_setMIO(UART_RX, 1U, 1U, 1U, 0U, 0U, 0U, 0U, 0x7U, 1U);
@@ -107,24 +102,24 @@ __attribute__((section(".init"))) void _hal_consoleInit(void)
 
 	(void)_zynq_setAmbaClk((u32)UART_CLK, 1U);
 
-	*(console_common.UART + idr) = 0xfffU;
+	*(console_common.base + idr) = 0xfffU;
 
 	/* Uart Mode Register
 	 * normal mode, 1 stop bit, no parity, 8 bits, uart_ref_clk as source clock
 	 * PAR = 0x4 */
-	*(console_common.UART + mr) = (*(console_common.UART + mr) & ~0x000003ffU) | 0x00000020U;
+	*(console_common.base + mr) = (*(console_common.base + mr) & ~0x000003ffU) | 0x00000020U;
 
 	/* Disable TX and RX */
-	*(console_common.UART + cr) = (*(console_common.UART + cr) & ~0x000001ffU) | 0x00000028U;
+	*(console_common.base + cr) = (*(console_common.base + cr) & ~0x000001ffU) | 0x00000028U;
 
 	/* Assumptions:
 	 * - baudarate : 115200
 	 * - ref_clk   : 50 MHz
 	 * - baud_rate = ref_clk / (bgen * (bdiv + 1)) */
-	*(console_common.UART + baudgen) = 62;
-	*(console_common.UART + baud_rate_divider_reg0) = 6;
+	*(console_common.base + baudgen) = 62;
+	*(console_common.base + baud_rate_divider_reg0) = 6;
 
 	/* Uart Control Register
 	 * TXEN = 0x1; RXEN = 0x1; TXRES = 0x1; RXRES = 0x1 */
-	*(console_common.UART + cr) = (*(console_common.UART + cr) & ~0x000001ffU) | 0x00000017U;
+	*(console_common.base + cr) = (*(console_common.base + cr) & ~0x000001ffU) | 0x00000017U;
 }

--- a/hal/armv7a/zynq7000/interrupts.c
+++ b/hal/armv7a/zynq7000/interrupts.c
@@ -20,6 +20,7 @@
 #include "hal/spinlock.h"
 #include "hal/interrupts.h"
 #include "hal/list.h"
+#include "hal/pmap.h"
 #include "config.h"
 
 #include "proc/userintr.h"
@@ -79,10 +80,6 @@ static const u8 spiConf[] = {
 void _hal_interruptsInitPerCPU(void);
 
 int threads_schedule(unsigned int n, cpu_context_t *context, void *arg);
-
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
-
 
 /* parasoft-begin-suppress MISRAC2012-RULE_2_2 MISRAC2012-RULE_8_4 "Function is used externally within assembler code" */
 int interrupts_dispatch(unsigned int n, cpu_context_t *ctx)
@@ -240,7 +237,7 @@ void _hal_interruptsInit(void)
 		hal_spinlockCreate(&interrupts_common.spinlock[i], "interrupts");
 	}
 
-	interrupts_common.gic = (void *)(((u32)&_end + (5U * SIZE_PAGE) - 1U) & ~(SIZE_PAGE - 1U));
+	interrupts_common.gic = _pmap_halMapDevice(hal_cpuGetCBAR(), 0, 2U * SIZE_PAGE);
 
 	/* Initialize Distributor of the gic
 	 * enable_secure = 0 */

--- a/hal/armv7a/zynq7000/timer.c
+++ b/hal/armv7a/zynq7000/timer.c
@@ -14,6 +14,7 @@
  */
 
 #include "hal/armv7a/armv7a.h"
+#include "hal/pmap.h"
 #include "hal/timer.h"
 #include "hal/spinlock.h"
 #include "hal/string.h"
@@ -21,6 +22,7 @@
 
 #include "zynq.h"
 
+#define TTC_BASE             0xf8001000U
 #define TIMER_SRC_CLK_CPU_1x 111111115U /* Hz */
 
 static struct {
@@ -40,10 +42,6 @@ enum {
 	irq_en3, ev_ctrl_t1, ev_ctrl_t2, ev_ctrl_t3, ev_reg1, ev_reg2, ev_reg3
 };
 /* clang-format on */
-
-
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
 
 
 static int _timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
@@ -155,7 +153,7 @@ char *hal_timerFeatures(char *features, size_t len)
 
 void _hal_timerInit(u32 interval)
 {
-	timer_common.ttc = (void *)(((u32)&_end + 10U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
+	timer_common.ttc = _pmap_halMapDevice(TTC_BASE, 0, SIZE_PAGE);
 	timer_common.jiffies = 0;
 
 	/* Disable timer */

--- a/hal/armv7a/zynq7000/zynq.c
+++ b/hal/armv7a/zynq7000/zynq.c
@@ -20,6 +20,10 @@
 #include "include/arch/armv7a/zynq7000/zynq7000.h"
 #include "hal/armv7a/zynq7000/zynq.h"
 
+#define SLCR_BASE 0xf8000000U
+#define SCU_BASE  0xf8f00000U
+#define L2CC_BASE 0xf8f02000U
+
 
 /* clang-format off */
 /* SLCR (System Level Control Registers) */
@@ -93,13 +97,12 @@ enum {
 static struct {
 	spinlock_t pltctlSp;
 	volatile u32 *slcr;
+	volatile u32 *scu;
 	volatile u32 *l2cc;
 	unsigned int nCpus;
 } zynq_common;
 
 
-/* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Provided by toolchain" */
-extern unsigned int _end;
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_4 "Definition in assembly" */
 volatile unsigned int nCpusStarted = 0;
 
@@ -733,8 +736,9 @@ static void _zynq_activateL2Cache(void)
 void _hal_platformInit(void)
 {
 	hal_spinlockCreate(&zynq_common.pltctlSp, "pltctl");
-	zynq_common.slcr = (void *)(((u32)&_end + 9U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
-	zynq_common.l2cc = (void *)(((u32)&_end + 7U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
+	zynq_common.slcr = _pmap_halMapDevice(SLCR_BASE, 0, SIZE_PAGE);
+	zynq_common.scu = _pmap_halMapDevice(SCU_BASE, 0, SIZE_PAGE);
+	zynq_common.l2cc = _pmap_halMapDevice(L2CC_BASE, 0, SIZE_PAGE);
 }
 
 
@@ -756,10 +760,11 @@ static u32 hal_checkNumCPUs(void)
 		return 1;
 	}
 
-	/* Otherwise we are in a multiprocessor system and we can check SCU for number of cores in SMP */
-	volatile u32 *scu = (void *)(((u32)&_end + 5U * SIZE_PAGE - 1U) & ~(SIZE_PAGE - 1U));
-	/* We cannot use SCU_CPU_Power_Status_Register because it's not implemented correctly on QEMU */
-	u32 powerStatus = (*(scu + 1U)) >> 4; /* SCU_CONFIGURATION_REGISTER */
+	/*
+	 * Otherwise we are in a multiprocessor system and we can check SCU for number of cores in SMP.
+	 * We cannot use SCU_CPU_Power_Status_Register because it's not implemented correctly on QEMU.
+	 */
+	u32 powerStatus = (*(zynq_common.scu + 1U)) >> 4; /* SCU_CONFIGURATION_REGISTER */
 	u32 cpusAvailable = 0;
 	for (unsigned int i = 0U; i < 4U; i++) {
 		if (((powerStatus >> i) & 0x1U) == 1U) {


### PR DESCRIPTION
Add IO memory mapping functionality similar to aarch64
Adjust code for imx6ull, zynq7000 targets to use this mapping functionality
Copy syspage to named object in `.bss` section instead of memory mapped past-the-end of `.bss`

## Description
Previously the way memory-mapped IO devices were made available to the kernel on armv7a platforms was very unintuitive. Code within `_init.S` mapped them past-the-end of `.bss` section at arbitrarily chosen offsets, which made it difficult for someone reading the code to understand what was going on.

To solve this, memory-mapped IO is now mapped near the top of the address space (range 0xFFC00000 - 0xFFFF0000) using unused entries in the page table `excptab`. It is done using `_pmap_halMapDevice` function with the same API as `aarch64`, `riscv64` and `sparcv8leon` targets. The physical addresses of peripherals are now declared in C code close to the driver where they are actually used, which helps readability and maintainability.

There are almost 4 MB of address space available through `excptab` which should be more than enough considering our OS has a microkernel design with few built-in drivers.

Additionally, memory for the syspage was also mapped past-the-end of `.bss` - which was not necessary considering that syspage could simply be stored to a named object within `.bss`. After changing this, there is nothing more mapped past `.bss` on armv7a and this unintuitive mechanism could be removed.

Other changes:
* On zynq7000 the entry for exception vectors in `excptab` was removed - it was unused because this target supports Security extensions and thus exception vector address is set using the VBAR register. This doesn't change the functioning of the system.
* The console driver for IMX6ULL was changed so that now it respects the `UART_CONSOLE_KERNEL` definition from `board_config.h`.

## Motivation and Context
Part of the work for https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1500

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a-imx6ull, armv7a-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
