### PR TITLE
perf: fix event discarding when not in rolling window mode

### DIFF
--- a/perf/buffer-mem.c
+++ b/perf/buffer-mem.c
@@ -146,8 +146,8 @@ ssize_t _trace_bufferWrite(u8 chan, const void *data, size_t sz)
 
 int _trace_bufferWaitUntilAvail(u8 chan, size_t sz)
 {
-	/* overwrite intentionally to prevent deadlock */
-	return 0;
+	/* not supported to prevent deadlock */
+	return -ENOSYS;
 }
 
 

--- a/perf/buffer-mem.c
+++ b/perf/buffer-mem.c
@@ -30,6 +30,10 @@
 #endif
 
 
+_Static_assert((TRACE_EVENT_CHANNEL_BUFSIZE & (SIZE_PAGE - 1U)) == 0U, "TRACE_EVENT_CHANNEL_BUFSIZE must be page aligned");
+_Static_assert((TRACE_META_CHANNEL_BUFSIZE & (SIZE_PAGE - 1U)) == 0U, "TRACE_META_CHANNEL_BUFSIZE must be page aligned");
+
+
 typedef struct {
 	cbuffer_t buffer;
 	page_t *pages;

--- a/perf/trace.c
+++ b/perf/trace.c
@@ -49,6 +49,7 @@ static struct {
 #define TRACE_NON_MONOTONICITY (1U << 1)
 #define TRACE_EVENT_DELAYED    (1U << 2)
 #define TRACE_BUFFER_WRITE_ERR (1U << 3)
+#define TRACE_EVENT_DISCARDED  (1U << 4)
 
 
 static u32 _getUsFromStart(void)
@@ -104,6 +105,10 @@ static void _writeEvent(u8 cpuChan, u8 event, const void *data, size_t sz, u32 *
 		}
 		else {
 			try = _trace_bufferWaitUntilAvail(chan, eventSz);
+			if (try < 0) {
+				trace_common.errorFlags |= TRACE_EVENT_DISCARDED;
+				return;
+			}
 		}
 	}
 
@@ -326,6 +331,10 @@ int trace_finish(void)
 
 		if ((errorFlags & TRACE_BUFFER_WRITE_ERR) != 0U) {
 			lib_printf("kernel (%s:%d): buffer write error detected\n", __func__, __LINE__);
+		}
+
+		if ((errorFlags & TRACE_EVENT_DISCARDED) != 0U) {
+			lib_printf("kernel (%s:%d): event discard detected\n", __func__, __LINE__);
 		}
 
 		ret = _trace_bufferFinish();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Returning 0 from _trace_bufferWaitUntilAvail() would cause the _writeEvent() to silently write partial events, thus corrupting the trace.

TASK: RTOS-1359

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
