### PR TITLE
proc: add sched_info syscall

### DIFF
--- a/include/sched.h
+++ b/include/sched.h
@@ -1,0 +1,23 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Scheduler definitions
+ *
+ * Copyright 2026 Phoenix Systems
+ * Authors: Adam Greloch
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_SCHED_H_
+#define _PH_SCHED_H_
+
+
+#define SCHED_FIFO  0
+#define SCHED_RR    1
+#define SCHED_OTHER 2
+
+
+#endif

--- a/include/sched.h
+++ b/include/sched.h
@@ -14,10 +14,21 @@
 #ifndef _PH_SCHED_H_
 #define _PH_SCHED_H_
 
+#include "types.h"
 
 #define SCHED_FIFO  0
 #define SCHED_RR    1
 #define SCHED_OTHER 2
+
+
+typedef struct {
+	time_t interval;
+	int minPriority;
+	int maxPriority;
+	union {
+		char reserved[32]; /* reserved for policy-specific values */
+	} policy;
+} sched_info_t;
 
 
 #endif

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -128,7 +128,9 @@
 	ID(sys_mprotect) \
 	\
 	ID(sys_statvfs) \
-	ID(sys_uname)
+	ID(sys_uname) \
+	ID(schedInfo)
+
 /* parasoft-end-suppress MISRAC2012-RULE_20_7-a */
 /* clang-format on */
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -2021,6 +2021,26 @@ int proc_threadsList(int n, threadinfo_t *info)
 }
 
 
+int proc_schedInfo(process_t *proc, int policy, sched_info_t *info)
+{
+	LIB_ASSERT(proc != NULL, "null proc");
+
+	if (policy < SCHED_FIFO || SCHED_OTHER < policy) {
+		return -EINVAL;
+	}
+
+	if (policy != SCHED_RR) {
+		return -ENOSYS;
+	}
+
+	info->interval = SYSTICK_INTERVAL;
+	info->minPriority = 0;
+	info->maxPriority = (int)MAX_PRIO;
+
+	return EOK;
+}
+
+
 int _threads_init(vm_map_t *kmap, vm_object_t *kernel)
 {
 	unsigned int i;

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -20,6 +20,7 @@
 #include "hal/hal.h"
 #include "lib/lib.h"
 #include "include/sysinfo.h"
+#include "include/sched.h"
 #include "process.h"
 #include "lock.h"
 
@@ -151,6 +152,9 @@ int proc_threadBroadcast(thread_t **queue);
 
 
 void proc_threadBroadcastYield(thread_t **queue);
+
+
+int proc_schedInfo(process_t *proc, int policy, sched_info_t *info);
 
 
 thread_t *threads_findThread(int tid);

--- a/syscalls.c
+++ b/syscalls.c
@@ -21,6 +21,7 @@
 #include "include/errno.h"
 #include "include/sysinfo.h"
 #include "include/mman.h"
+#include "include/sched.h"
 #include "include/syscalls.h"
 #include "include/threads.h"
 #include "include/utsname.h"
@@ -372,6 +373,35 @@ int syscalls_priority(u8 *ustack)
 	GETFROMSTACK(ustack, int, priority, 0U);
 
 	return proc_threadPriority(priority);
+}
+
+
+int syscalls_schedInfo(u8 *ustack)
+{
+	int err, policy;
+	process_t *proc;
+	pid_t pid;
+	sched_info_t *info;
+
+	GETFROMSTACK(ustack, pid_t, pid, 0U);
+	GETFROMSTACK(ustack, int, policy, 1U);
+	GETFROMSTACK(ustack, sched_info_t *, info, 2U);
+
+	proc = proc_find(pid);
+	if (proc == NULL) {
+		return -EINVAL;
+	}
+
+	if (vm_mapBelongs(proc_current()->process, info, sizeof(*info)) < 0) {
+		(void)proc_put(proc);
+		return -EINVAL;
+	}
+
+	err = proc_schedInfo(proc, policy, info);
+
+	(void)proc_put(proc);
+
+	return err;
 }
 
 


### PR DESCRIPTION
Pthreads need to validate sched_param->sched_priority values. It'd be best not to hardcode the bounds in libphoenix.

TASK: RTOS-1353

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
