### PR TITLE
vm/map: Entries merging bugfixes

### DIFF
--- a/syscalls.c
+++ b/syscalls.c
@@ -82,6 +82,11 @@ int syscalls_sys_mmap(u8 *ustack)
 		return -EFAULT;
 	}
 
+	if ((flags & (MAP_DEVICE | MAP_PHYSMEM)) == MAP_DEVICE) {
+		/* MAP_DEVICE without MAP_PHYSMEM can lead to undefined behavior within vm subsystem */
+		return -EINVAL;
+	}
+
 	if ((flags & MAP_ANONYMOUS) != 0U) {
 		if ((flags & MAP_PHYSMEM) != 0U) {
 			o = VM_OBJ_PHYSMEM;

--- a/syscalls.c
+++ b/syscalls.c
@@ -112,7 +112,7 @@ int syscalls_sys_mmap(u8 *ustack)
 		}
 	}
 
-	flags &= ~(MAP_ANONYMOUS | MAP_CONTIGUOUS | MAP_PHYSMEM);
+	flags &= ~(MAP_ANONYMOUS | MAP_CONTIGUOUS | MAP_PHYSMEM | MAP_NEEDSCOPY);
 
 	(*vaddr) = vm_mmap(proc_current()->process->mapp, *vaddr, NULL, size, PROT_USER | (vm_prot_t)prot, o, (o == NULL) ? -1 : offs, flags);
 	(void)vm_objectPut(o);

--- a/vm/map.c
+++ b/vm/map.c
@@ -367,11 +367,11 @@ static void *_map_map(vm_map_t *map, void *vaddr, process_t *proc, size_t size, 
 
 		if (o == NULL) {
 			/* Try to use existing amap */
-			if (next != NULL && next->amap != NULL && e->vaddr >= (next->vaddr - next->aoffs)) {
+			if (next != NULL && next->amap != NULL && e->vaddr >= (next->vaddr - next->aoffs) && (next->flags & MAP_NEEDSCOPY) == 0U) {
 				e->amap = amap_ref(next->amap);
 				e->aoffs = next->aoffs - ((ptr_t)next->vaddr - (ptr_t)e->vaddr);
 			}
-			else if (prev != NULL && prev->amap != NULL && (SIZE_PAGE * prev->amap->size - prev->aoffs + (size_t)prev->vaddr) >= ((size_t)e->vaddr + size)) {
+			else if (prev != NULL && prev->amap != NULL && (SIZE_PAGE * prev->amap->size - prev->aoffs + (size_t)prev->vaddr) >= ((size_t)e->vaddr + size) && (prev->flags & MAP_NEEDSCOPY) == 0U) {
 				e->amap = amap_ref(prev->amap);
 				e->aoffs = prev->aoffs + ((ptr_t)e->vaddr - (ptr_t)prev->vaddr);
 			}
@@ -947,7 +947,7 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 			attr = (vm_protToAttr(e->prot) | vm_flagsToAttr(e->flags));
 			needscopyNonLazy = 0;
 			/* If an entry needs copy, enter it as a readonly to copy it on first access. */
-			if ((e->flags & MAP_NEEDSCOPY) != 0U) {
+			if (((e->flags & MAP_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
 				if ((p == NULL) || (p->lazy == 0U)) {
 					needscopyNonLazy = 1;
 				}
@@ -1146,7 +1146,7 @@ int vm_mapCopy(process_t *proc, vm_map_t *dst, vm_map_t *src)
 		_vm_mapEntryCopy(f, e, 1);
 		(void)_map_add(proc, dst, f);
 
-		if (((e->protOrig & PROT_WRITE) != 0U) && ((e->flags & MAP_DEVICE) == 0U)) {
+		if ((e->flags & MAP_DEVICE) == 0U) {
 			e->flags |= MAP_NEEDSCOPY;
 			f->flags |= MAP_NEEDSCOPY;
 

--- a/vm/map.c
+++ b/vm/map.c
@@ -854,7 +854,7 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 	addr_t pa;
 	vm_attr_t attr;
 	int needscopyNonLazy;
-	map_entry_t *e, *buf = NULL, *prev;
+	map_entry_t *e, *buf = NULL, *prev, *head, *tail;
 	map_entry_t t;
 
 	if (((((ptr_t)vaddr) & (SIZE_PAGE - 1U)) != 0U) || (len == 0U) || ((len & (SIZE_PAGE - 1U)) != 0U)) {
@@ -901,79 +901,89 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 		}
 	}
 
-	if (result == EOK) {
-		t.vaddr = vaddr;
-		prev = NULL;
-		lenLeft = len;
-		do {
-			e = lib_treeof(map_entry_t, linkage, lib_rbFind(&map->tree, &t.linkage));
+	if (result != EOK) {
+		(void)proc_lockClear(&map->lock);
+		return result;
+	}
+
+	t.vaddr = vaddr;
+	prev = NULL;
+	lenLeft = len;
+	do {
+		e = lib_treeof(map_entry_t, linkage, lib_rbFind(&map->tree, &t.linkage));
+
+		currSize = e->size;
+		currVaddr = t.vaddr;
+
+		if (e->vaddr < currVaddr) {
+			/* Split */
+			head = e;
+
+			e = buf;
+			buf = buf->next;
+
+			_vm_mapEntrySplit(p, map, head, e, (ptr_t)currVaddr - (ptr_t)head->vaddr);
 
 			currSize = e->size;
-			currVaddr = t.vaddr;
+		}
 
-			if (e->vaddr < currVaddr) {
-				/* Split */
-				prev = e;
+		if (lenLeft < currSize) {
+			tail = buf;
+			buf = buf->next; /* Avoid freeing the split entry in final cleanup */
+			_vm_mapEntrySplit(p, map, e, tail, lenLeft + ((ptr_t)currVaddr - (ptr_t)e->vaddr));
+			currSize = lenLeft;
+		}
 
-				e = buf;
-				buf = buf->next;
+		if ((prev != NULL) && (prev->protOrig == e->protOrig) && (prev->flags == e->flags) &&
+				(prev->object == e->object) && ((prev->object == NULL) || (e->offs == (prev->offs + prev->size))) &&
+				(prev->amap == e->amap) && ((e->amap == NULL) || (e->aoffs == (prev->aoffs + prev->size)))) {
+			/* Merge */
+			prev->rmaxgap = e->rmaxgap;
+			prev->size += e->size;
 
-				_vm_mapEntrySplit(p, map, prev, e, (ptr_t)currVaddr - (ptr_t)prev->vaddr);
+			_entry_put(map, e);
 
-				currSize = e->size;
-				prev = NULL; /* Avoid merge'ing with prev outside of provided range */
+			map_augment(&prev->linkage);
+			e = prev;
+		}
+
+		e->prot = prot;
+
+		attr = (vm_protToAttr(e->prot) | vm_flagsToAttr(e->flags));
+		needscopyNonLazy = 0;
+		/* If an entry needs copy, enter it as a readonly to copy it on first access. */
+		if (((e->flags & MAP_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
+			if ((p == NULL) || (p->lazy == 0U)) {
+				needscopyNonLazy = 1;
 			}
-
-			if (lenLeft < currSize) {
-				_vm_mapEntrySplit(p, map, e, buf, lenLeft + ((ptr_t)currVaddr - (ptr_t)e->vaddr));
-				currSize = lenLeft;
+			else {
+				attr &= ~PGHD_WRITE;
 			}
-
-			if ((prev != NULL) && (prev->protOrig == e->protOrig) && (prev->flags == e->flags) &&
-					(prev->object == e->object) && ((prev->object == NULL) || (e->offs == (prev->offs + prev->size))) &&
-					(prev->amap == e->amap) && ((e->amap == NULL) || (e->aoffs == (prev->aoffs + prev->size)))) {
-				/* Merge */
-				prev->rmaxgap = e->rmaxgap;
-				prev->size += e->size;
-
-				_entry_put(map, e);
-
-				map_augment(&prev->linkage);
-				e = prev;
-			}
-
-			e->prot = prot;
-
-			attr = (vm_protToAttr(e->prot) | vm_flagsToAttr(e->flags));
-			needscopyNonLazy = 0;
-			/* If an entry needs copy, enter it as a readonly to copy it on first access. */
-			if (((e->flags & MAP_NEEDSCOPY) != 0U) && ((prot & PROT_WRITE) != 0U)) {
-				if ((p == NULL) || (p->lazy == 0U)) {
-					needscopyNonLazy = 1;
-				}
-				else {
-					attr &= ~PGHD_WRITE;
+		}
+		for (currVaddr = t.vaddr; currVaddr < (e->vaddr + e->size); currVaddr += SIZE_PAGE) {
+			if (needscopyNonLazy == 0) {
+				pa = pmap_resolve(&map->pmap, currVaddr);
+				if (pa != 0U) {
+					result = pmap_enter(&map->pmap, pa, currVaddr, attr, NULL);
 				}
 			}
-			for (currVaddr = t.vaddr; currVaddr < (e->vaddr + e->size); currVaddr += SIZE_PAGE) {
-				if (needscopyNonLazy == 0) {
-					pa = pmap_resolve(&map->pmap, currVaddr);
-					if (pa != 0U) {
-						result = pmap_enter(&map->pmap, pa, currVaddr, attr, NULL);
-					}
-				}
-				else {
-					result = _map_force(map, e, currVaddr, prot);
-				}
-				if (result != EOK) {
-					break;
-				}
+			else {
+				result = _map_force(map, e, currVaddr, prot);
 			}
+			if (result != EOK) {
+				break;
+			}
+		}
 
-			t.vaddr += currSize;
-			lenLeft -= currSize;
-			prev = e;
-		} while ((lenLeft != 0U) && (result == EOK));
+		t.vaddr += currSize;
+		lenLeft -= currSize;
+		prev = e;
+	} while ((lenLeft != 0U) && (result == EOK));
+
+	while (buf != NULL) {
+		e = buf;
+		buf = buf->next;
+		map_free(e);
 	}
 
 	(void)proc_lockClear(&map->lock);

--- a/vm/map.c
+++ b/vm/map.c
@@ -929,7 +929,9 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 				currSize = lenLeft;
 			}
 
-			if ((prev != NULL) && (prev->protOrig == e->protOrig) && (prev->object == e->object) && (prev->flags == e->flags)) {
+			if ((prev != NULL) && (prev->protOrig == e->protOrig) && (prev->flags == e->flags) &&
+					(prev->object == e->object) && ((prev->object == NULL) || (e->offs == (prev->offs + prev->size))) &&
+					(prev->amap == e->amap) && ((e->amap == NULL) || (e->aoffs == (prev->aoffs + prev->size)))) {
 				/* Merge */
 				prev->rmaxgap = e->rmaxgap;
 				prev->size += e->size;

--- a/vm/map.c
+++ b/vm/map.c
@@ -908,19 +908,28 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 		do {
 			e = lib_treeof(map_entry_t, linkage, lib_rbFind(&map->tree, &t.linkage));
 
-			if (prev == NULL) {
-				/* First entry */
-				if (e->vaddr < t.vaddr) {
-					/* Split */
-					prev = e;
+			currSize = e->size;
+			currVaddr = t.vaddr;
 
-					e = buf;
-					buf = buf->next;
+			if (e->vaddr < currVaddr) {
+				/* Split */
+				prev = e;
 
-					_vm_mapEntrySplit(p, map, prev, e, (ptr_t)t.vaddr - (ptr_t)prev->vaddr);
-				}
+				e = buf;
+				buf = buf->next;
+
+				_vm_mapEntrySplit(p, map, prev, e, (ptr_t)currVaddr - (ptr_t)prev->vaddr);
+
+				currSize = e->size;
+				prev = NULL; /* Avoid merge'ing with prev outside of provided range */
 			}
-			else if ((prev->protOrig == e->protOrig) && (prev->object == e->object) && (prev->flags == e->flags)) {
+
+			if (lenLeft < currSize) {
+				_vm_mapEntrySplit(p, map, e, buf, lenLeft + ((ptr_t)currVaddr - (ptr_t)e->vaddr));
+				currSize = lenLeft;
+			}
+
+			if ((prev != NULL) && (prev->protOrig == e->protOrig) && (prev->object == e->object) && (prev->flags == e->flags)) {
 				/* Merge */
 				prev->rmaxgap = e->rmaxgap;
 				prev->size += e->size;
@@ -929,14 +938,6 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 
 				map_augment(&prev->linkage);
 				e = prev;
-			}
-			else {
-				/* No action required */
-			}
-
-
-			if (lenLeft < e->size) {
-				_vm_mapEntrySplit(p, map, e, buf, lenLeft);
 			}
 
 			e->prot = prot;
@@ -952,7 +953,7 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 					attr &= ~PGHD_WRITE;
 				}
 			}
-			for (currVaddr = e->vaddr; currVaddr < (e->vaddr + e->size); currVaddr += SIZE_PAGE) {
+			for (currVaddr = t.vaddr; currVaddr < (e->vaddr + e->size); currVaddr += SIZE_PAGE) {
 				if (needscopyNonLazy == 0) {
 					pa = pmap_resolve(&map->pmap, currVaddr);
 					if (pa != 0U) {
@@ -962,9 +963,13 @@ int vm_mprotect(vm_map_t *map, void *vaddr, size_t len, vm_prot_t prot)
 				else {
 					result = _map_force(map, e, currVaddr, prot);
 				}
+				if (result != EOK) {
+					break;
+				}
 			}
 
-			lenLeft -= e->size;
+			t.vaddr += currSize;
+			lenLeft -= currSize;
 			prev = e;
 		} while ((lenLeft != 0U) && (result == EOK));
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There is an memory management bug that can cause Use after free of anons or leave mapped pages that system considers free (and hence e.g. corrupt arbitrary memory page in the future). These errors are rare, as require very specific fork and remap combination with both RO and RW memory. 
Seems to also be a source of sporadic mprotect CI fails.

Adding NEEDSCOPY flag to entries with unwriteable protOrig should not impact performance - the amap copy is done only if entry is writeable anyway. This way NEEDSCOPY flag protects us from reusing amaps that can be also held by forked processes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves phoenix-rtos/phoenix-rtos-project#1714 - this PR uses different solution than suggested in the issue, as this way amap merge'ing policy is less strict while covering detected problems.

AI-assisted test cases created for triggering all fixed errors: [test_anon_race.c](https://github.com/user-attachments/files/30410944/test_anon_race.c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
