### PR TITLE
cond: handle conditional without mutex

### DIFF
--- a/include/threads.h
+++ b/include/threads.h
@@ -31,8 +31,13 @@ struct lockAttr {
 /* Condvar attributes */
 
 
+#define PH_COND_NORMAL   0
+#define PH_COND_UNLOCKED 1 /* Cond without lock - can be used for waiting for IRQ signal or sync on atomics */
+
+
 struct condAttr {
 	int clock;
+	int type;
 };
 
 

--- a/proc/cond.c
+++ b/proc/cond.c
@@ -54,7 +54,8 @@ int proc_condCreate(const struct condAttr *attr)
 	cond_t *cond;
 	int id;
 
-	if ((attr->clock != PH_CLOCK_RELATIVE) && (attr->clock != PH_CLOCK_REALTIME) && (attr->clock != PH_CLOCK_MONOTONIC)) {
+	if (((attr->clock != PH_CLOCK_RELATIVE) && (attr->clock != PH_CLOCK_REALTIME) && (attr->clock != PH_CLOCK_MONOTONIC)) ||
+			((attr->type != PH_COND_NORMAL) && (attr->type != PH_COND_UNLOCKED))) {
 		return -EINVAL;
 	}
 
@@ -85,18 +86,33 @@ int proc_condCreate(const struct condAttr *attr)
 int proc_condWait(int c, int m, time_t timeout)
 {
 	cond_t *cond;
-	mutex_t *mutex;
+	mutex_t *mutex = NULL;
 	int err = 0;
 	time_t offs, abstime = 0;
+	int condType;
 
 	cond = cond_get(c);
 	if (cond == NULL) {
 		return -EINVAL;
 	}
 
-	mutex = mutex_get(m);
-	if (mutex == NULL) {
-		cond_put(cond);
+	condType = cond->attr.type;
+
+	if (condType == PH_COND_NORMAL) {
+		mutex = mutex_get(m);
+		if (mutex == NULL) {
+			cond_put(cond);
+			return -EINVAL;
+		}
+	}
+	else if (condType == PH_COND_UNLOCKED) {
+		if (m != -1) {
+			cond_put(cond);
+			return -EINVAL;
+		}
+	}
+	else {
+		/* wrong type, should never happen */
 		return -EINVAL;
 	}
 
@@ -132,13 +148,28 @@ int proc_condWait(int c, int m, time_t timeout)
 				err = -EINVAL;
 				break;
 		}
+
+		if (err != 0) {
+			if (mutex != NULL) {
+				mutex_put(mutex);
+			}
+			cond_put(cond);
+			return err;
+		}
 	}
 
-	if (err == 0) {
+	if (condType == PH_COND_NORMAL) {
 		err = proc_lockWait(&cond->queue, &mutex->lock, abstime);
+
+		mutex_put(mutex);
+	}
+	else if (condType == PH_COND_UNLOCKED) {
+		err = proc_threadWaitExclusive(&cond->queue, abstime);
+	}
+	else {
+		/* already checked, no action required */
 	}
 
-	mutex_put(mutex);
 	cond_put(cond);
 
 	return err;

--- a/proc/cond.c
+++ b/proc/cond.c
@@ -67,15 +67,15 @@ int proc_condCreate(const struct condAttr *attr)
 	cond->resource.payload.cond = cond;
 	cond->resource.type = rtCond;
 
+	cond->queue = NULL;
+
+	hal_memcpy(&cond->attr, attr, sizeof(cond->attr));
+
 	id = resource_alloc(p, &cond->resource);
 	if (id < 0) {
 		vm_kfree(cond);
 		return -ENOMEM;
 	}
-
-	cond->queue = NULL;
-
-	hal_memcpy(&cond->attr, attr, sizeof(cond->attr));
 
 	(void)resource_put(p, &cond->resource);
 

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -33,6 +33,8 @@ enum { event_scheduling, event_enqueued, event_waking, event_preempted };
 #define UNLOCK_TRY        0
 #define UNLOCK_FORCE      1
 
+#define THREAD_WAIT_INTERRUPTIBLE (1U << 0)
+#define THREAD_WAIT_EXCLUSIVE     (1U << 1) /* reject a second waiter (unlocked exclusive conditional) */
 
 const struct lockAttr proc_lockAttrDefault = { .type = PH_LOCK_NORMAL };
 
@@ -1039,30 +1041,42 @@ int proc_threadNanoSleep(time_t *sec, long int *nsec, int absolute)
 }
 
 
-static int proc_threadWaitEx(thread_t **queue, spinlock_t *spinlock, time_t timeout, u8 interruptible, spinlock_ctx_t *scp)
+static int proc_threadWaitEx(thread_t **queue, spinlock_t *spinlock, time_t timeout, u32 flags, spinlock_ctx_t *scp)
 {
 	int err;
 	spinlock_ctx_t tsc;
+	spinlock_ctx_t *rescheduleScp = (scp == NULL) ? &tsc : scp;
+
+	LIB_ASSERT((spinlock == NULL) == (scp == NULL), "spinlock and scp must both be NULL or both be non-NULL");
 
 	hal_spinlockSet(&threads_common.spinlock, &tsc);
 
-	if ((interruptible != 0U) && (_proc_current()->exit != 0U)) {
+	if (((flags & THREAD_WAIT_INTERRUPTIBLE) != 0U) && (_proc_current()->exit != 0U)) {
 		/* Waiting in this state can lead to becoming a hanging zombie */
 		hal_spinlockClear(&threads_common.spinlock, &tsc);
 		return -EINTR;
 	}
 
-	_proc_threadEnqueue(queue, timeout, interruptible);
+	if (((flags & THREAD_WAIT_EXCLUSIVE) != 0U) && (*queue != NULL) && (*queue != wakeupPending)) {
+		hal_spinlockClear(&threads_common.spinlock, &tsc);
+		return -EBUSY;
+	}
+
+	_proc_threadEnqueue(queue, timeout, ((flags & THREAD_WAIT_INTERRUPTIBLE) != 0U) ? 1U : 0U);
 
 	if (*queue == NULL) {
 		hal_spinlockClear(&threads_common.spinlock, &tsc);
 		return EOK;
 	}
 
-	/* tsc and scp are swapped intentionally, we need to enable interrupts */
-	hal_spinlockClear(spinlock, &tsc);
-	err = hal_cpuReschedule(&threads_common.spinlock, scp);
-	hal_spinlockSet(spinlock, scp);
+	if (spinlock != NULL) {
+		/* tsc and scp are swapped intentionally, we need to enable interrupts */
+		hal_spinlockClear(spinlock, &tsc);
+	}
+	err = hal_cpuReschedule(&threads_common.spinlock, rescheduleScp);
+	if (spinlock != NULL) {
+		hal_spinlockSet(spinlock, scp);
+	}
 
 	return err;
 }
@@ -1076,7 +1090,13 @@ int proc_threadWait(thread_t **queue, spinlock_t *spinlock, time_t timeout, spin
 
 int proc_threadWaitInterruptible(thread_t **queue, spinlock_t *spinlock, time_t timeout, spinlock_ctx_t *scp)
 {
-	return proc_threadWaitEx(queue, spinlock, timeout, 1U, scp);
+	return proc_threadWaitEx(queue, spinlock, timeout, THREAD_WAIT_INTERRUPTIBLE, scp);
+}
+
+
+int proc_threadWaitExclusive(thread_t **queue, time_t timeout)
+{
+	return proc_threadWaitEx(queue, NULL, timeout, THREAD_WAIT_INTERRUPTIBLE | THREAD_WAIT_EXCLUSIVE, NULL);
 }
 
 
@@ -1831,7 +1851,7 @@ int proc_lockWait(thread_t **queue, lock_t *lock, time_t timeout)
 
 	err = _proc_lockClear(lock);
 	if (err >= 0) {
-		err = proc_threadWaitEx(queue, &lock->spinlock, timeout, 1U, &sc);
+		err = proc_threadWaitInterruptible(queue, &lock->spinlock, timeout, &sc);
 		if (err != -EINTR) {
 			(void)_proc_lockSet(lock, 0U, &sc);
 		}

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -140,6 +140,9 @@ int proc_threadWait(thread_t **queue, spinlock_t *spinlock, time_t timeout, spin
 int proc_threadWaitInterruptible(thread_t **queue, spinlock_t *spinlock, time_t timeout, spinlock_ctx_t *scp);
 
 
+int proc_threadWaitExclusive(thread_t **queue, time_t timeout);
+
+
 int proc_threadWakeup(thread_t **queue);
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This commit introduces `PH_COND_UNLOCKED`, attribute which allows to use conditional variable without mutex. This is useful for utilizing the interrupt-signaled condition variables, where the condition does not require a mutex to be safely checked.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Get rid of redundant locks in device drivers, which surround conditionals signaled through interrupts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/phoenix-rtos-tests/pull/509 https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/265 https://github.com/phoenix-rtos/libphoenix/pull/513 https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/825
- [ ] I will merge this PR by myself when appropriate.
