### PR TITLE
vm/map: fix shared maps allocated calculation

### DIFF
--- a/vm/map.c
+++ b/vm/map.c
@@ -1410,13 +1410,17 @@ void vm_mapinfo(meminfo_t *info)
 			}
 
 			total = (ptr_t)map->stop - (ptr_t)map->start;
-			if (map->tree.root == NULL) {
-				free = total; /* Map is empty */
+			free = total;
+
+			(void)proc_lockSet(&map->lock);
+
+			e = lib_treeof(map_entry_t, linkage, lib_rbMinimum(map->tree.root));
+			while (e != NULL) {
+				free -= e->size;
+				e = lib_treeof(map_entry_t, linkage, lib_rbNext(&e->linkage));
 			}
-			else {
-				e = lib_treeof(map_entry_t, linkage, map->tree.root);
-				free = e->lmaxgap + e->rmaxgap;
-			}
+
+			(void)proc_lockClear(&map->lock);
 
 			/* All maps together */
 			info->maps.total += total;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Implementation was overestimating allocated memory when map memory was fragmented.

TASK: RTOS-1345

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The result is used in psh `mem -s` command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
