### PR TITLE
proc/threads: preserve priority inheritance for SMP

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -1520,7 +1520,7 @@ static int _proc_lockSet(lock_t *lock, u8 interruptible, spinlock_ctx_t *scp)
 {
 	thread_t *current;
 	spinlock_ctx_t sc;
-	int ret = EOK, tid;
+	int ret = EOK, err = EOK, tid;
 
 	hal_spinlockSet(&threads_common.spinlock, &sc);
 
@@ -1547,11 +1547,10 @@ static int _proc_lockSet(lock_t *lock, u8 interruptible, spinlock_ctx_t *scp)
 			_proc_threadSetPriority(lock->owner, current->priority);
 		}
 
-		hal_spinlockClear(&threads_common.spinlock, &sc);
-
-		do {
+		for (;;) {
 			/* _proc_lockUnlock will give us a lock by it's own */
-			if (proc_threadWaitEx(&lock->queue, &lock->spinlock, 0, interruptible, scp) == -EINTR) {
+			if ((interruptible != 0U) && ((current->exit != 0U) || (err == -EINTR))) {
+				hal_spinlockClear(&threads_common.spinlock, &sc);
 				/* Can happen when thread_destroy is called on lock owner and current */
 				if (lock->owner == NULL) {
 					ret = -EINTR;
@@ -1572,7 +1571,18 @@ static int _proc_lockSet(lock_t *lock, u8 interruptible, spinlock_ctx_t *scp)
 					return ret;
 				}
 			}
-		} while (lock->owner != current);
+			else {
+				_proc_threadEnqueue(&lock->queue, 0, interruptible);
+				hal_spinlockClear(&lock->spinlock, &sc);
+				err = hal_cpuReschedule(&threads_common.spinlock, scp);
+				hal_spinlockSet(&lock->spinlock, scp);
+			}
+
+			if (lock->owner == current) {
+				break;
+			}
+			hal_spinlockSet(&threads_common.spinlock, &sc);
+		}
 
 		/* we acquired the lock */
 		lock->depth = 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Potential priority inheritance race can occur on SMP when contender bumps owner priority while waiting for a lock, but owner releases another lock, before contender was added to lock waiting queue.
This solution just rips `proc_threadWaitEx()` so thread_common spinlock is not released before contender is added to lock waiting queue. Without some priority inheritance structures (like tree) this is the smallest amount of fixing source code I could come up with, although not very elegant. Feel free to share another ideas.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes phoenix-rtos/phoenix-rtos-project#1626

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-qemu.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
