### PR TITLE
hal/aarch64: fix hal_strncpy

### DIFF
--- a/hal/aarch64/string.c
+++ b/hal/aarch64/string.c
@@ -113,16 +113,17 @@ char *hal_strcpy(char *dest, const char *src)
 
 char *hal_strncpy(char *dest, const char *src, size_t n)
 {
-	size_t i;
+	size_t i = 0U;
 
 	if (n == 0U) {
 		return dest;
 	}
 
 	/* parasoft-begin-suppress MISRAC2012-RULE_18_1 "src is assumed to end with a null-byte" */
-	for (i = 0; i < n && src[i] != '\0'; i++) {
+	do {
 		dest[i] = src[i];
-	}
+		i++;
+	} while ((i < n) && (src[i - 1U] != '\0'));
 	/* parasoft-end-suppress MISRAC2012-RULE_18_1 */
 
 	return dest;


### PR DESCRIPTION
## Description
Commit https://github.com/phoenix-rtos/phoenix-rtos-kernel/commit/c6170c8092133c3d98a7b380a387164c77361414 broke the implementation of function `hal_strncpy`, leading to it not copying the final `\0` character of a string. This commit restores the previous implementation.

`hal_strncpy` isn't used very frequently in the kernel, but it is used for the system capabilities marquee at startup. How this mistake got overlooked for so long is beyond me:
```
Phoenix-RTOS microkernel v. 3.3.1 rev. ######## +0
hal: Xilinx Zynq Ultrascale+ ARMv8 Cortex-A53 r0p4 x4
hal: EL3, EL2, FP, AdvSIMD, AES, SHA1, SHA256, CRC32
hal: Using GIC interrupt controllerA1, SHA256, CRC32
hal: Using Triple Timer CounterllerA1, SHA256, CRC32
```

## Motivation and Context
JIRA: RTOS-1394

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: aarch64a53-zynqmp-som

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
