### PR TITLE
hal/armv7r/zynqmp: watchdog handler (ZynqMP RPU)

### DIFF
--- a/hal/armv7r/zynqmp/zynqmp.c
+++ b/hal/armv7r/zynqmp/zynqmp.c
@@ -5,8 +5,8 @@
  *
  * ZynqMP internal peripheral control functions
  *
- * Copyright 2025 Phoenix Systems
- * Author: Jacek Maksymowicz
+ * Copyright 2025, 2026 Phoenix Systems
+ * Author: Jacek Maksymowicz, Kamil Ber
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -17,18 +17,29 @@
 #include "hal/hal.h"
 #include "hal/armv7r/armv7r.h"
 #include "hal/spinlock.h"
+#include "include/errno.h"
 #include "include/arch/armv7r/zynqmp/zynqmp.h"
 #include "zynqmp.h"
 
 #include "hal/armv7r/halsyspage.h"
 #include "zynqmp_regs.h"
 
+#include <board_config.h>
+
 #define IOU_SLCR_BASE_ADDRESS 0xff180000U
 #define APU_BASE_ADDRESS      0xfd5c0000U
 #define CRF_APB_BASE_ADDRESS  0xfd1a0000U
 #define CRL_APB_BASE_ADDRESS  0xff5e0000U
 #define PMU_GLOBAL_MODULE     0xffd80000U
+#define SWDT_LPD_MODULE       0xff150000U
 
+#if defined(WATCHDOG)
+#if !defined(WATCHDOG_TIMEOUT)
+#error "WATCHDOG_TIMEOUT not defined!"
+#elif (WATCHDOG_TIMEOUT > 0xFFFU)
+#error "Watchdog timeout out of bounds!"
+#endif
+#endif
 
 /* PLO entrypoint */
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Definition in assembly code" */
@@ -39,6 +50,7 @@ static struct {
 	volatile u32 *crf_apb;
 	volatile u32 *crl_apb;
 	volatile u32 *pmu_glb;
+	volatile u32 *swdt_lpd;
 	spinlock_t pltctlSp;
 } zynq_common;
 
@@ -423,9 +435,9 @@ __attribute__((noreturn)) void hal_cpuReboot(void)
 }
 
 
-/* TODO */
 void hal_wdgReload(void)
 {
+	*(zynq_common.swdt_lpd + swdt_lpd_restart) = SWDT_RESTART_RKEY;
 }
 
 
@@ -489,6 +501,40 @@ int hal_platformctl(void *ptr)
 			}
 			break;
 
+		case pctl_wdg_config:
+			/* If watchdog support is not enabled (WATCHDOG not defined) this will take no effects */
+			ret = 0;
+			if ((data->action == pctl_set) && (data->wdg_config.reload >= 0x0U) && (data->wdg_config.reload <= 0xFFFU)) {
+				*(zynq_common.swdt_lpd + swdt_lpd_control) = (SWDT_CONTROL_CKEY | (data->wdg_config.reload << SWDT_CONTROL_CRV_BIT) | SWDT_CONTROL_CLKSEL);
+				*(zynq_common.swdt_lpd + swdt_lpd_restart) = SWDT_RESTART_RKEY;
+			}
+			else if (data->action == pctl_get) {
+				data->wdg_config.reload = (unsigned int)((*(zynq_common.swdt_lpd + swdt_lpd_control) >> SWDT_CONTROL_CRV_BIT) & 0xFFFU);
+			}
+			else {
+				ret = -EINVAL;
+			}
+			break;
+
+		case pctl_wdg_enable:
+			/* If watchdog support is not enabled (WATCHDOG not defined) this will take no effects */
+			ret = 0;
+			if ((data->action == pctl_set) && (data->wdg_enable.enable == 1U)) {
+				*(zynq_common.swdt_lpd + swdt_lpd_restart) = SWDT_RESTART_RKEY;
+				*(zynq_common.swdt_lpd + swdt_lpd_mode) = (SWDT_MODE_ZKEY | SWDT_MODE_RSTLN | SWDT_MODE_RSTEN | SWDT_MODE_WDEN);
+			}
+			else if ((data->action == pctl_set) && (data->wdg_enable.enable == 0U)) {
+				*(zynq_common.swdt_lpd + swdt_lpd_restart) = SWDT_RESTART_RKEY;
+				*(zynq_common.swdt_lpd + swdt_lpd_mode) = (SWDT_MODE_ZKEY);
+			}
+			else if (data->action == pctl_get) {
+				data->wdg_enable.enable = (*(zynq_common.swdt_lpd + swdt_lpd_mode) & SWDT_MODE_WDEN) != 0U ? 1 : 0;
+			}
+			else {
+				ret = -EINVAL;
+			}
+			break;
+
 		default:
 			/* Error by default */
 			break;
@@ -507,7 +553,48 @@ void _hal_platformInit(void)
 	zynq_common.crf_apb = (void *)CRF_APB_BASE_ADDRESS;
 	zynq_common.crl_apb = (void *)CRL_APB_BASE_ADDRESS;
 	zynq_common.pmu_glb = (void *)PMU_GLOBAL_MODULE;
+	zynq_common.swdt_lpd = (void *)SWDT_LPD_MODULE;
+
+	/* On ZynqMP platform, the hardware error handler is triggered on PMU_ERR_STATUS bits which
+	 * are only clear on external POR or by writing to this register (WTC). It means that after
+	 * software reset, status bits are preserved and hence a new reset would be triggered again
+	 * effectively leading to boot-loop. To avoid that, the error status bits should be cleared.
+	 * Here, we assume that this clear operation is performed in plo during the reboot reason
+	 * investigation.
+	 */
+
+	/* Enable reset on RPU lockstep errors */
 	_zynqmp_setSysErrHandler(PMU_ERR_RPU_LS, system_reset, 1);
+
+	/* Disable Watchdog */
+	/* Xilinx UG1085: unlocking/key values for registers:
+	 * mode: 0xabc
+	 * control: 0x248
+	 * restart: 0x1999
+	 *
+	 * Here both mode and control registers are reset after power on
+	 * or after watchdog timeout triggered reset. the control reset is specified
+	 * in the UG: "Note: If a restart signal is received the prescaler should be reset.
+	 */
+	(void)_zynq_setDevRst(pctl_devreset_lpd_swdt, 0);
+	*(zynq_common.swdt_lpd + swdt_lpd_mode) = (SWDT_MODE_ZKEY);
+	*(zynq_common.swdt_lpd + swdt_lpd_control) = (SWDT_CONTROL_CKEY | (0xFFFU << SWDT_CONTROL_CRV_BIT) | SWDT_CONTROL_CLKSEL);
+
+#if defined(WATCHDOG)
+	/* set cotnrol: LPD_LSBUS_CLK scaler = 512 (gives reload value from ~20ms to 85s for 100MHz LPD_LSBUS_CLK)*/
+	*(zynq_common.swdt_lpd + swdt_lpd_control) = (SWDT_CONTROL_CKEY | ((WATCHDOG_TIMEOUT & 0xFFFU) << SWDT_CONTROL_CRV_BIT) | SWDT_CONTROL_CLKSEL);
+
+	/* reload */
+	*(zynq_common.swdt_lpd + swdt_lpd_restart) = SWDT_RESTART_RKEY;
+
+	/* enable watchdog: no irq, reset enabled (32 clock cycles pulse) */
+	*(zynq_common.swdt_lpd + swdt_lpd_mode) = (SWDT_MODE_ZKEY | SWDT_MODE_RSTLN | SWDT_MODE_RSTEN | SWDT_MODE_WDEN);
+
+	/* By default the PMU error handler is disabled and resets generated by SWDT are ignored */
+
+	/* Enable reset on LPD SWDT  */
+	_zynqmp_setSysErrHandler(PMU_ERR_LPD_SWDT, system_reset, 1);
+#endif
 }
 
 

--- a/hal/armv7r/zynqmp/zynqmp_regs.h
+++ b/hal/armv7r/zynqmp/zynqmp_regs.h
@@ -245,5 +245,12 @@ enum {
 	pmu_glb_error_en_2
 };
 
+enum {
+	swdt_lpd_mode = 0x00,
+	swdt_lpd_control,
+	swdt_lpd_restart,
+	swdt_lpd_status
+};
+
 
 #endif /* _PH_ZYNQMP_REGS_H_ */

--- a/include/arch/armv7r/zynqmp/zynqmp.h
+++ b/include/arch/armv7r/zynqmp/zynqmp.h
@@ -5,8 +5,8 @@
  *
  * ZynqMP basic peripherals control functions
  *
- * Copyright 2021, 2024 Phoenix Systems
- * Author: Hubert Buczynski, Jacek Maksymowicz
+ * Copyright 2021, 2024, 2026 Phoenix Systems
+ * Author: Hubert Buczynski, Jacek Maksymowicz, Kamil Ber
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -44,6 +44,18 @@
 #define PMU_ERR_PL       ((0xFUL << 2) + PMU_ERR_SECOND_SET)
 #define PMU_ERR_PLL_LOCK ((0x1FUL << 8) + PMU_ERR_SECOND_SET)
 #define PMU_ERR_CSU      ((0x1UL << 16) + PMU_ERR_SECOND_SET)
+
+#define SWDT_ZKEY            (0xABCU)
+#define SWDT_CKEY            (0x248U)
+#define SWDT_RKEY            (0x1999U)
+#define SWDT_MODE_ZKEY       (SWDT_ZKEY << 12)
+#define SWDT_MODE_WDEN       (0x1U)
+#define SWDT_MODE_RSTEN      (0x1U << 1)
+#define SWDT_MODE_RSTLN      (0x4U << 4) /* reset len = 4 -> 32 clock cycles*/
+#define SWDT_CONTROL_CKEY    (SWDT_CKEY << 14)
+#define SWDT_CONTROL_CRV_BIT (2)
+#define SWDT_CONTROL_CLKSEL  (0x2U) /* LPD_LSBUS_CLK/512 */
+#define SWDT_RESTART_RKEY    (SWDT_RKEY)
 
 
 /* clang-format off */
@@ -145,7 +157,7 @@ enum {
 typedef struct {
 	/* clang-format off */
 	enum { pctl_set = 0, pctl_get } action;
-	enum { pctl_devclock = 0, pctl_mioclock, pctl_mio, pctl_devreset, pctl_reboot } type;
+	enum { pctl_devclock = 0, pctl_mioclock, pctl_mio, pctl_devreset, pctl_reboot, pctl_wdg_config, pctl_wdg_enable } type;
 	/* clang-format on */
 	union {
 		struct {
@@ -174,6 +186,14 @@ typedef struct {
 			__u32 magic;
 			__u32 reason;
 		} reboot;
+
+		struct {
+			__u32 reload;
+		} wdg_config;
+
+		struct {
+			__u8 enable;
+		} wdg_enable;
 	};
 } __attribute__((packed)) platformctl_t;
 


### PR DESCRIPTION
## Description
This PR introduces Watchdog handlers for ZynqMP RPU

- LPD (low power domain) SWDT (Software watchdog) 
- LPD bus clock with 512 scaler used for watchdog counter
- `hal_wdgReload` is now defined
- `platformctl`: `pctl_wdg_reload` and `pctl_wdg_enable` (set new reload value, 
enable/disable respectively) are now defined

## Motivation and Context
The ZynqMP RPU targets critical application in UAV domain. By default it is configured 
to  run in lock-step. Watchdog support is required for this kind of application.s

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
