### PR TITLE
syscalls: fix input validation and early return in syscalls_dispatch

### DIFF
--- a/hal/armv8m/stm32/_init.S
+++ b/hal/armv8m/stm32/_init.S
@@ -191,7 +191,7 @@ _syscall_dispatch:
 	stmdb r0!, {r1-r4}
 
 	/* Prepare arguments for function call:
-	 * void *syscalls_dispatch(int n, char *ustack, cpu_context_t *ctx) */
+	 * void *syscalls_dispatch(unsigned int n, u8 *ustack, cpu_context_t *ctx) */
 	mov r1, r0
 	mov r2, sp
 	ldrb r0, [r7, #-3] /* get syscall number by examining SVC instruction */

--- a/hal/sparcv8leon/_traps.S
+++ b/hal/sparcv8leon/_traps.S
@@ -684,7 +684,7 @@ s_fpu_done:
 	nop
 	nop
 
-	/* void *syscalls_dispatch(int n, char *ustack, cpu_context_t *ctx) */
+	/* void *syscalls_dispatch(unsigned int n, u8 *ustack, cpu_context_t *ctx) */
 	call syscalls_dispatch
 	add %sp, 0x60, %o2
 

--- a/syscalls.c
+++ b/syscalls.c
@@ -1947,12 +1947,13 @@ int syscalls_notimplemented(void)
 const void *const syscalls[] = { SYSCALLS(SYSCALLS_NAME) };
 
 
-void *syscalls_dispatch(int n, u8 *ustack, cpu_context_t *ctx)
+void *syscalls_dispatch(unsigned int n, u8 *ustack, cpu_context_t *ctx)
 {
 	void *retval;
 	thread_t *thread;
 
-	if (n >= (int)(sizeof(syscalls) / sizeof(syscalls[0]))) {
+	if (n >= sizeof(syscalls) / sizeof(syscalls[0])) {
+		threads_setupUserReturn((void *)-EINVAL, ctx);
 		return (void *)-EINVAL;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
`syscalls_dispatch` checked for bad system call number, but only for n >= <# system calls>. Since n was signed, this meant values n < 0 were allowed. Additionally, the return value was not set up on early return.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
