### PR TITLE
vm/map: Message buffers memory safety

### DIFF
--- a/include/mman.h
+++ b/include/mman.h
@@ -16,7 +16,7 @@
 
 
 #define MAP_NONE       0x0U
-#define MAP_NEEDSCOPY  (0x1U << 0)
+#define MAP_ALL        ~(0x1U)
 #define MAP_UNCACHED   (0x1U << 1)
 #define MAP_DEVICE     (0x1U << 2)
 #define MAP_NOINHERIT  (0x1U << 3)

--- a/proc/msg-nommu.c
+++ b/proc/msg-nommu.c
@@ -174,7 +174,7 @@ int proc_recv(u32 port, msg_t *msg, msg_rid_t *rid)
 			(pmap_isAllowed(current->process->pmapp, kmsg->msg->i.data, kmsg->msg->i.size) == 0)) {
 
 		idata = vm_mmap(current->process->mapp, NULL, NULL, round_page(kmsg->msg->i.size),
-				PROT_READ | PROT_USER, NULL, -1, MAP_ANONYMOUS);
+				PROT_READ | PROT_USER, NULL, -1, MAP_ANONYMOUS, 0U);
 		if (idata == NULL) {
 			/* Free RID */
 			(void)proc_portRidGet(p, *rid);
@@ -190,7 +190,7 @@ int proc_recv(u32 port, msg_t *msg, msg_rid_t *rid)
 			(pmap_isAllowed(current->process->pmapp, kmsg->msg->o.data, kmsg->msg->o.size) == 0)) {
 
 		msg->o.data = vm_mmap(current->process->mapp, NULL, NULL, round_page(kmsg->msg->o.size),
-				PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_ANONYMOUS);
+				PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_ANONYMOUS, 0U);
 		if (msg->o.data == NULL) {
 			if (idata != NULL) {
 				(void)vm_munmap(current->process->mapp, idata, round_page(kmsg->msg->i.size));

--- a/proc/msg.c
+++ b/proc/msg.c
@@ -36,7 +36,7 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 	void *w = NULL, *vaddr;
 	size_t boffs, eoffs;
 	u8 bone, eone;
-	size_t n = 0, i;
+	size_t n = 0;
 	vm_attr_t attr;
 	vm_prot_t prot;
 	page_t *nep = NULL, *nbp = NULL;
@@ -44,7 +44,7 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 	struct _kmsg_layout_t *ml = (dir != 0) ? &kmsg->o : &kmsg->i;
 	int err;
 	vm_flags_t flags;
-	addr_t bpa, pa, epa;
+	addr_t bpa, epa;
 
 	if ((size == 0U) || (data == NULL)) {
 		return NULL;
@@ -138,12 +138,16 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 	/* Map pages */
 	vaddr = (void *)CEIL((ptr_t)data);
 
-	for (i = 0; i < n; i++) {
-		pa = pmap_resolve(&srcmap->pmap, vaddr) & ~(SIZE_PAGE - 1U);
-		if (page_map(&dstmap->pmap, w + (i + bone) * SIZE_PAGE, pa, attr) < 0) {
+	if (n > 0U) {
+		if (pmap_belongs(&srcmap->pmap, data) != 0) {
+			err = vm_mapBorrow(dstmap, w + bone * SIZE_PAGE, srcmap, vaddr, n * SIZE_PAGE, prot);
+		}
+		else {
+			err = vm_mapBorrow(dstmap, w + bone * SIZE_PAGE, msg_common.kmap, vaddr, n * SIZE_PAGE, prot);
+		}
+		if (err < 0) {
 			return NULL;
 		}
-		vaddr += SIZE_PAGE;
 	}
 
 	if (eoffs != 0U) {

--- a/proc/msg.c
+++ b/proc/msg.c
@@ -117,7 +117,7 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 			return NULL;
 		}
 
-		vaddr = vm_mmap(msg_common.kmap, NULL, NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, VM_OBJ_PHYSMEM, (off_t)bpa, flags);
+		vaddr = vm_mmap(msg_common.kmap, NULL, NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, VM_OBJ_PHYSMEM, (off_t)bpa, flags, 0U);
 		ml->bvaddr = vaddr;
 		if (vaddr == NULL) {
 			return NULL;
@@ -166,7 +166,7 @@ static void *msg_map(int dir, kmsg_t *kmsg, void *data, size_t size, process_t *
 			nep = nbp;
 		}
 
-		vaddr = vm_mmap(msg_common.kmap, NULL, NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, VM_OBJ_PHYSMEM, (off_t)epa, flags);
+		vaddr = vm_mmap(msg_common.kmap, NULL, NULL, SIZE_PAGE, PROT_READ | PROT_WRITE, VM_OBJ_PHYSMEM, (off_t)epa, flags, 0U);
 		ml->evaddr = vaddr;
 		if (vaddr == NULL) {
 			return NULL;

--- a/proc/process.c
+++ b/proc/process.c
@@ -501,7 +501,7 @@ static int process_load32(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 	size_t memsz, filesz, misalign;
 	unsigned int i;
 	vm_prot_t prot;
-	vm_flags_t flags;
+	vm_state_t state;
 	off_t offs;
 	char *snameTab;
 
@@ -550,7 +550,7 @@ static int process_load32(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 		memsz = (size_t)(u32)(phdr->p_memsz + misalign);
 
 		prot = PROT_USER;
-		flags = MAP_NONE;
+		state = 0U;
 
 		if ((phdr->p_flags & PF_R) != 0U) {
 			prot |= PROT_READ;
@@ -565,15 +565,15 @@ static int process_load32(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 		}
 
 		if ((filesz != 0U) && ((prot & PROT_WRITE) != 0U)) {
-			flags |= MAP_NEEDSCOPY;
+			state |= ENTRY_NEEDSCOPY;
 		}
 
-		if ((filesz != 0U) && (vm_mmap(map, vaddr, NULL, round_page(filesz), prot, o, base + offs, flags) == NULL)) {
+		if ((filesz != 0U) && (vm_mmap(map, vaddr, NULL, round_page(filesz), prot, o, base + offs, MAP_NONE, state) == NULL)) {
 			return -ENOMEM;
 		}
 
 		if (filesz != memsz) {
-			if ((round_page(memsz) != round_page(filesz)) && (vm_mmap(map, vaddr, NULL, round_page(memsz) - round_page(filesz), prot, NULL, -1, MAP_NONE) == NULL)) {
+			if ((round_page(memsz) != round_page(filesz)) && (vm_mmap(map, vaddr, NULL, round_page(memsz) - round_page(filesz), prot, NULL, -1, MAP_NONE, 0U) == NULL)) {
 				return -ENOMEM;
 			}
 
@@ -593,7 +593,7 @@ static int process_load64(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 	Elf64_Phdr *phdr;
 	Elf64_Shdr *shdr, *shstrshdr;
 	vm_prot_t prot;
-	vm_flags_t flags;
+	vm_state_t state;
 	off_t offs;
 	char *snameTab;
 
@@ -642,7 +642,7 @@ static int process_load64(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 		memsz = (size_t)phdr->p_memsz + misalign;
 
 		prot = PROT_USER;
-		flags = MAP_NONE;
+		state = 0U;
 
 		if ((phdr->p_flags & PF_R) != 0U) {
 			prot |= PROT_READ;
@@ -657,15 +657,15 @@ static int process_load64(vm_map_t *map, vm_object_t *o, off_t base, void *iehdr
 		}
 
 		if ((filesz != 0U) && ((prot & PROT_WRITE) != 0U)) {
-			flags |= MAP_NEEDSCOPY;
+			state |= ENTRY_NEEDSCOPY;
 		}
 
-		if ((filesz != 0U) && (vm_mmap(map, vaddr, NULL, round_page(filesz), prot, o, base + offs, flags) == NULL)) {
+		if ((filesz != 0U) && (vm_mmap(map, vaddr, NULL, round_page(filesz), prot, o, base + offs, MAP_NONE, state) == NULL)) {
 			return -ENOMEM;
 		}
 
 		if (filesz != memsz) {
-			if ((round_page(memsz) != round_page(filesz)) && (vm_mmap(map, vaddr, NULL, round_page(memsz) - round_page(filesz), prot, NULL, -1, MAP_NONE) == NULL)) {
+			if ((round_page(memsz) != round_page(filesz)) && (vm_mmap(map, vaddr, NULL, round_page(memsz) - round_page(filesz), prot, NULL, -1, MAP_NONE, 0U) == NULL)) {
 				return -ENOMEM;
 			}
 
@@ -695,7 +695,7 @@ static int process_load(process_t *process, vm_object_t *o, off_t base, size_t s
 
 	size = round_page(size);
 
-	ehdr = vm_mmap(process_common.kmap, NULL, NULL, size, PROT_READ, o, base, MAP_NONE);
+	ehdr = vm_mmap(process_common.kmap, NULL, NULL, size, PROT_READ, o, base, MAP_NONE, 0U);
 	if (ehdr == NULL) {
 		return -ENOMEM;
 	}
@@ -726,7 +726,7 @@ static int process_load(process_t *process, vm_object_t *o, off_t base, size_t s
 	process_tlsAssign(&process->tls, &tlsNew, tbssAddr);
 
 	/* Allocate and map user stack */
-	stack = vm_mmap(map, map->pmap.end - ustacksz, NULL, ustacksz, PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_NONE);
+	stack = vm_mmap(map, map->pmap.end - ustacksz, NULL, ustacksz, PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_NONE, 0U);
 	if (stack == NULL) {
 		return -ENOMEM;
 	}
@@ -827,7 +827,7 @@ static int process_load(process_t *process, vm_object_t *o, off_t base, size_t s
 			if ((process->imapp != NULL) &&
 					(((ptr_t)base < (ptr_t)process->imapp->start) ||
 							((ptr_t)base > (ptr_t)process->imapp->stop))) {
-				paddr = vm_mmap(process->imapp, NULL, NULL, round_page(phdrCurr->p_memsz), prot, NULL, -1, flags);
+				paddr = vm_mmap(process->imapp, NULL, NULL, round_page(phdrCurr->p_memsz), prot, NULL, -1, flags, 0U);
 				if (paddr == NULL) {
 					return -ENOMEM;
 				}
@@ -844,7 +844,7 @@ static int process_load(process_t *process, vm_object_t *o, off_t base, size_t s
 
 			reloffs = phdrCurr->p_vaddr % SIZE_PAGE;
 
-			paddr = vm_mmap(process->mapp, NULL, NULL, round_page(phdrCurr->p_memsz + reloffs), prot, NULL, -1, flags);
+			paddr = vm_mmap(process->mapp, NULL, NULL, round_page(phdrCurr->p_memsz + reloffs), prot, NULL, -1, flags, 0U);
 			if (paddr == NULL) {
 				return -ENOMEM;
 			}
@@ -988,7 +988,7 @@ static int process_load(process_t *process, vm_object_t *o, off_t base, size_t s
 	process_tlsAssign(&process->tls, &tlsNew, tbssAddr);
 
 	/* Allocate and map user stack */
-	stack = vm_mmap(process->mapp, NULL, NULL, stacksz, PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_NONE);
+	stack = vm_mmap(process->mapp, NULL, NULL, stacksz, PROT_READ | PROT_WRITE | PROT_USER, NULL, -1, MAP_NONE, 0U);
 	if (stack == NULL) {
 		return -ENOMEM;
 	}
@@ -1841,7 +1841,7 @@ int process_tlsInit(hal_tls_t *dest, hal_tls_t *source, vm_map_t *map)
 	dest->tls_sz = round_page(source->tls_sz);
 	dest->arm_m_tls = source->arm_m_tls;
 
-	dest->tls_base = (ptr_t)vm_mmap(map, NULL, NULL, dest->tls_sz, PROT_READ | PROT_WRITE | PROT_USER, NULL, 0, MAP_NONE);
+	dest->tls_base = (ptr_t)vm_mmap(map, NULL, NULL, dest->tls_sz, PROT_READ | PROT_WRITE | PROT_USER, NULL, 0, MAP_NONE, 0U);
 
 	if (dest->tls_base != 0U) {
 		hal_memcpy((void *)dest->tls_base, (void *)source->tls_base, dest->tdata_sz);

--- a/syscalls.c
+++ b/syscalls.c
@@ -112,9 +112,10 @@ int syscalls_sys_mmap(u8 *ustack)
 		}
 	}
 
-	flags &= ~(MAP_ANONYMOUS | MAP_CONTIGUOUS | MAP_PHYSMEM | MAP_NEEDSCOPY);
+	flags &= ~(MAP_ANONYMOUS | MAP_CONTIGUOUS | MAP_PHYSMEM);
+	flags &= MAP_ALL;
 
-	(*vaddr) = vm_mmap(proc_current()->process->mapp, *vaddr, NULL, size, PROT_USER | (vm_prot_t)prot, o, (o == NULL) ? -1 : offs, flags);
+	(*vaddr) = vm_mmap(proc_current()->process->mapp, *vaddr, NULL, size, PROT_USER | (vm_prot_t)prot, o, (o == NULL) ? -1 : offs, flags, 0U);
 	(void)vm_objectPut(o);
 
 	if ((*vaddr) == NULL) {

--- a/test/vm.c
+++ b/test/vm.c
@@ -74,7 +74,7 @@ void test_vm_mmap(void)
 	vm_map_t map;
 
 	lib_printf("test: Virtual memory map test\n");
-	vm_mmap(&map, (void *)0x123, NULL, SIZE_PAGE, 0, NULL, 0, 0);
+	vm_mmap(&map, (void *)0x123, NULL, SIZE_PAGE, 0, NULL, 0, 0, 0);
 
 	vm_mapDump(&map);
 	return;

--- a/vm/amap.c
+++ b/vm/amap.c
@@ -206,10 +206,10 @@ static anon_t *anon_new(page_t *p)
 static void *amap_map(vm_map_t *map, page_t *p)
 {
 	if (map == amap_common.kmap) {
-		return _vm_mmap(amap_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, amap_common.kernel, VM_OFFS_MAX, MAP_NONE);
+		return _vm_mmap(amap_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, amap_common.kernel, VM_OFFS_MAX, MAP_NONE, 0U);
 	}
 
-	return vm_mmap(amap_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, amap_common.kernel, -1, MAP_NONE);
+	return vm_mmap(amap_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, amap_common.kernel, -1, MAP_NONE, 0U);
 }
 
 

--- a/vm/map.c
+++ b/vm/map.c
@@ -22,6 +22,10 @@
 #include "vm/types.h"
 
 
+#define ENTRY_NEEDSCOPY (0x1U << 0)
+#define ENTRY_BORROWED  (0x1U << 1)
+
+
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Definition in assembly code" */
 extern unsigned int __bss_start;
 
@@ -249,6 +253,7 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 	map_entry_t *prev, *next, *e;
 	unsigned int lmerge, rmerge;
 	amap_t *amap;
+	vm_state_t state;
 
 #ifdef NOMMU
 	if (o == VM_OBJ_PHYSMEM) {
@@ -262,8 +267,11 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 		return NULL;
 	}
 
-	rmerge = (next != NULL && v + size == next->vaddr && next->object == o && next->flags == flags && next->prot == prot && next->protOrig == prot) ? 1U : 0U;
-	lmerge = (prev != NULL && v == prev->vaddr + prev->size && prev->object == o && prev->flags == flags && prev->prot == prot && prev->protOrig == prot) ? 1U : 0U;
+	state = (flags & MAP_NEEDSCOPY) != 0U ? ENTRY_NEEDSCOPY : 0U;
+	flags &= ~MAP_NEEDSCOPY;
+
+	rmerge = (next != NULL && v + size == next->vaddr && next->object == o && next->flags == flags && next->state == state && next->prot == prot && next->protOrig == prot) ? 1U : 0U;
+	lmerge = (prev != NULL && v == prev->vaddr + prev->size && prev->object == o && prev->flags == flags && prev->state == state && prev->prot == prot && prev->protOrig == prot) ? 1U : 0U;
 
 	if (offs != VM_OFFS_MAX) {
 		if ((offs & (SIZE_PAGE - 1UL)) != 0UL) {
@@ -359,6 +367,7 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 		e->object = vm_objectRef(o);
 		e->offs = offs;
 		e->flags = flags;
+		e->state = state;
 		e->prot = prot;
 		e->protOrig = prot;
 
@@ -367,11 +376,11 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 
 		if (o == NULL) {
 			/* Try to use existing amap */
-			if (next != NULL && next->amap != NULL && e->vaddr >= (next->vaddr - next->aoffs) && (next->flags & MAP_NEEDSCOPY) == 0U) {
+			if (next != NULL && next->amap != NULL && e->vaddr >= (next->vaddr - next->aoffs) && (next->state & (ENTRY_NEEDSCOPY | ENTRY_BORROWED)) == 0U) {
 				e->amap = amap_ref(next->amap);
 				e->aoffs = next->aoffs - ((ptr_t)next->vaddr - (ptr_t)e->vaddr);
 			}
-			else if (prev != NULL && prev->amap != NULL && (SIZE_PAGE * prev->amap->size - prev->aoffs + (size_t)prev->vaddr) >= ((size_t)e->vaddr + size) && (prev->flags & MAP_NEEDSCOPY) == 0U) {
+			else if (prev != NULL && prev->amap != NULL && (SIZE_PAGE * prev->amap->size - prev->aoffs + (size_t)prev->vaddr) >= ((size_t)e->vaddr + size) && (prev->state & (ENTRY_NEEDSCOPY | ENTRY_BORROWED)) == 0U) {
 				e->amap = amap_ref(prev->amap);
 				e->aoffs = prev->aoffs + ((ptr_t)e->vaddr - (ptr_t)prev->vaddr);
 			}
@@ -692,7 +701,7 @@ int vm_mapFlags(vm_map_t *map, void *vaddr)
 		return -EFAULT;
 	}
 
-	flags = e->flags & ~MAP_NEEDSCOPY;
+	flags = e->flags;
 	(void)proc_lockClear(&map->lock);
 
 	return (int)flags;
@@ -741,14 +750,14 @@ static int _map_force(vm_map_t *map, map_entry_t *e, void *paddr, vm_prot_t prot
 	if (flagsCheck != 0U) {
 		return -EINVAL;
 	}
-	if ((((prot & PROT_WRITE) != 0U) && ((e->flags & MAP_NEEDSCOPY) != 0U)) || ((e->object == NULL) && (e->amap == NULL))) {
+	if ((((prot & PROT_WRITE) != 0U) && ((e->state & ENTRY_NEEDSCOPY) != 0U)) || ((e->object == NULL) && (e->amap == NULL))) {
 		amapNew = amap_create(e->amap, &e->aoffs, e->size);
 		if (amapNew == NULL) {
 			return -ENOMEM;
 		}
 		e->amap = amapNew;
 
-		e->flags &= ~MAP_NEEDSCOPY;
+		e->state &= ~ENTRY_NEEDSCOPY;
 	}
 
 	offs = (ptr_t)paddr - (ptr_t)e->vaddr;
@@ -952,7 +961,7 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 		attr = (vm_protToAttr(e->prot) | vm_flagsToAttr(e->flags));
 		needscopyNonLazy = 0;
 		/* If an entry needs copy, enter it as a readonly to copy it on first access. */
-		if (((e->flags & MAP_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
+		if (((e->state & ENTRY_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
 			if ((p == NULL) || (p->lazy == 0U)) {
 				needscopyNonLazy = 1;
 			}
@@ -989,6 +998,123 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 	(void)proc_lockClear(&map->lock);
 
 	return result;
+}
+
+
+int vm_mapBorrow(vm_map_t *dstMap, void *dstaddr, vm_map_t *srcMap, void *srcaddr, size_t size, vm_prot_t prot)
+{
+	ptr_t offset, i;
+	map_entry_t *dstEntry, *srcEntry, f, *e;
+	size_t overlapSize, srcOverlapStart;
+	vm_flags_t orgFlags;
+	vm_prot_t orgProt;
+	vm_attr_t attr;
+	addr_t pa;
+	int err = EOK;
+
+	if (((size & (SIZE_PAGE - 1U)) != 0U) || (((ptr_t)dstaddr & (SIZE_PAGE - 1U)) != 0U) || (((ptr_t)srcaddr & (SIZE_PAGE - 1U)) != 0U)) {
+		return -EINVAL;
+	}
+
+	(void)proc_lockSet2(&dstMap->lock, &srcMap->lock);
+
+	f.vaddr = dstaddr;
+	f.size = size;
+	dstEntry = lib_treeof(map_entry_t, linkage, lib_rbFind(&dstMap->tree, &f.linkage));
+	/* Accept only the memory inside of a single vm_mapFind allocation */
+	if ((dstEntry == NULL) || ((ptr_t)dstEntry->vaddr > (ptr_t)dstaddr) || ((ptr_t)dstEntry->vaddr + dstEntry->size < (ptr_t)dstaddr + size) ||
+			(dstEntry->object != map_common.kernel) || (dstEntry->amap != NULL)) {
+		(void)proc_lockClear(&dstMap->lock);
+		(void)proc_lockClear(&srcMap->lock);
+		return -EINVAL;
+	}
+	orgFlags = dstEntry->flags;
+	orgProt = dstEntry->prot;
+
+	if (dstEntry->vaddr < dstaddr) {
+		/* Leave the prefix of dstEntry unchanged */
+		e = map_alloc();
+		if (e == NULL) {
+			(void)proc_lockClear(&dstMap->lock);
+			(void)proc_lockClear(&srcMap->lock);
+			return -EINVAL;
+		}
+		else {
+			_vm_mapEntrySplit(NULL, dstMap, dstEntry, e, (ptr_t)dstaddr - (ptr_t)dstEntry->vaddr);
+			dstEntry = e;
+		}
+	}
+
+	/* Iterate over all related source map entries and split dstEntry accordingly with shared amaps/objects */
+	offset = 0U;
+	while ((offset < size) && (err == EOK)) {
+		f.vaddr = srcaddr + offset;
+		f.size = 1;
+		srcEntry = lib_treeof(map_entry_t, linkage, lib_rbFind(&srcMap->tree, &f.linkage));
+		if ((srcEntry == NULL) || (((srcEntry->prot & prot) & ~PROT_USER) != (prot & ~PROT_USER))) {
+			err = -EINVAL;
+			break;
+		}
+
+		srcOverlapStart = (ptr_t)srcaddr + offset - (ptr_t)srcEntry->vaddr;
+		overlapSize = min(srcEntry->size - srcOverlapStart, size - offset);
+
+		if (((srcEntry->state & ENTRY_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
+			/* Ensure all pages are writable to avoid breaking COW pages and lazy allocation of writable shared map entries */
+			for (i = offset; i < offset + overlapSize; i += SIZE_PAGE) {
+				err = _map_force(srcMap, srcEntry, srcaddr + i, prot);
+				if (err != EOK) {
+					break;
+				}
+			}
+		}
+
+		if (dstEntry->size > overlapSize) {
+			e = map_alloc();
+			if (e == NULL) {
+				err = -ENOMEM;
+				break;
+			}
+			_vm_mapEntrySplit(NULL, dstMap, dstEntry, e, overlapSize);
+		}
+		else {
+			e = NULL;
+		}
+		dstEntry->object = vm_objectRef(srcEntry->object);
+		dstEntry->offs = srcEntry->offs == VM_OFFS_MAX ? VM_OFFS_MAX : srcEntry->offs + srcOverlapStart;
+		dstEntry->amap = amap_ref(srcEntry->amap);
+		dstEntry->aoffs = srcEntry->aoffs + srcOverlapStart;
+		dstEntry->state = srcEntry->state | ENTRY_BORROWED; /* Ensure that the dstEntry amap is not modified nor merged with future dstMap mappings */
+		dstEntry->prot = prot;
+		dstEntry->protOrig = prot;
+		amap_getanons(dstEntry->amap, dstEntry->aoffs, overlapSize);
+
+		attr = vm_protToAttr(dstEntry->prot) | vm_flagsToAttr(dstEntry->flags);
+
+		for (i = offset; i < offset + overlapSize; i += SIZE_PAGE) {
+			pa = pmap_resolve(&srcMap->pmap, srcaddr + i);
+			if (pa != 0U) {
+				err = pmap_enter(&dstMap->pmap, pa, dstaddr + i, attr, NULL);
+			}
+			if (err != EOK) {
+				break;
+			}
+		}
+		if (e != NULL) {
+			dstEntry = e;
+		}
+		offset += overlapSize;
+	}
+
+	if (err != EOK) {
+		/* Revert to state from vm_mapFind allocation */
+		(void)_vm_munmap(dstMap, dstaddr, size);
+		(void)_map_map(dstMap, dstaddr, NULL, size, orgProt, map_common.kernel, VM_OFFS_MAX, orgFlags, NULL);
+	}
+
+	(void)proc_lockClear(&dstMap->lock);
+	(void)proc_lockClear(&srcMap->lock);
+	return err;
 }
 
 
@@ -1157,8 +1283,8 @@ int vm_mapCopy(process_t *proc, vm_map_t *dst, vm_map_t *src)
 		(void)_map_add(proc, dst, f);
 
 		if ((e->flags & MAP_DEVICE) == 0U) {
-			e->flags |= MAP_NEEDSCOPY;
-			f->flags |= MAP_NEEDSCOPY;
+			e->state |= ENTRY_NEEDSCOPY;
+			f->state |= ENTRY_NEEDSCOPY;
 
 			if ((proc != NULL) && (proc->lazy != 0U)) {
 				for (offs = 0; offs < f->size; offs += SIZE_PAGE) {
@@ -1631,6 +1757,7 @@ static int _map_mapsInit(vm_map_t *kmap, vm_object_t *kernel, void **bss, void *
 				entry->object = kernel;
 				entry->offs = VM_OFFS_MAX;
 				entry->flags = MAP_NONE;
+				entry->state = 0U;
 				/* TODO: initialize map properties based on attributes in syspage */
 				entry->prot = PROT_READ | PROT_EXEC;
 				entry->protOrig = entry->prot;
@@ -1719,6 +1846,7 @@ int _map_init(vm_map_t *kmap, vm_object_t *kernel, void **bss, void **top)
 		e->object = kernel;
 		e->offs = VM_OFFS_MAX;
 		e->flags = MAP_NONE;
+		e->state = 0U;
 		e->prot = (vm_prot_t)prot;
 		e->protOrig = (vm_prot_t)prot;
 		e->amap = NULL;

--- a/vm/map.c
+++ b/vm/map.c
@@ -22,10 +22,6 @@
 #include "vm/types.h"
 
 
-#define ENTRY_NEEDSCOPY (0x1U << 0)
-#define ENTRY_BORROWED  (0x1U << 1)
-
-
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_6 "Definition in assembly code" */
 extern unsigned int __bss_start;
 
@@ -247,13 +243,12 @@ static void *_map_find(vm_map_t *map, void *vaddr, size_t size, map_entry_t **pr
 }
 
 
-static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, vm_prot_t prot, vm_object_t *o, u64 offs, vm_flags_t flags, map_entry_t **entry)
+static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, vm_prot_t prot, vm_object_t *o, u64 offs, vm_flags_t flags, vm_state_t state, map_entry_t **entry)
 {
 	void *v;
 	map_entry_t *prev, *next, *e;
 	unsigned int lmerge, rmerge;
 	amap_t *amap;
-	vm_state_t state;
 
 #ifdef NOMMU
 	if (o == VM_OBJ_PHYSMEM) {
@@ -266,9 +261,6 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 	if (v == NULL) {
 		return NULL;
 	}
-
-	state = (flags & MAP_NEEDSCOPY) != 0U ? ENTRY_NEEDSCOPY : 0U;
-	flags &= ~MAP_NEEDSCOPY;
 
 	rmerge = (next != NULL && v + size == next->vaddr && next->object == o && next->flags == flags && next->state == state && next->prot == prot && next->protOrig == prot) ? 1U : 0U;
 	lmerge = (prev != NULL && v == prev->vaddr + prev->size && prev->object == o && prev->flags == flags && prev->state == state && prev->prot == prot && prev->protOrig == prot) ? 1U : 0U;
@@ -407,7 +399,7 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 void *vm_mapFind(vm_map_t *map, void *vaddr, size_t size, vm_flags_t flags, vm_prot_t prot)
 {
 	(void)proc_lockSet(&map->lock);
-	vaddr = _map_map(map, vaddr, NULL, size, prot, map_common.kernel, VM_OFFS_MAX, flags, NULL);
+	vaddr = _map_map(map, vaddr, NULL, size, prot, map_common.kernel, VM_OFFS_MAX, flags, 0U, NULL);
 	(void)proc_lockClear(&map->lock);
 
 	return vaddr;
@@ -577,7 +569,7 @@ static vm_attr_t vm_protToAttr(vm_prot_t prot)
 }
 
 
-void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, vm_object_t *o, u64 offs, vm_flags_t flags)
+void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, vm_object_t *o, u64 offs, vm_flags_t flags, vm_state_t state)
 {
 	vm_attr_t attr;
 	void *w;
@@ -610,7 +602,7 @@ void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t pro
 	}
 
 
-	vaddr = _map_map(map, vaddr, process, size, prot, o, offs, flags, &e);
+	vaddr = _map_map(map, vaddr, process, size, prot, o, offs, flags, state, &e);
 	if (vaddr == NULL) {
 		return NULL;
 	}
@@ -640,14 +632,14 @@ void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t pro
 }
 
 
-void *vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, vm_object_t *o, off_t offs, vm_flags_t flags)
+void *vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, vm_object_t *o, off_t offs, vm_flags_t flags, vm_state_t state)
 {
 	if (map == NULL) {
 		map = map_common.kmap;
 	}
 
 	(void)proc_lockSet(&map->lock);
-	vaddr = _vm_mmap(map, vaddr, p, size, prot, o, (offs < 0) ? VM_OFFS_MAX : (u64)offs, flags);
+	vaddr = _vm_mmap(map, vaddr, p, size, prot, o, (offs < 0) ? VM_OFFS_MAX : (u64)offs, flags, state);
 	(void)proc_lockClear(&map->lock);
 	return vaddr;
 }
@@ -1023,7 +1015,7 @@ int vm_mapBorrow(vm_map_t *dstMap, void *dstaddr, vm_map_t *srcMap, void *srcadd
 	dstEntry = lib_treeof(map_entry_t, linkage, lib_rbFind(&dstMap->tree, &f.linkage));
 	/* Accept only the memory inside of a single vm_mapFind allocation */
 	if ((dstEntry == NULL) || ((ptr_t)dstEntry->vaddr > (ptr_t)dstaddr) || ((ptr_t)dstEntry->vaddr + dstEntry->size < (ptr_t)dstaddr + size) ||
-			(dstEntry->object != map_common.kernel) || (dstEntry->amap != NULL)) {
+			(dstEntry->object != map_common.kernel) || (dstEntry->amap != NULL) || (dstEntry->state != 0U)) {
 		(void)proc_lockClear(&dstMap->lock);
 		(void)proc_lockClear(&srcMap->lock);
 		return -EINVAL;
@@ -1109,7 +1101,7 @@ int vm_mapBorrow(vm_map_t *dstMap, void *dstaddr, vm_map_t *srcMap, void *srcadd
 	if (err != EOK) {
 		/* Revert to state from vm_mapFind allocation */
 		(void)_vm_munmap(dstMap, dstaddr, size);
-		(void)_map_map(dstMap, dstaddr, NULL, size, orgProt, map_common.kernel, VM_OFFS_MAX, orgFlags, NULL);
+		(void)_map_map(dstMap, dstaddr, NULL, size, orgProt, map_common.kernel, VM_OFFS_MAX, orgFlags, 0U, NULL);
 	}
 
 	(void)proc_lockClear(&dstMap->lock);
@@ -1143,7 +1135,7 @@ int vm_mapCreate(vm_map_t *map, void *start, void *stop)
 		return -ENOMEM;
 	}
 
-	map->pmap.pmapv = vm_mmap(map_common.kmap, NULL, map->pmap.pmapp, 1UL << map->pmap.pmapp->idx, PROT_READ | PROT_WRITE, map_common.kernel, -1, MAP_NONE);
+	map->pmap.pmapv = vm_mmap(map_common.kmap, NULL, map->pmap.pmapp, 1UL << map->pmap.pmapp->idx, PROT_READ | PROT_WRITE, map_common.kernel, -1, MAP_NONE, 0U);
 	if (map->pmap.pmapv == NULL) {
 		vm_pageFree(map->pmap.pmapp);
 		return -ENOMEM;

--- a/vm/map.h
+++ b/vm/map.h
@@ -64,6 +64,7 @@ typedef struct _map_entry_t {
 	size_t rmaxgap;
 
 	vm_flags_t flags;
+	vm_state_t state;
 	vm_prot_t prot;
 	vm_prot_t protOrig;
 	struct _vm_object_t *object;
@@ -75,6 +76,9 @@ typedef struct _map_entry_t {
 
 
 void *vm_mapFind(vm_map_t *map, void *vaddr, size_t size, vm_flags_t flags, vm_prot_t prot);
+
+
+int vm_mapBorrow(vm_map_t *dstMap, void *dstaddr, vm_map_t *srcMap, void *srcaddr, size_t size, vm_prot_t prot);
 
 
 void *vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, struct _vm_object_t *o, off_t offs, vm_flags_t flags);

--- a/vm/map.h
+++ b/vm/map.h
@@ -72,7 +72,11 @@ typedef struct _map_entry_t {
 } map_entry_t;
 
 
-#define VM_OFFS_MAX ((u64)-1)
+#define VM_OFFS_MAX ((u64) - 1)
+
+
+#define ENTRY_NEEDSCOPY (0x1U << 0)
+#define ENTRY_BORROWED  (0x1U << 1)
 
 
 void *vm_mapFind(vm_map_t *map, void *vaddr, size_t size, vm_flags_t flags, vm_prot_t prot);
@@ -81,10 +85,10 @@ void *vm_mapFind(vm_map_t *map, void *vaddr, size_t size, vm_flags_t flags, vm_p
 int vm_mapBorrow(vm_map_t *dstMap, void *dstaddr, vm_map_t *srcMap, void *srcaddr, size_t size, vm_prot_t prot);
 
 
-void *vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, struct _vm_object_t *o, off_t offs, vm_flags_t flags);
+void *vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, struct _vm_object_t *o, off_t offs, vm_flags_t flags, vm_state_t state);
 
 
-void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, struct _vm_object_t *o, u64 offs, vm_flags_t flags);
+void *_vm_mmap(vm_map_t *map, void *vaddr, page_t *p, size_t size, vm_prot_t prot, struct _vm_object_t *o, u64 offs, vm_flags_t flags, vm_state_t state);
 
 
 int vm_mapForce(vm_map_t *map, void *paddr, vm_prot_t prot);

--- a/vm/object.c
+++ b/vm/object.c
@@ -184,7 +184,7 @@ static page_t *object_fetch(oid_t oid, u64 offs)
 		return NULL;
 	}
 
-	v = vm_mmap(object_common.kmap, NULL, p, SIZE_PAGE, PROT_WRITE | PROT_USER, object_common.kernel, 0, MAP_NONE);
+	v = vm_mmap(object_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, object_common.kernel, 0, MAP_NONE);
 	if (v == NULL) {
 		vm_pageFree(p);
 		(void)proc_close(oid, 0);

--- a/vm/object.c
+++ b/vm/object.c
@@ -184,7 +184,7 @@ static page_t *object_fetch(oid_t oid, u64 offs)
 		return NULL;
 	}
 
-	v = vm_mmap(object_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, object_common.kernel, 0, MAP_NONE);
+	v = vm_mmap(object_common.kmap, NULL, p, SIZE_PAGE, PROT_READ | PROT_WRITE, object_common.kernel, 0, MAP_NONE, 0U);
 	if (v == NULL) {
 		vm_pageFree(p);
 		(void)proc_close(oid, 0);

--- a/vm/page-nommu.c
+++ b/vm/page-nommu.c
@@ -37,7 +37,7 @@ static struct {
 } pages;
 
 
-static page_t *_page_alloc(size_t size, vm_flags_t flags)
+static page_t *_page_alloc(size_t size, vm_pageflags_t flags)
 {
 	page_t *lh = pages.freeq;
 
@@ -61,7 +61,7 @@ static page_t *_page_alloc(size_t size, vm_flags_t flags)
 }
 
 
-page_t *vm_pageAlloc(size_t size, vm_flags_t flags)
+page_t *vm_pageAlloc(size_t size, vm_pageflags_t flags)
 {
 	page_t *p;
 

--- a/vm/page.c
+++ b/vm/page.c
@@ -36,7 +36,7 @@ static struct {
 } pages_info;
 
 
-static page_t *_page_alloc(size_t size, vm_flags_t flags)
+static page_t *_page_alloc(size_t size, vm_pageflags_t flags)
 {
 	unsigned int start, stop, i;
 	page_t *lh, *rh;
@@ -88,7 +88,7 @@ static page_t *_page_alloc(size_t size, vm_flags_t flags)
 }
 
 
-page_t *vm_pageAlloc(size_t size, vm_flags_t flags)
+page_t *vm_pageAlloc(size_t size, vm_pageflags_t flags)
 {
 	page_t *p;
 

--- a/vm/page.h
+++ b/vm/page.h
@@ -20,7 +20,7 @@
 #include "types.h"
 
 
-page_t *vm_pageAlloc(size_t size, vm_flags_t flags);
+page_t *vm_pageAlloc(size_t size, vm_pageflags_t flags);
 
 
 void vm_pageFree(page_t *p);

--- a/vm/types.h
+++ b/vm/types.h
@@ -18,6 +18,8 @@
 
 #include "hal/types.h"
 
+typedef u8 vm_pageflags_t;
+
 typedef u8 vm_flags_t;
 
 typedef u32 vm_attr_t;

--- a/vm/types.h
+++ b/vm/types.h
@@ -24,6 +24,8 @@ typedef u32 vm_attr_t;
 
 typedef u8 vm_prot_t;
 
+typedef u8 vm_state_t;
+
 #endif
 
 #endif

--- a/vm/zone.c
+++ b/vm/zone.c
@@ -40,7 +40,7 @@ int _vm_zoneCreate(vm_zone_t *zone, size_t blocksz, unsigned int blocks)
 		return -ENOMEM;
 	}
 
-	zone->vaddr = vm_mmap(zone_common.kmap, zone_common.kmap->start, zone->pages, (size_t)1U << zone->pages->idx, PROT_READ | PROT_WRITE, zone_common.kernel, -1, MAP_NONE);
+	zone->vaddr = vm_mmap(zone_common.kmap, zone_common.kmap->start, zone->pages, (size_t)1U << zone->pages->idx, PROT_READ | PROT_WRITE, zone_common.kernel, -1, MAP_NONE, 0U);
 	if (zone->vaddr == NULL) {
 		vm_pageFree(zone->pages);
 		return -ENOMEM;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Update message receiver map entries with corresponding amap/objects to ensure these pages won't get allocated by keeping reference counters non-zero even when message sender unmaps these sent pages.

Introduced new MAP_BORROWED flag and vm_mapBorrow function to create and manage vm map entries shared with message sender.

<details>

<summary>Example that causes kernel panics on ia32 via the problem described above:</summary>

```C
#include <stdio.h>
#include <sys/mman.h>
#include <sys/msg.h>
#include <pthread.h>
#include <fcntl.h>
#include <unistd.h>

void* buf = MAP_FAILED;

#define OP_SIZE 0x40000

void* thr2(void* a){
    for (;;) {
        while (buf == MAP_FAILED) {
            printf("thr2: waiting for buf\n");
            usleep(100000);
        }
        munmap((void*)buf, OP_SIZE);
        buf = MAP_FAILED;
        printf("freed\n");
    }
}



int main(void) {
    uint32_t port;
    pthread_t t;

    int fd = open("/test", O_RDWR | O_CREAT);

    buf = mmap(NULL, OP_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
    if (buf == MAP_FAILED) {
        return 1;
    }
    for (int i = 0; i < OP_SIZE; i++) {
        ((char*)buf)[i] = 0xAB;
    }
    write(fd, buf, OP_SIZE);
    munmap(buf, OP_SIZE);

    // Memory saturation to speed up the exchange of available pages
    while ((buf = mmap(NULL, OP_SIZE*2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0)) != MAP_FAILED) {
    }

    portCreate(&port);
    pthread_create(&t, NULL, thr2, NULL);

    for (;;) {
        buf = mmap(NULL, OP_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
        if (buf == MAP_FAILED) {
            continue;
        }

        printf("allocated buf: %p\n", buf);
        while (buf != MAP_FAILED) {
            lseek(fd, 0, SEEK_SET);
            // printf("written %d\n", write(fd, (void*)buf, OP_SIZE));
            printf("read %ld\n", read(fd, (void*)buf, OP_SIZE));
            printf("buf: %p\n", buf);
        }
    }

    return 0;
}
```

</details>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current msg implementation maps pages without marking them anywhere, leading to potential reallocation and multimapping such pages in other places (even as kernel structures).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
 - #817 
 - phoenix-rtos/phoenix-rtos-utils#273
- [ ] I will merge this PR by myself when appropriate.
