### PR TITLE
hal/stm32l4x6: Add missing hal_rttInit()

### DIFF
--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -19,6 +19,7 @@
 #include "hal/hal.h"
 #include "include/errno.h"
 
+#include "hal/arm/rtt.h"
 #include "hal/arm/scs.h"
 
 #include <board_config.h>
@@ -772,6 +773,7 @@ void _stm32_init(void)
 	stm32_common.flash = (void *)0x40022000U;
 
 	_hal_scsInit();
+	(void)_hal_rttInit();
 
 	/* Enable System configuration controller */
 	(void)_stm32_rccSetDevClock(pctl_syscfg, 1U);


### PR DESCRIPTION
This is crucial when PERF_RTT_ENABLED is enabled - call to _hal_rttSetup() performs NULL check on variable nullified by the _hal_rttInit(), and omit that setup when variable is not NULL

TASK: ISC-326

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
First steps to run perf on RTT on stm32l4x6 – fix missing init when PERF_RTT_ENABLED

As I am not sure which targets are prepared and will run RTT so I added this only in stm32l4x6.

I see that some of RTT things is in stm32n6 plo ld script so I could also add it there if welcomed.

I could also add it to every ARM target as RTT is available there, but probably it's not a use-case to have RTT on big MMU target.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: DEND hardware

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
