### PR TITLE
threads: introduce threads_halt function

### DIFF
--- a/hal/armv7a/imx6ull/memtest.c
+++ b/hal/armv7a/imx6ull/memtest.c
@@ -300,5 +300,7 @@ void test_ddr(void)
 	test_ddrAll();
 #endif
 
-	hal_cpuHalt();
+	for (;;) {
+		hal_cpuHalt();
+	}
 }

--- a/lib/assert.c
+++ b/lib/assert.c
@@ -19,6 +19,7 @@
 #include "printf.h"
 #include "log/log.h"
 #include "hal/hal.h"
+#include "proc/threads.h"
 
 
 void lib_assertPanic(const char *func, int line, const char *fmt, ...)
@@ -38,8 +39,6 @@ void lib_assertPanic(const char *func, int line, const char *fmt, ...)
 #ifdef NDEBUG
 	hal_cpuReboot();
 #else
-	for (;;) {
-		hal_cpuHalt();
-	}
+	threads_halt();
 #endif
 }

--- a/lib/assert.c
+++ b/lib/assert.c
@@ -22,7 +22,7 @@
 #include "proc/threads.h"
 
 
-void lib_assertPanic(const char *func, int line, const char *fmt, ...)
+__attribute__((noreturn)) void lib_assertPanic(const char *func, int line, const char *fmt, ...)
 {
 	va_list ap;
 

--- a/lib/assert.h
+++ b/lib/assert.h
@@ -17,7 +17,7 @@
 #define _PH_LIB_ASSERT_H_
 
 
-void lib_assertPanic(const char *func, int line, const char *fmt, ...);
+__attribute__((noreturn)) void lib_assertPanic(const char *func, int line, const char *fmt, ...);
 
 
 #define LIB_ASSERT_ALWAYS(condition, fmt, ...) \

--- a/proc/process.c
+++ b/proc/process.c
@@ -288,9 +288,7 @@ static void process_exception(unsigned int n, exc_context_t *ctx)
 
 	process_dumpException(n, ctx);
 
-	if (thread->process == NULL) {
-		hal_cpuHalt();
-	}
+	LIB_ASSERT_ALWAYS(thread->process != NULL, "exception in kernel")
 
 	(void)threads_sigpost(thread->process, thread, signal_kill);
 
@@ -307,9 +305,7 @@ static void process_illegal(unsigned int n, exc_context_t *ctx)
 	thread_t *thread = proc_current();
 	process_t *process = thread->process;
 
-	if (process == NULL) {
-		hal_cpuHalt();
-	}
+	LIB_ASSERT_ALWAYS(process != NULL, "exception in kernel")
 
 	(void)threads_sigpost(process, thread, signal_illegal);
 }

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -248,6 +248,20 @@ static int threads_timeintr(unsigned int n, cpu_context_t *context, void *arg)
 static void proc_lockForceUnlock(lock_t *lock, int doYield);
 
 
+__attribute__((noreturn)) void threads_halt(void)
+{
+	spinlock_ctx_t sc;
+
+	/* take the spinlock, and not release it; other threads will eventually hang trying to reschedule */
+	hal_spinlockSet(&threads_common.spinlock, &sc);
+	for (;;) {
+		hal_cpuHalt();
+	}
+
+	__builtin_unreachable();
+}
+
+
 static void thread_destroy(thread_t *thread)
 {
 	process_t *process;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -252,7 +252,10 @@ __attribute__((noreturn)) void threads_halt(void)
 {
 	spinlock_ctx_t sc;
 
-	/* take the spinlock, and not release it; other threads will eventually hang trying to reschedule */
+	/*
+	 * Take the threads spinlock and not release it - this is an attempt to stop other cores in SMP from
+	 * continuing to execute code (they should eventually hang trying to run the scheduler).
+	 */
 	hal_spinlockSet(&threads_common.spinlock, &sc);
 	for (;;) {
 		hal_cpuHalt();

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -190,4 +190,7 @@ int threads_sigsuspend(unsigned int mask);
 void threads_setupUserReturn(void *retval, cpu_context_t *ctx);
 
 
+__attribute__((noreturn)) void threads_halt(void);
+
+
 #endif

--- a/test/msg.c
+++ b/test/msg.c
@@ -18,6 +18,7 @@
 #include "hal/hal.h"
 #include "include/errno.h"
 #include "proc/proc.h"
+#include "proc/threads.h"
 
 
 unsigned int test_randsize(unsigned int *seed, unsigned int bufsz)
@@ -169,7 +170,7 @@ void test_msg(void)
 
 	if (proc_portCreate(&port) != EOK) {
 		lib_printf("Failed to create port\n");
-		hal_cpuHalt();
+		threads_halt();
 	}
 
 	proc_threadCreate(NULL, test_pong, NULL, 4, 1024, NULL, 0, 0, (void *)(long)port);

--- a/test/rb.c
+++ b/test/rb.c
@@ -19,6 +19,7 @@
 #include "lib/lib.h"
 #include "vm/vm.h"
 #include "proc/proc.h"
+#include "proc/threads.h"
 
 
 static int test_rbCheckEx(rbnode_t *node, int level)
@@ -155,7 +156,7 @@ static void test_rbGenerateTest(int level, int insert, int vector[], int selecte
 					}
 
 					lib_printf("\n");
-					hal_cpuHalt();
+					threads_halt();
 				}
 
 				if (rb_processVector(0, &tree, vector) < 0) {
@@ -165,7 +166,7 @@ static void test_rbGenerateTest(int level, int insert, int vector[], int selecte
 					}
 
 					lib_printf("\n");
-					hal_cpuHalt();
+					threads_halt();
 				}
 			}
 		}

--- a/vm/map.c
+++ b/vm/map.c
@@ -827,10 +827,7 @@ static void map_pageFault(unsigned int n, exc_context_t *ctx)
 	if (vm_mapForce(map, paddr, prot) != 0) {
 		process_dumpException(n, ctx);
 
-		if (thread->process == NULL) {
-			hal_cpuDisableInterrupts();
-			hal_cpuHalt();
-		}
+		LIB_ASSERT_ALWAYS(thread->process != NULL, "exception in kernel");
 
 		(void)threads_sigpost(thread->process, thread, signal_segv);
 	}


### PR DESCRIPTION
hal_cpuHalt() is used for two purposes, for putting the processor into low-power mode and waiting for an interrupt, and for 'halt and catch fire' use case. Even moreso, it is still done incorrectly on SMP systems, as that would only halt the core the fault happened on.

This begs for differentiation.
threads_halt() is a replacement for the second use case.

TASK: RTOS-1401

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
