### PR TITLE
hal/{armv7m,armv8m}: remove unused timer_jiffiesAdd function

### DIFF
--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -36,9 +36,7 @@ void hal_cpuLowPower(time_t us, spinlock_t *spinlock, spinlock_ctx_t *sc)
 
 	hal_spinlockSet(&cpu_common.busySp, &scp);
 	if (cpu_common.busy == 0) {
-		/* Don't increment jiffies if sleep was unsuccessful */
-		us = _stm32_pwrEnterLPStop(us);
-		timer_jiffiesAdd(us);
+		_stm32_pwrEnterLPStop(us);
 		hal_spinlockClear(&cpu_common.busySp, &scp);
 	}
 	else {

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -478,7 +478,7 @@ void _stm32_pwrSetCPUVolt(u8 range)
 
 
 /* parasoft-suppress-next-line MISRAC2012-DIR_4_3 "Assembly is required for low-level operations" */
-time_t _stm32_pwrEnterLPStop(time_t us)
+void _stm32_pwrEnterLPStop(time_t us)
 {
 	unsigned int t;
 	int restoreMsi = 0;
@@ -520,8 +520,6 @@ time_t _stm32_pwrEnterLPStop(time_t us)
 	if (stm32_common.cpuclk <= 6U * 1000U * 1000U) {
 		_stm32_pwrSetCPUVolt(2U);
 	}
-
-	return 0;
 }
 
 

--- a/hal/armv7m/stm32/l4/timer.c
+++ b/hal/armv7m/stm32/l4/timer.c
@@ -137,12 +137,6 @@ static time_t hal_timerGetCyc(void)
 
 /* Additional functions */
 
-void timer_jiffiesAdd(time_t t)
-{
-	(void)t;
-}
-
-
 void timer_setAlarm(time_t us)
 {
 	int cmpdone = 0;

--- a/hal/armv7m/stm32/stm32-timer.h
+++ b/hal/armv7m/stm32/stm32-timer.h
@@ -17,9 +17,6 @@
 #include "hal/types.h"
 
 
-void timer_jiffiesAdd(time_t t);
-
-
 void timer_setAlarm(time_t us);
 
 

--- a/hal/armv7m/stm32/stm32.h
+++ b/hal/armv7m/stm32/stm32.h
@@ -61,7 +61,7 @@ int _stm32_gpioGetPort(int d, u16 *val);
 void _stm32_pwrSetCPUVolt(u8 range);
 
 
-time_t _stm32_pwrEnterLPStop(time_t us);
+void _stm32_pwrEnterLPStop(time_t us);
 
 
 void _stm32_rtcUnlockRegs(void);

--- a/hal/armv8m/stm32/n6/timer.c
+++ b/hal/armv8m/stm32/n6/timer.c
@@ -64,21 +64,6 @@ static int _timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 }
 
 
-void timer_jiffiesAdd(time_t t)
-{
-	spinlock_ctx_t sc;
-
-	hal_spinlockSet(&timer_common.sp, &sc);
-	if (timer_common.frequency == (1000UL * 1000UL)) {
-		timer_common.ticks += (u64)t;
-	}
-	else {
-		timer_common.ticks += ((u64)t * timer_common.frequency) / (1000UL * 1000UL);
-	}
-	hal_spinlockClear(&timer_common.sp, &sc);
-}
-
-
 char *hal_timerFeatures(char *features, size_t len)
 {
 	(void)hal_strncpy(features, "Using STM32 TIM timer", len);

--- a/hal/armv8m/stm32/stm32-timer.h
+++ b/hal/armv8m/stm32/stm32-timer.h
@@ -17,7 +17,7 @@
 #include "hal/types.h"
 
 
-void timer_jiffiesAdd(time_t t);
+void timer_setAlarm(time_t us);
 
 
 #endif


### PR DESCRIPTION
## Description
The function `timer_jiffiesAdd` was used in `hal_cpuLowPower`, but its implementation was empty on the only platform where it was actually used (STM32L4x6). On STM32N6 the function was implemented but never called, as that target doesn't support deep sleep modes.

After discussion with @agkaminski we concluded that the function was a leftover of the STM32L1 port that has since been deleted. For clarity we decided to remove the function. Because the output of `_stm32_pwrEnterLPStop` function was now unused (and it was always 0 anyway) I decided to remove it too.

I also added `timer_setAlarm` to `hal/armv8m/stm32/stm32-timer.h` in preparation for ARMv8-M STM32 targets which will support low-power modes.

## Motivation and Context
Prepare for port to STM32U3
YT: RTOS-1409

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
