### PR TITLE
hal: move page size definitions to userspace accessible headers

### DIFF
--- a/hal/aarch64/arch/cpu.h
+++ b/hal/aarch64/arch/cpu.h
@@ -17,9 +17,10 @@
 #define _PH_HAL_AARCH64_CPU_H_
 
 #include "hal/types.h"
+#include "include/page.h"
 #include "config.h"
 
-#define SIZE_PAGE 0x1000UL
+#define SIZE_PAGE _PAGE_SIZE
 #define SIZE_PDIR SIZE_PAGE
 
 #define SIZE_INITIAL_KSTACK (2U * SIZE_PAGE) /* Must be multiple of page size */

--- a/hal/armv7a/arch/cpu.h
+++ b/hal/armv7a/arch/cpu.h
@@ -17,9 +17,10 @@
 #define _PH_HAL_ARMV7A_CPU_H_
 
 #include "hal/types.h"
+#include "include/page.h"
 #include "config.h"
 
-#define SIZE_PAGE 0x1000U
+#define SIZE_PAGE _PAGE_SIZE
 #define SIZE_PDIR 0x2000U
 
 #ifndef SIZE_KSTACK

--- a/hal/armv7m/arch/cpu.h
+++ b/hal/armv7m/arch/cpu.h
@@ -26,8 +26,9 @@
 #endif
 
 #include "hal/types.h"
+#include "include/page.h"
 
-#define SIZE_PAGE 0x200U
+#define SIZE_PAGE _PAGE_SIZE
 
 #ifndef SIZE_USTACK
 #define SIZE_USTACK (3U * SIZE_PAGE)

--- a/hal/armv7r/arch/cpu.h
+++ b/hal/armv7r/arch/cpu.h
@@ -16,7 +16,9 @@
 #ifndef _PH_HAL_ARMV7R_CPU_H_
 #define _PH_HAL_ARMV7R_CPU_H_
 
-#define SIZE_PAGE 0x1000U
+#include "include/page.h"
+
+#define SIZE_PAGE _PAGE_SIZE
 
 #define SIZE_INITIAL_KSTACK  SIZE_PAGE
 #define INITIAL_KSTACK_SHIFT 12U

--- a/hal/armv8m/arch/cpu.h
+++ b/hal/armv8m/arch/cpu.h
@@ -17,8 +17,9 @@
 #define _PH_HAL_ARMV8M_CPU_H_
 
 #include "hal/types.h"
+#include "include/page.h"
 
-#define SIZE_PAGE 0x200U
+#define SIZE_PAGE _PAGE_SIZE
 
 #ifndef SIZE_USTACK
 #define SIZE_USTACK (3U * SIZE_PAGE)

--- a/hal/armv8r/arch/cpu.h
+++ b/hal/armv8r/arch/cpu.h
@@ -16,7 +16,9 @@
 #ifndef _PH_HAL_ARMV8R_CPU_H_
 #define _PH_HAL_ARMV8R_CPU_H_
 
-#define SIZE_PAGE 0x1000U
+#include "include/page.h"
+
+#define SIZE_PAGE _PAGE_SIZE
 
 #define SIZE_INITIAL_KSTACK  SIZE_PAGE
 #define INITIAL_KSTACK_SHIFT 12U

--- a/hal/ia32/arch/cpu.h
+++ b/hal/ia32/arch/cpu.h
@@ -17,10 +17,10 @@
 #ifndef _PH_HAL_IA32_CPU_H_
 #define _PH_HAL_IA32_CPU_H_
 
+#include "include/page.h"
 #include "hal/types.h"
 
-#define SIZE_PAGE 0x1000U
-
+#define SIZE_PAGE _PAGE_SIZE
 
 /* Default kernel and user stack sizes */
 #ifndef SIZE_KSTACK

--- a/hal/riscv64/arch/cpu.h
+++ b/hal/riscv64/arch/cpu.h
@@ -17,8 +17,9 @@
 #define _PH_HAL_RISCV64_CPU_H_
 
 #include "hal/types.h"
+#include "include/page.h"
 
-#define SIZE_PAGE 0x1000UL
+#define SIZE_PAGE _PAGE_SIZE
 
 #define MAX_CPU_COUNT 8U
 

--- a/hal/sparcv8leon/arch/cpu.h
+++ b/hal/sparcv8leon/arch/cpu.h
@@ -16,10 +16,11 @@
 #ifndef _PH_HAL_LEON3_CPU_H_
 #define _PH_HAL_LEON3_CPU_H_
 
+#include "include/page.h"
+
+#define SIZE_PAGE _PAGE_SIZE
 
 #ifdef NOMMU
-
-#define SIZE_PAGE 0x200U
 
 /* Default kernel and user stack sizes */
 #ifndef SIZE_KSTACK
@@ -31,8 +32,6 @@
 #endif
 
 #else
-
-#define SIZE_PAGE 0x1000U
 
 /* Default kernel and user stack sizes */
 #ifndef SIZE_KSTACK

--- a/include/arch/aarch64/page.h
+++ b/include/arch/aarch64/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - AArch64
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_AARCH64_PAGE_H_
+#define _PH_ARCH_AARCH64_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_AARCH64_PAGE_H_ */

--- a/include/arch/armv7a/page.h
+++ b/include/arch/armv7a/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - ARMv7a
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_ARMV7A_PAGE_H_
+#define _PH_ARCH_ARMV7A_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_ARMV7A_PAGE_H_ */

--- a/include/arch/armv7m/page.h
+++ b/include/arch/armv7m/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - ARMv7m
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_ARMV7M_PAGE_H_
+#define _PH_ARCH_ARMV7M_PAGE_H_
+
+#define _PAGE_SHIFT 9U
+
+#endif /* _PH_ARCH_ARMV7M_PAGE_H_ */

--- a/include/arch/armv7r/page.h
+++ b/include/arch/armv7r/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - ARMv7r
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_ARMV7R_PAGE_H_
+#define _PH_ARCH_ARMV7R_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_ARMV7R_PAGE_H_ */

--- a/include/arch/armv8m/page.h
+++ b/include/arch/armv8m/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - ARMv8m
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_ARMV8M_PAGE_H_
+#define _PH_ARCH_ARMV8M_PAGE_H_
+
+#define _PAGE_SHIFT 9U
+
+#endif /* _PH_ARCH_ARMV8M_PAGE_H_ */

--- a/include/arch/armv8r/page.h
+++ b/include/arch/armv8r/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - ARMv8r
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_ARMV8R_PAGE_H_
+#define _PH_ARCH_ARMV8R_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_ARMV8R_PAGE_H_ */

--- a/include/arch/ia32/page.h
+++ b/include/arch/ia32/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - IA-32
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_IA32_PAGE_H_
+#define _PH_ARCH_IA32_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_IA32_PAGE_H_ */

--- a/include/arch/riscv64/page.h
+++ b/include/arch/riscv64/page.h
@@ -1,0 +1,19 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - RISC-V
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_RISCV64_PAGE_H_
+#define _PH_ARCH_RISCV64_PAGE_H_
+
+#define _PAGE_SHIFT 12U
+
+#endif /* _PH_ARCH_RISCV64_PAGE_H_ */

--- a/include/arch/sparcv8leon/page.h
+++ b/include/arch/sparcv8leon/page.h
@@ -1,0 +1,23 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page shift definition - SPARC
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_ARCH_LEON3_PAGE_H_
+#define _PH_ARCH_LEON3_PAGE_H_
+
+#ifdef NOMMU
+#define _PAGE_SHIFT 9U
+#else
+#define _PAGE_SHIFT 12U
+#endif
+
+#endif

--- a/include/page.h
+++ b/include/page.h
@@ -1,0 +1,51 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * Page size definition
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Michal Lach
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _PH_PAGE_H_
+#define _PH_PAGE_H_
+
+#if defined(__i386__) || defined(__x86_64__)
+#include "arch/ia32/page.h"
+#elif defined(__ARM_ARCH_6M__) || defined(__ARM_ARCH_7M__) || defined(__ARM_ARCH_7EM__)
+#include "arch/armv7m/page.h"
+#elif defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A__) || defined(__ARM_ARCH_7__)
+#include "arch/armv7a/page.h"
+#elif defined(__ARM_ARCH_7R__)
+#include "arch/armv7r/page.h"
+#elif defined(__ARM_ARCH_4T__) || defined(__ARM_ARCH_5TE__)
+#include "arch/armv7m/page.h"
+#elif defined(__ARM_ARCH_8M_BASE__) || defined(__ARM_ARCH_8M_MAIN__)
+#include "arch/armv8m/page.h"
+#elif defined(__ARM_ARCH_8R__)
+#include "arch/armv8r/page.h"
+#elif defined(__aarch64__)
+#include "arch/aarch64/page.h"
+/* parasoft-begin-suppress MISRAC2012-RULE_20_9 "macro defined in riscv architecture,
+ * we won't check value of __riscv_xlen if __riscv is not defined"
+ */
+#elif defined(__riscv) && (__riscv_xlen == 64)
+#include "arch/riscv64/page.h"
+/*parasoft-end-suppress MISRAC2012-RULE_20_9*/
+#elif defined(__sparc__)
+#include "arch/sparcv8leon/page.h"
+#else
+#error "unsupported architecture"
+#endif
+
+#ifndef _PAGE_SHIFT
+#error "_PAGE_SHIFT is undefined for target architecture"
+#endif
+
+#define _PAGE_SIZE (1UL << _PAGE_SHIFT)
+
+#endif /* _PH_PAGE_H_ */


### PR DESCRIPTION
We currently define SIZE_PAGE in the kernel and _PAGE_SIZE in the userspace independently of eachother, which should not be the case.

Additionally, page size is now defined to be a bitshift of PAGE_SHIFT bits. Shift value is sometimes used by thirdparty software (see JFFS2) and PAGE_SHIFT is Linux-compatible, so that might make porting some software a bit easier.

JIRA: RTOS-1358
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- https://github.com/phoenix-rtos/libphoenix/pull/486
- https://github.com/phoenix-rtos/phoenix-rtos-filesystems/pull/166
- [x] I will merge this PR by myself when appropriate.
