### PR TITLE
posix: implement pid == -1 and pid == 0 cases for kill

### DIFF
--- a/posix/posix.c
+++ b/posix/posix.c
@@ -2515,17 +2515,28 @@ static int posix_killOne(pid_t pid, int tid, int sig)
 }
 
 
-static int posix_killGroup(pid_t pgid, int sig)
+enum killMode { tkill_group, tkill_all };
+
+
+static int posix_killMulti(enum killMode mode, pid_t pgid, int sig)
 {
 	process_info_t *pinfo;
 	rbnode_t *node;
+	pid_t selfPid = process_getPid(proc_current()->process);
 
 	(void)proc_lockSet(&posix_common.lock);
 	for (node = lib_rbMinimum(posix_common.pid.root); node != NULL; node = lib_rbNext(node)) {
 		pinfo = lib_treeof(process_info_t, linkage, node);
 
-		if (pinfo->pgid == pgid) {
-			(void)proc_sigpost(pinfo->process, sig);
+		if (mode == tkill_group) {
+			if (pinfo->pgid == pgid) {
+				(void)proc_sigpost(pinfo->process, sig);
+			}
+		}
+		else {
+			if ((pinfo->process != 1) && (pinfo->process != selfPid)) {
+				(void)proc_sigpost(pinfo->process, sig);
+			}
 		}
 	}
 	(void)proc_lockClear(&posix_common.lock);
@@ -2536,22 +2547,32 @@ static int posix_killGroup(pid_t pgid, int sig)
 
 int posix_tkill(pid_t pid, int tid, int sig)
 {
+	process_info_t *pinfo;
+	pid_t myPgid;
+
 	TRACE("tkill(%p, %d, %d)", pid, tid, sig);
 
 	if ((sig < 0) || (sig > NSIG)) {
 		return -EINVAL;
 	}
 
-	/* TODO: handle pid = 0 */
 	if (pid == 0) {
-		return -ENOSYS;
+		pinfo = pinfo_find(process_getPid(proc_current()->process));
+		if (pinfo == NULL) {
+			return -ESRCH;
+		}
+
+		myPgid = pinfo->pgid;
+		pinfo_put(pinfo);
+
+		return posix_killMulti(tkill_group, myPgid, sig);
 	}
 
 	if (pid == -1) {
-		return -ESRCH;
+		return posix_killMulti(tkill_all, 0, sig);
 	}
 
-	return (pid > 0) ? posix_killOne(pid, tid, sig) : posix_killGroup(-pid, sig);
+	return (pid > 0) ? posix_killOne(pid, tid, sig) : posix_killMulti(tkill_group, -pid, sig);
 }
 
 


### PR DESCRIPTION
## Description
Implements the `pid == -1` and `pid == 0` cases for `kill`/`tkill` per POSIX.1-2017:

- `pid == 0`: sends the signal to all processes sharing the caller's process group (reuses existing `posix_killGroup`).
- `pid == -1`: sends the signal to all processes (new `posix_killAll` function, following the same loop pattern as `posix_killGroup`).

Note: neither case performs additional permission checks beyond what `posix_killGroup` already does, since the kernel doesn't currently track per-process signal permissions. Happy to adjust if you'd like something different here.

## Motivation and Context
Previously, `kill(0, sig)` returned `-ENOSYS` and `kill(-1, sig)` returned `-ESRCH`, both were unimplemented (marked with a TODO in the code) rather than following POSIX-defined behavior.

Fixes #1692

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Tested by hand on: ia32-generic-qemu (compiles cleanly; behavioral testing pending — planning to add a test case per phoenix-rtos-tests, tracked separately)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment
- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
