### PR TITLE
WIP: TEST DO-430 - DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   call-ci:
-    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@master
+    uses: phoenix-rtos/phoenix-rtos-project/.github/workflows/ci-submodule.yml@nalajcie/DO-430
     secrets: inherit
     with:
       cpptest_enabled: true

--- a/hal/armv8m/stm32/n6/timer.c
+++ b/hal/armv8m/stm32/n6/timer.c
@@ -170,3 +170,5 @@ void _hal_timerInit(u32 interval)
 	hal_cpuDataMemoryBarrier();
 	*(timer_common.base + tim_cr1) |= 1U; /* Start counting */
 }
+
+/* WIP: TEST DO-430 - touch a .c file so any_changed=true; to be reverted */


### PR DESCRIPTION
Throwaway PR used **only** to exercise phoenix-rtos-project#1739 (the `cpptest` job cannot be tested from the project repo - submodules pin `ci-submodule.yml@master`).

The WIP commit repoints `uses:` at the `nalajcie/DO-430` project branch. To be closed and the branch deleted after verification. **DO NOT MERGE.**

Test plan:
1. this commit touches only `.yml` -> `Get changed files` must report `any_changed=false` and cpptest must be skipped
2. follow-up commit touches a `.c` file -> `any_changed=true`, cpptest runs, incl. the newly enabled `armv8m55-stm32n6-nucleo` target

TASK: DO-430