### PR TITLE
hal/{aarch64,arm}: fix possible race condition in hal_cpuReschedule

### DIFF
--- a/hal/aarch64/_exceptions.S
+++ b/hal/aarch64/_exceptions.S
@@ -220,22 +220,30 @@ _syscalls_dispatch:
 	bic X_SPSR_EL1, X_SPSR_EL1, #NO_INT /* Re-enable interrupts in the caller */
 	str X_SPSR_EL1, [sp, 0x220]
 
-	ldr x2, [sp, #0x230]  /* Load x0 -> pointer to spinlock */
-	cbz x2, 1f /* If pointer not NULL, clear the spinlock - but don't restore the DAIF */
-	mov w1, #1
-	stlrb w1, [x2] /* Global monitor clear generates an event, SEV not necessary */
-1:
+	ldr x19, [sp, #0x230]  /* Load x0 -> pointer to spinlock */
+	mov x1, sp            /* argument to function - cpu_context_t* */
 	str xzr, [sp, #0x230] /* Store 0 into x0 as return value (EOK) */
+	cbz x19, .Lno_spinlock
 
-	mov x1, sp /* argument to function - cpu_context_t* */
+	bl _threads_schedule
+	ldr x1, [sp] /* Load pointer to new context (must be done BEFORE clearing spinlock) */
 
+	/* Clear the given spinlock */
+	mov w0, #1
+	stlrb w0, [x19] /* Global monitor clear generates an event, SEV not necessary */
+	b .Lcontext_ready
+
+.Lno_spinlock:
 	/* Arguments to threads_schedule:
 	 * * x0 - n (unused)
 	 * * x1 - pointer to CPU context
 	 * * x2 - arg (unused)*/
 	bl threads_schedule
+	ldr x1, [sp] /* Load pointer to new context */
 
-	ldr x1, [sp]
+.Lcontext_ready:
+	/* NOTE: at this point our stack pointer may be invalid (e.g. if this is the ending of exit() syscall)
+	 * No code beyond this point until `eret` may use the stack! */
 	unlock_scheduler x0
 	b _hal_cpuRestoreCtx
 .size _exceptions_dispatch, .-_exceptions_dispatch

--- a/hal/armv7a/_interrupts.S
+++ b/hal/armv7a/_interrupts.S
@@ -159,14 +159,11 @@ hal_cpuReschedule:
 
 	mrs r4, cpsr
 
-	/* If spinlock not NULL, clear it */
+	/* If spinlock was given, restore spinlock context into SPSR */
 	cmp r0, #0
 	beq 1f
-	mov r3, #1
-	dmb
-	strb r3, [r0]
-	ldr r1, [r1]
 
+	ldr r1, [r1]
 	bic r4, #0xff
 	and r1, #0xff
 	orr r4, r4, r1
@@ -179,13 +176,28 @@ hal_cpuReschedule:
 
 	push_fpu_state r4
 
-	sub r1, sp, #8
+	sub r1, sp, #8 /* argument to function - cpu_context_t* */
 	push {r1}
 	push {r1}
 
+	movs r4, r0
+	beq .Lno_spinlock
+
+	/* Call the non-locked version of threads_schedule */
+	blx _threads_schedule
+	ldr sp, [sp] /* Load pointer to new context (must be done BEFORE clearing spinlock) */
+
+	/* Clear the given spinlock */
+	mov r0, #1
+	dmb
+	strb r0, [r4]
+	b .Lcontext_ready
+
+.Lno_spinlock:
 	blx threads_schedule
+	ldr sp, [sp] /* Load pointer to new context */
 
-	ldr sp, [sp]
+.Lcontext_ready:
 	add sp, sp, #8
 
 	unlock_scheduler

--- a/hal/armv7r/_interrupts.S
+++ b/hal/armv7r/_interrupts.S
@@ -155,14 +155,11 @@ hal_cpuReschedule:
 
 	mrs r4, cpsr
 
-	/* If spinlock not NULL, clear it */
+	/* If spinlock was given, restore spinlock context into SPSR */
 	cmp r0, #0
 	beq 1f
-	mov r3, #1
-	dmb
-	strb r3, [r0]
-	ldr r1, [r1]
 
+	ldr r1, [r1]
 	bic r4, #0xff
 	and r1, #0xff
 	orr r4, r4, r1
@@ -175,13 +172,28 @@ hal_cpuReschedule:
 
 	push_fpu_state r4
 
-	sub r1, sp, #8
+	sub r1, sp, #8 /* argument to function - cpu_context_t* */
 	push {r1}
 	push {r1}
 
+	movs r4, r0
+	beq .Lno_spinlock
+
+	/* Call the non-locked version of threads_schedule */
+	blx _threads_schedule
+	ldr sp, [sp] /* Load pointer to new context (must be done BEFORE clearing spinlock) */
+
+	/* Clear the given spinlock */
+	mov r0, #1
+	dmb
+	strb r0, [r4]
+	b .Lcontext_ready
+
+.Lno_spinlock:
 	blx threads_schedule
+	ldr sp, [sp] /* Load pointer to new context */
 
-	ldr sp, [sp]
+.Lcontext_ready:
 	add sp, sp, #8
 
 	unlock_scheduler

--- a/hal/armv8r/_interrupts.S
+++ b/hal/armv8r/_interrupts.S
@@ -159,14 +159,11 @@ hal_cpuReschedule:
 
 	mrs r4, cpsr
 
-	/* If spinlock not NULL, clear it */
+	/* If spinlock was given, restore spinlock context into SPSR */
 	cmp r0, #0
 	beq 1f
-	mov r3, #1
-	dmb
-	strb r3, [r0]
-	ldr r1, [r1]
 
+	ldr r1, [r1]
 	bic r4, #0xff
 	and r1, #0xff
 	orr r4, r4, r1
@@ -179,13 +176,28 @@ hal_cpuReschedule:
 
 	push_fpu_state r4
 
-	sub r1, sp, #8
+	sub r1, sp, #8 /* argument to function - cpu_context_t* */
 	push {r1}
 	push {r1}
 
+	movs r4, r0
+	beq .Lno_spinlock
+
+	/* Call the non-locked version of threads_schedule */
+	blx _threads_schedule
+	ldr sp, [sp] /* Load pointer to new context (must be done BEFORE clearing spinlock) */
+
+	/* Clear the given spinlock */
+	mov r0, #1
+	dmb
+	strb r0, [r4]
+	b .Lcontext_ready
+
+.Lno_spinlock:
 	blx threads_schedule
+	ldr sp, [sp] /* Load pointer to new context */
 
-	ldr sp, [sp]
+.Lcontext_ready:
 	add sp, sp, #8
 
 	unlock_scheduler

--- a/hal/cpu.h
+++ b/hal/cpu.h
@@ -84,6 +84,14 @@ void hal_cpuSetGot(void *got);
 int hal_cpuCreateContext(cpu_context_t **nctx, startFn_t start, void *kstack, size_t kstacksz, void *ustack, void *arg, struct _hal_tls_t *tls);
 
 
+/*
+ * Perform a voluntary reschedule.
+ * Function may be called under the `threads_common.spinlock`. In that case, pointer to this spinlock
+ * must be given in the argument - the spinlock will be cleared once reschedule is performed.
+ *
+ * * spinlock - must be either NULL or `&threads_common.spinlock`.
+ * * scp - pointer to spinlock context. Must not be NULL if `spinlock` is not NULL.
+ */
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Definition in assembly code" */
 int hal_cpuReschedule(struct _spinlock_t *spinlock, spinlock_ctx_t *scp);
 


### PR DESCRIPTION
Fix a possible race condition between `hal_cpuReschedule` and `proc_reap`.

## Description
A race condition has been identified in `hal_cpuReschedule` implementation on aarch64 and armv7a that can manifest itself at the end of the `exit` syscall.

The unwanted interleave starts when `hal_cpuReschedule`, is called at the end of handling the `exit` syscall on core A. Within the function the spinlock is cleared, then on core B the thread running the `proc_reap` function is woken up. `proc_reap` then proceeds to free the resources belonging to the exited thread, including unmapping its kernel stack. However, the kernel stack is still in use by core A. This results in either:

1. An infinite loop of exception handling: the first step of exception handling involves pushing registers onto the stack - the stack is inaccessible due to being unmapped - this causes another exception in an infinite loop.
2. If another thread's kernel stack is mapped into the same memory various other errors may occur - e.g. core A handling the exception from step 1 may corrupt the stack contents of another kernel thread or core A may try to restore from an invalid stored state.

The issue is most pronounced on `aarch64a53-zynqmp-qemu` due to the fact that it uses spinlocks with `wfe`/ `sev` and emulation can execute large chunks of code from one CPU before switching to another.

On `armv7a-zynq7000-qemu` this may not occur due to the fact that emulation is done on many cores in parallel and spinlocks don't use `wfe` / `sev`.

On real hardware this may not occur very frequently due to code being executed in parallel, so the first CPU always "wins the race".

The fact that `exit` is called frequently within the test suite increases the likelihood of hitting this unwanted interleave - which is why the issue occurs frequently in testing, but seemingly not in practical applications on that platform.

The fix from `armv7a` was also applied to `armv7r` and `armv8r` for consistency - even though these platforms don't work in SMP so this race condition will never occur.

On `ia32` and `riscv64` platforms the implementation of `hal_cpuReschedule` is different and not susceptible to this error.

## Motivation and Context
May fix https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1386 and https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1387 - needs more testing

YT: RTOS-1392

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: aarch64a53-zynqmp-qemu, armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
