### PR TITLE
proc/threads: publish thread after full initialization

### DIFF
--- a/proc/threads.c
+++ b/proc/threads.c
@@ -575,21 +575,15 @@ int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority,
 	t->priorityBase = priority;
 	t->priority = priority;
 	t->cpuTime = 0;
+	proc_gettime(&t->readyTime, NULL);
 	t->maxWait = 0;
-	proc_gettime(&t->startTime, NULL);
-	t->lastTime = t->startTime;
+	t->startTime = t->readyTime;
+	t->lastTime = t->readyTime;
 	t->longjmpctx = NULL;
-
-	if (thread_alloc(t) < 0) {
-		vm_kfree(t->kstack);
-		vm_kfree(t);
-		return -ENOMEM;
-	}
 
 	if (process != NULL && (process->tls.tdata_sz != 0U || process->tls.tbss_sz != 0U)) {
 		err = process_tlsInit(&t->tls, &process->tls, process->mapp);
 		if (err != EOK) {
-			lib_idtreeRemove(&threads_common.id, &t->idlinkage);
 			vm_kfree(t->kstack);
 			vm_kfree(t);
 			return err;
@@ -601,6 +595,15 @@ int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority,
 		t->tls.tbss_sz = 0;
 		t->tls.tls_sz = 0;
 		t->tls.arm_m_tls = 0;
+	}
+
+	if (thread_alloc(t) < 0) {
+		if (t->tls.tls_sz != 0U) {
+			(void)process_tlsDestroy(&t->tls, process->mapp);
+		}
+		vm_kfree(t->kstack);
+		vm_kfree(t);
+		return -ENOMEM;
 	}
 
 	if (id != NULL) {


### PR DESCRIPTION
Move thread_alloc() after TLS initialization so a new thread becomes visible to other CPUs only after it is fully constructed.

This also fixes the TLS initialization failure path, which no longer needs to remove a partially constructed thread that may have already been observed by another CPU.

YT: RTOS-209

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
