### PR TITLE
!proc: increase the number of priorities from 8 to 64

### DIFF
--- a/include/msg.h
+++ b/include/msg.h
@@ -72,7 +72,7 @@ struct _attrAll {
 typedef struct _msg_t {
 	int type;
 	int pid;
-	unsigned int priority;
+	int priority;
 	oid_t oid;
 
 	struct {

--- a/include/syscalls.h
+++ b/include/syscalls.h
@@ -70,7 +70,7 @@
 	ID(signalPost) \
 	ID(signalMask) \
 	ID(signalSuspend) \
-	ID(priority) \
+	ID(sys_priority) \
 	\
 	ID(sys_read) \
 	ID(sys_write) \

--- a/include/threads.h
+++ b/include/threads.h
@@ -15,6 +15,10 @@
 #define _PH_THREADS_H_
 
 
+#define PH_GET_PRIO     0x7fffffff
+#define PH_PRIO_DEFAULT 4
+
+
 /* Mutex attributes */
 
 
@@ -34,7 +38,7 @@ struct lockAttr {
 	unsigned char type;
 	unsigned char protocol;
 	unsigned char robust;
-	unsigned char prioceiling;
+	signed char prioceiling;
 };
 
 

--- a/main.c
+++ b/main.c
@@ -23,6 +23,7 @@
 #include "syspage.h"
 #include "test/test.h"
 #include "perf/perf.h"
+#include "log/log.h"
 
 
 static struct {
@@ -119,17 +120,25 @@ int main(void)
 	(void)_proc_init(&main_common.kmap, &main_common.kernel);
 	_syscalls_init();
 
-#if 0 /* Basic kernel tests */
-	/* Start tests */
+#if 0
+	/*
+	 * Basic kernel tests - should be run in separation with logging disabled
+	 * and without the main_initthr started.
+	 *
+	 * Available tests:
+	 * - test_proc_threads1
+	 * - test_proc_threads2
+	 * - test_vm_kmallocsim
+	 * - test_vm_alloc
+	 * - test_vm_kmalloc
+	 * - test_proc_exit
+	 */
+	log_disable();
 	test_proc_threads1();
-	test_vm_kmallocsim();
-	test_proc_conditional();
-	test_vm_alloc();
-	test_vm_kmalloc();
-	test_proc_exit();
-#endif
-
+	(void)main_initthr;
+#else
 	(void)proc_start(main_initthr, NULL, (const char *)"init");
+#endif
 
 	/* Start scheduling, leave current stack */
 	hal_cpuEnableInterrupts();

--- a/perf/trace-events.h
+++ b/perf/trace-events.h
@@ -205,13 +205,13 @@ static inline void trace_eventThreadMeta(u8 id, const thread_t *t)
 	struct {
 		u16 pid;
 		u16 tid;
-		u8 priority;
+		s8 priority;
 		char name[128];
 	} __attribute__((packed)) ev;
 
 	TRACE_META_BODY(id, ev, NULL, {
 		ev.tid = (u16)proc_getTid(t);
-		ev.priority = (u8)t->priority;
+		ev.priority = (s8)t->priority;
 
 		if (t->process != NULL) {
 			ev.pid = (u16)process_getPid(t->process);
@@ -288,16 +288,16 @@ static inline void trace_eventSchedExit(unsigned int cpuId)
 }
 
 
-static inline void trace_eventThreadPriority(int tid, u8 priority)
+static inline void trace_eventThreadPriority(int tid, priority_t priority)
 {
 	struct {
 		u16 tid;
-		u8 priority;
+		s8 priority;
 	} __attribute__((packed)) ev;
 
 	TRACE_EVENT_BODY(TRACE_EVENT_THREAD_PRIORITY, ev, NULL, {
 		ev.tid = (u16)tid;
-		ev.priority = priority;
+		ev.priority = (s8)priority;
 	});
 }
 

--- a/perf/trace.c
+++ b/perf/trace.c
@@ -170,12 +170,12 @@ static void _emitThreadsCb(void *arg, int i, threadinfo_t *tinfo)
 	struct {
 		u16 pid;
 		u16 tid;
-		u8 priority;
+		s8 priority;
 		char name[128];
 	} __attribute__((packed)) ev;
 
 	ev.tid = (u16)tinfo->tid;
-	ev.priority = (u8)tinfo->priority;
+	ev.priority = (s8)tinfo->priority;
 	ev.pid = (u16)tinfo->pid;
 
 	hal_memcpy(ev.name, tinfo->name, sizeof(tinfo->name));

--- a/perf/tsdl/metadata
+++ b/perf/tsdl/metadata
@@ -14,8 +14,8 @@ trace {
 };
 
 clock {
-    name = monotonic;
-    freq = 1000000;
+	name = monotonic;
+	freq = 1000000;
 };
 
 
@@ -83,7 +83,7 @@ event {
 	fields := struct {
 		u16 pid;
 		u16 tid;
-		u8 prio;
+		i8 prio;
 		str name[128];
 	};
 };
@@ -183,7 +183,8 @@ event {
 	id = 0x31;
 	fields := struct {
 		u16 tid;
-		u8 priority;
+		/* TODO: rename to prio to stay consistent with thread_create and process_exec */
+		i8 priority;
 	};
 };
 
@@ -201,7 +202,9 @@ event {
 	fields := struct {
 		u16 pid;
 		u16 tid;
-		u8 prio;
+		i8 prio;
 		str name[128];
 	};
 };
+
+// vim:noexpandtab:ts=2:sw=2

--- a/proc/lock.h
+++ b/proc/lock.h
@@ -68,7 +68,7 @@ int proc_lockInit(lock_t *lock, const struct lockAttr *attr, const char *name);
 int proc_lockConsistent(lock_t *lock);
 
 
-int proc_lockPrioCeiling(lock_t *lock, int prioceiling);
+int proc_lockPrioCeiling(lock_t *lock, int prioceiling, int *res);
 
 
 int proc_lockDone(lock_t *lock);

--- a/proc/mutex.c
+++ b/proc/mutex.c
@@ -64,7 +64,7 @@ int proc_mutexCreate(const struct lockAttr *attr)
 		return -EINVAL;
 	}
 
-	if (attr->prioceiling > MAX_PRIO) {
+	if (((int)attr->prioceiling < MIN_PRIO) || ((int)attr->prioceiling > MAX_PRIO)) {
 		return -EINVAL;
 	}
 
@@ -144,7 +144,7 @@ int proc_mutexConsistent(int h)
 }
 
 
-int proc_mutexPrioCeiling(int h, int prioceiling)
+int proc_mutexPrioCeiling(int h, int prioceiling, int *res)
 {
 	mutex_t *mutex;
 	int err;
@@ -154,7 +154,7 @@ int proc_mutexPrioCeiling(int h, int prioceiling)
 		return -EINVAL;
 	}
 
-	err = proc_lockPrioCeiling(&mutex->lock, prioceiling);
+	err = proc_lockPrioCeiling(&mutex->lock, prioceiling, res);
 
 	mutex_put(mutex);
 

--- a/proc/mutex.h
+++ b/proc/mutex.h
@@ -39,7 +39,7 @@ int proc_mutexTry(int h);
 int proc_mutexConsistent(int h);
 
 
-int proc_mutexPrioCeiling(int h, int prioceiling);
+int proc_mutexPrioCeiling(int h, int prioceiling, int *res);
 
 
 int proc_mutexUnlock(int h);

--- a/proc/process.c
+++ b/proc/process.c
@@ -230,7 +230,7 @@ int proc_start(startFn_t start, void *arg, const char *path)
 	_resource_init(process);
 	(void)process_alloc(process);
 
-	err = proc_threadCreate(process, start, NULL, 4, SIZE_KSTACK, NULL, 0, 0, (void *)arg);
+	err = proc_threadCreate(process, start, NULL, PH_PRIO_DEFAULT, SIZE_KSTACK, NULL, 0, 0, (void *)arg);
 	if (err < 0) {
 		(void)proc_put(process);
 		return err;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -603,8 +603,6 @@ int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority,
 	t->execdata = NULL;
 	t->wait = NULL;
 	t->locks = NULL;
-	t->stick = 0;
-	t->utick = 0;
 	t->priorityBase = priority;
 	t->priority = priority;
 	t->cpuTime = 0;

--- a/proc/threads.c
+++ b/proc/threads.c
@@ -45,7 +45,14 @@ static struct {
 	vm_map_t *kmap;
 	spinlock_t spinlock;
 	lock_t lock;
-	thread_t *ready[MAX_PRIO + 1U];
+
+	thread_t *ready[NPRIOS];
+	/*
+	 * TODO: optimize and split readyBitmask into u32/u64 bitmask table depending
+	 * on the platform size. Currently, this is suboptimal for 32-bit platforms.
+	 */
+	u64 readyBitmask;
+
 	thread_t **current;
 	time_t utcoffs;
 
@@ -70,9 +77,7 @@ static struct {
 	time_t prev;
 } threads_common;
 
-
-_Static_assert(MAX_PRIO <= (u8)-1, "MAX_PRIO must fit into priority type");
-
+_Static_assert(NPRIOS <= sizeof(threads_common.readyBitmask) * 8U, "NPRIOS must fit into ready bitmask type");
 
 static thread_t *_proc_current(void);
 static void _proc_threadDequeue(thread_t *t);
@@ -198,6 +203,53 @@ static void _threads_updateWakeup(time_t now, thread_t *minimum)
 	}
 
 	hal_timerSetWakeup((unsigned int)wakeup);
+}
+
+
+static void _readyAdd(thread_t *t)
+{
+	int sidx = (int)t->priority + (int)PRIO_OFFSET;
+	unsigned int idx = (unsigned int)sidx;
+
+	LIB_ASSERT_THREADS(sidx >= 0, "bad idx");
+	LIB_ASSERT_THREADS(LIST_BELONGS(&threads_common.ready[idx], t) == 0, "thread already on the ready list");
+
+	LIST_ADD(&threads_common.ready[idx], t);
+	threads_common.readyBitmask |= ((u64)1U << idx);
+}
+
+
+static void _readyRemove(thread_t *t)
+{
+	int sidx = (int)t->priority + (int)PRIO_OFFSET;
+	unsigned int idx = (unsigned int)sidx;
+
+	LIB_ASSERT_THREADS(sidx >= 0, "bad idx");
+	LIB_ASSERT_THREADS(LIST_BELONGS(&threads_common.ready[idx], t) != 0, "thread is not on the ready list");
+
+	LIST_REMOVE(&threads_common.ready[idx], t);
+	if (threads_common.ready[idx] == NULL) {
+		threads_common.readyBitmask &= ~((u64)1U << idx);
+	}
+}
+
+
+static unsigned int _readyMinPrioIdx(void)
+{
+	/* TODO: replace with __builtin_ctzll once GOT issues in sparc libgcc are resolved. */
+	u32 high, low;
+
+	if (threads_common.readyBitmask == 0ULL) {
+		return NPRIOS;
+	}
+
+	low = (u32)threads_common.readyBitmask;
+	if (low != 0U) {
+		return hal_cpuGetFirstBit(low);
+	}
+
+	high = (u32)(threads_common.readyBitmask >> 32);
+	return hal_cpuGetFirstBit(high) + 32U;
 }
 
 
@@ -379,8 +431,8 @@ static int _threads_checkSignal(thread_t *selected, process_t *proc, cpu_context
 /* parasoft-suppress-next-line MISRAC2012-RULE_8_4 "Function is used externally within assembler code" */
 int _threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 {
-	thread_t *current, *selected;
-	unsigned int i;
+	thread_t *current, *selected = NULL;
+	unsigned int idx;
 	process_t *proc;
 	cpu_context_t *signalCtx, *selCtx;
 	unsigned int cpuId = hal_cpuGetID();
@@ -400,21 +452,17 @@ int _threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 
 		/* Move thread to the end of queue */
 		if (current->state == READY) {
-			LIST_ADD(&threads_common.ready[current->priority], current);
+			_readyAdd(current);
 			_threads_preempted(current);
 		}
 	}
 
-	/* Get next thread */
-	i = 0;
-	while (i < sizeof(threads_common.ready) / sizeof(thread_t *)) {
-		selected = threads_common.ready[i];
-		if (selected == NULL) {
-			i++;
-			continue;
-		}
-
-		LIST_REMOVE(&threads_common.ready[i], selected);
+	/* Select next thread */
+	idx = _readyMinPrioIdx();
+	while (idx < NPRIOS) {
+		selected = threads_common.ready[idx];
+		LIB_ASSERT(selected != NULL, "empty queue marked as nonempty?");
+		_readyRemove(selected);
 
 		if (selected->exit == 0U) {
 			break;
@@ -427,6 +475,9 @@ int _threads_schedule(unsigned int n, cpu_context_t *context, void *arg)
 		selected->state = GHOST;
 		LIST_ADD(&threads_common.ghosts, selected);
 		(void)_proc_threadWakeup(&threads_common.reaper);
+
+		idx = _readyMinPrioIdx();
+		selected = NULL;
 	}
 
 	LIB_ASSERT(selected != NULL, "no threads to schedule");
@@ -568,13 +619,13 @@ void threads_canaryInit(thread_t *t, void *ustack)
 }
 
 
-int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority, size_t kstacksz, void *stack, size_t stacksz, unsigned int sigmask, void *arg)
+int proc_threadCreate(process_t *process, startFn_t start, int *id, priority_t priority, size_t kstacksz, void *stack, size_t stacksz, unsigned int sigmask, void *arg)
 {
 	thread_t *t;
 	spinlock_ctx_t sc;
 	int err;
 
-	if (priority >= sizeof(threads_common.ready) / sizeof(thread_t *)) {
+	if (priority < MIN_PRIO || priority > MAX_PRIO) {
 		return -EINVAL;
 	}
 
@@ -660,7 +711,7 @@ int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority,
 	/* Insert thread to scheduler queue */
 
 	_threads_waking(t);
-	LIST_ADD(&threads_common.ready[priority], t);
+	_readyAdd(t);
 
 	hal_spinlockClear(&threads_common.spinlock, &sc);
 
@@ -668,9 +719,9 @@ int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority,
 }
 
 
-static u8 _proc_lockGetPriority(lock_t *lock)
+static priority_t _proc_lockGetPriority(lock_t *lock)
 {
-	u8 priority = MAX_PRIO;
+	priority_t priority = MAX_PRIO;
 	thread_t *thread = lock->queue;
 
 	if (lock->attr.protocol == PH_LOCK_PROTO_PRIOCEILING) {
@@ -690,9 +741,9 @@ static u8 _proc_lockGetPriority(lock_t *lock)
 }
 
 
-static u8 _proc_threadGetLockPriority(thread_t *thread)
+static priority_t _proc_threadGetLockPriority(thread_t *thread)
 {
-	u8 ret, priority = MAX_PRIO;
+	priority_t ret, priority = MAX_PRIO;
 	lock_t *lock = thread->locks;
 
 	if (lock != NULL) {
@@ -709,16 +760,17 @@ static u8 _proc_threadGetLockPriority(thread_t *thread)
 }
 
 
-static u8 _proc_threadGetPriority(thread_t *thread)
+static priority_t _proc_threadGetPriority(thread_t *thread)
 {
-	u8 ret = _proc_threadGetLockPriority(thread);
+	priority_t ret = _proc_threadGetLockPriority(thread);
 	return (ret < thread->priorityBase) ? ret : thread->priorityBase;
 }
 
 
-static void _proc_threadSetPriority(thread_t *thread, u8 priority)
+static void _proc_threadSetPriority(thread_t *thread, priority_t priority)
 {
 	unsigned int i;
+	int onReadyList = 0;
 
 	/* Don't allow decreasing the priority below base level */
 	if (priority > thread->priorityBase) {
@@ -733,35 +785,43 @@ static void _proc_threadSetPriority(thread_t *thread, u8 priority)
 		}
 
 		if (i == hal_cpuGetCount()) {
-			LIB_ASSERT(LIST_BELONGS(&threads_common.ready[thread->priority], thread) != 0,
-					"thread: 0x%p, tid: %d, priority: %d, is not on the ready list",
-					thread, proc_getTid(thread), thread->priority);
-			LIST_REMOVE(&threads_common.ready[thread->priority], thread);
-			LIST_ADD(&threads_common.ready[priority], thread);
+			onReadyList = 1;
 		}
 	}
 
-	thread->priority = priority;
+	if (onReadyList != 0) {
+		_readyRemove(thread);
+		thread->priority = priority;
+		_readyAdd(thread);
+	}
+	else {
+		thread->priority = priority;
+	}
+
 	trace_eventThreadPriority(proc_getTid(thread), thread->priority);
 }
 
 
-int proc_threadPriority(thread_t *t, int signedPriority)
+/* val == PH_GET_PRIO retrieves t priority only */
+int proc_threadPriority(thread_t *t, int val, int *res)
 {
 	spinlock_ctx_t sc;
-	int ret, reschedule = 0;
-	u8 priority;
+	int reschedule = 0, priorityBase;
+	priority_t priority;
 
-	if ((signedPriority < -1) || (signedPriority > (int)MAX_PRIO)) {
+	if ((val != PH_GET_PRIO) && ((val < (int)MIN_PRIO) || (val > (int)MAX_PRIO))) {
 		return -EINVAL;
 	}
 
-	priority = (u8)signedPriority;
+	if ((val == PH_GET_PRIO) && (res == NULL)) {
+		return -EINVAL;
+	}
 
 	hal_spinlockSet(&threads_common.spinlock, &sc);
 
-	/* NOTE: -1 is used to retrieve the thread priority only */
-	if (signedPriority >= 0) {
+	if (val != PH_GET_PRIO) {
+		priority = (priority_t)val;
+
 		/*
 		 * _proc_threadSetPriority will clamp the priority to priorityBase, so it
 		 * must be updated prior to the call
@@ -787,7 +847,8 @@ int proc_threadPriority(thread_t *t, int signedPriority)
 		}
 	}
 
-	ret = (int)t->priorityBase;
+	priorityBase = (int)t->priorityBase;
+	priority = t->priority;
 
 	if (reschedule != 0) {
 		(void)hal_cpuReschedule(&threads_common.spinlock, &sc);
@@ -796,9 +857,13 @@ int proc_threadPriority(thread_t *t, int signedPriority)
 		(void)hal_spinlockClear(&threads_common.spinlock, &sc);
 	}
 
-	trace_eventThreadPriority(proc_getTid(t), t->priority);
+	if (res != NULL) {
+		*res = priorityBase;
+	}
 
-	return ret;
+	trace_eventThreadPriority(proc_getTid(t), priority);
+
+	return EOK;
 }
 
 
@@ -933,7 +998,7 @@ static void _proc_threadDequeue(thread_t *t)
 	}
 
 	if (i == hal_cpuGetCount()) {
-		LIST_ADD(&threads_common.ready[t->priority], t);
+		_readyAdd(t);
 	}
 }
 
@@ -1786,7 +1851,7 @@ static int _proc_lockUnlock(lock_t *lock, int doForceUnlock)
 {
 	thread_t *owner = lock->owner, *current;
 	int ret = 0;
-	u8 lockPriority;
+	priority_t lockPriority;
 
 	current = _proc_current();
 
@@ -2011,17 +2076,21 @@ int proc_lockConsistent(lock_t *lock)
 }
 
 
-/* prioceiling == -1 retrieves current priority ceiling for the lock without obtaining it */
-int proc_lockPrioCeiling(lock_t *lock, int prioceiling)
+/* prioceiling == PH_GET_PRIO retrieves current priority ceiling for the lock without obtaining it */
+int proc_lockPrioCeiling(lock_t *lock, int prioceiling, int *res)
 {
 	spinlock_ctx_t sc;
-	int err;
+	int err, resCeiling;
 
 	if (hal_started() == 0) {
 		return -EINVAL;
 	}
 
-	if (prioceiling < -1 || prioceiling > (int)MAX_PRIO) {
+	if ((prioceiling != PH_GET_PRIO) && ((prioceiling < (int)MIN_PRIO) || prioceiling > (int)MAX_PRIO)) {
+		return -EINVAL;
+	}
+
+	if ((prioceiling == PH_GET_PRIO) && (res == NULL)) {
 		return -EINVAL;
 	}
 
@@ -2029,7 +2098,7 @@ int proc_lockPrioCeiling(lock_t *lock, int prioceiling)
 		return -EINVAL;
 	}
 
-	if (prioceiling >= 0) {
+	if (prioceiling != PH_GET_PRIO) {
 		hal_spinlockSet(&lock->spinlock, &sc);
 		err = _proc_lockSetRaw(lock, 0, &sc);
 		if (err < 0) {
@@ -2038,15 +2107,20 @@ int proc_lockPrioCeiling(lock_t *lock, int prioceiling)
 		}
 		hal_spinlockClear(&lock->spinlock, &sc);
 
-		err = (int)__atomic_exchange_n(&lock->attr.prioceiling, (unsigned char)prioceiling, __ATOMIC_RELAXED);
+		/* parasoft-suppress-next-line MISRAC2012-RULE_10_3-b "__atomic_exchange_1 uses unsigned char but __atomic_exchange_n requires first two arg types to match." */
+		resCeiling = (int)__atomic_exchange_n(&lock->attr.prioceiling, (signed char)prioceiling, __ATOMIC_RELAXED);
 
 		(void)proc_lockClear(lock);
 	}
 	else {
-		err = (int)__atomic_load_n(&lock->attr.prioceiling, __ATOMIC_RELAXED);
+		resCeiling = (int)__atomic_load_n(&lock->attr.prioceiling, __ATOMIC_RELAXED);
 	}
 
-	return err;
+	if (res != NULL) {
+		*res = resCeiling;
+	}
+
+	return EOK;
 }
 
 
@@ -2113,10 +2187,12 @@ static void threads_idlethr(void *arg)
 }
 
 
-void proc_threadsDump(u8 priority)
+void proc_threadsDump(priority_t priority)
 {
 	thread_t *t;
 	spinlock_ctx_t sc;
+	int sidx = (int)priority + (int)PRIO_OFFSET;
+	size_t idx = (size_t)sidx;
 
 	/* Strictly needed - no lock can be taken
 	 * while threads_common.spinlock is being
@@ -2126,7 +2202,7 @@ void proc_threadsDump(u8 priority)
 	lib_printf("threads: ");
 	hal_spinlockSet(&threads_common.spinlock, &sc);
 
-	t = threads_common.ready[priority];
+	t = threads_common.ready[idx];
 	do {
 		lib_printf("[%p] ", t);
 
@@ -2135,7 +2211,7 @@ void proc_threadsDump(u8 priority)
 		}
 
 		t = t->next;
-	} while (t != threads_common.ready[priority]);
+	} while (t != threads_common.ready[idx]);
 	hal_spinlockClear(&threads_common.spinlock, &sc);
 
 	lib_printf("\n");
@@ -2282,7 +2358,7 @@ int proc_schedInfo(int policy, sched_info_t *info)
 	}
 
 	info->interval = SYSTICK_INTERVAL;
-	info->minPriority = 0;
+	info->minPriority = (int)MIN_PRIO;
 	info->maxPriority = (int)MAX_PRIO;
 
 	return EOK;
@@ -2309,8 +2385,6 @@ int proc_schedGet(thread_t *t, sched_params_t *params)
 
 int proc_schedSet(thread_t *t, int policy, sched_params_t *params)
 {
-	int err;
-
 	if (policy != SCHED_FIFO && policy != SCHED_RR && policy != SCHED_OTHER) {
 		return -EINVAL;
 	}
@@ -2319,12 +2393,11 @@ int proc_schedSet(thread_t *t, int policy, sched_params_t *params)
 		return -ENOTSUP;
 	}
 
-	if (params->priorityBase < 0) {
+	if (params->priorityBase == PH_GET_PRIO) {
 		return -EINVAL;
 	}
 
-	err = proc_threadPriority(t, params->priorityBase);
-	return err < 0 ? err : EOK;
+	return proc_threadPriority(t, params->priorityBase, NULL);
 }
 
 
@@ -2344,15 +2417,14 @@ int _threads_init(vm_map_t *kmap, vm_object_t *kernel)
 		threads_common.stackCanary[i] = ((i & 1U) != 0U) ? 0xaaU : 0x55U;
 	}
 
-	/* Initiaizlie scheduler queue */
-	for (i = 0; i < sizeof(threads_common.ready) / sizeof(thread_t *); i++) {
-		threads_common.ready[i] = NULL;
-	}
+	/* Initialize scheduler queue */
+	threads_common.readyBitmask = 0;
+	hal_memset(threads_common.ready, 0, sizeof(threads_common.ready));
 
 	lib_rbInit(&threads_common.sleeping, threads_sleepcmp, NULL);
 	lib_idtreeInit(&threads_common.id);
 
-	lib_printf("proc: Initializing thread scheduler, priorities=%d\n", sizeof(threads_common.ready) / sizeof(thread_t *));
+	lib_printf("proc: Initializing thread scheduler, priorities=%u\n", NPRIOS);
 
 	hal_spinlockCreate(&threads_common.spinlock, "threads.spinlock");
 

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -66,9 +66,6 @@ typedef struct _thread_t {
 	unsigned int sigmask;
 	unsigned int sigpend;
 
-	time_t stick;
-	time_t utick;
-
 	void *kstack;
 	size_t kstacksz;
 	char *ustack;

--- a/proc/threads.h
+++ b/proc/threads.h
@@ -22,13 +22,27 @@
 #include "process.h"
 #include "lock.h"
 
+#include <board_config.h>
+
 #ifdef DEBUG_THREADS
 #define LIB_ASSERT_THREADS(condition, fmt, ...) LIB_ASSERT_ALWAYS((condition), (fmt), ##__VA_ARGS__)
 #else
 #define LIB_ASSERT_THREADS(condition, fmt, ...)
 #endif
 
-#define MAX_PRIO 7U /* Maximum priority value, of the lowest criticality (prio=0 is of the HIGHEST) */
+#ifndef NPRIOS
+#define NPRIOS 64U
+#endif
+
+_Static_assert(NPRIOS % 2U == 0U, "NPRIOS should be even");
+_Static_assert(NPRIOS >= 16U, "NPRIOS should be greater than 16");
+
+typedef s8 priority_t;
+_Static_assert(NPRIOS <= (1UL << (sizeof(priority_t) * 8U)), "NPRIOS must fit into priority_t range");
+
+#define PRIO_OFFSET (NPRIOS / 2U)
+#define MAX_PRIO    (((priority_t)PRIO_OFFSET) - 1) /* Maximum priority value, of the lowest criticality (scheduled when no threads with p < MAX_PRIO are ready) */
+#define MIN_PRIO    (-((priority_t)PRIO_OFFSET))    /* Minimum priority value, of the HIGHEST criticality (scheduled before MIN_PRIO + 1) */
 
 #define MAX_TID        MAX_ID
 #define THREAD_END     1U
@@ -57,11 +71,12 @@ typedef struct _thread_t {
 	struct _thread_t **wait;
 	time_t wakeup;
 
-	unsigned int priorityBase : 4;
-	unsigned int priority : 4;
+	priority_t priorityBase;
+	priority_t priority;
+
 	unsigned int state : 2;
 	unsigned int exit : 2;
-	unsigned interruptible : 1;
+	unsigned int interruptible : 1;
 
 	unsigned int sigmask;
 	unsigned int sigpend;
@@ -100,10 +115,11 @@ thread_t *proc_current(void);
 void threads_canaryInit(thread_t *t, void *ustack);
 
 
-int proc_threadCreate(process_t *process, startFn_t start, int *id, u8 priority, size_t kstacksz, void *stack, size_t stacksz, unsigned int sigmask, void *arg);
+int proc_threadCreate(process_t *process, startFn_t start, int *id, priority_t priority, size_t kstacksz, void *stack, size_t stacksz, unsigned int sigmask, void *arg);
 
 
-int proc_threadPriority(thread_t *t, int signedPriority);
+/* Sets the priority of t to val or retrieves the current priority of t when val == PH_GET_PRIO. Returns the current priority of t in *res if res != NULL. */
+int proc_threadPriority(thread_t *t, int val, int *res);
 
 
 __attribute__((noreturn)) void proc_threadEnd(void);
@@ -190,7 +206,7 @@ int proc_settime(time_t offs);
 __attribute__((noreturn)) void proc_longjmp(cpu_context_t *ctx);
 
 
-void proc_threadsDump(u8 priority);
+void proc_threadsDump(priority_t priority);
 
 
 int _threads_init(vm_map_t *kmap, vm_object_t *kernel);

--- a/syscalls.c
+++ b/syscalls.c
@@ -303,13 +303,14 @@ int syscalls_beginthreadex(u8 *ustack)
 {
 	process_t *proc = proc_current()->process;
 	startFn_t start;
-	unsigned int priority, stacksz; /* FIXME: stacksz should probably be size_t */
+	int priority;
+	unsigned int stacksz; /* FIXME: stacksz should probably be size_t */
 	void *stack, *arg;
 	int *id;
 	int err;
 
 	GETFROMSTACK(ustack, startFn_t, start, 0U);
-	GETFROMSTACK(ustack, unsigned int, priority, 1U);
+	GETFROMSTACK(ustack, int, priority, 1U);
 	GETFROMSTACK(ustack, void *, stack, 2U);
 	GETFROMSTACK(ustack, unsigned int, stacksz, 3U);
 	GETFROMSTACK(ustack, void *, arg, 4U);
@@ -319,13 +320,13 @@ int syscalls_beginthreadex(u8 *ustack)
 		return -EFAULT;
 	}
 
-	if (priority > (u8)-1) {
+	if (priority < (int)MIN_PRIO || priority > (int)MAX_PRIO) {
 		return -EINVAL;
 	}
 
 	proc_get(proc);
 
-	err = proc_threadCreate(proc, start, id, (u8)priority, (size_t)SIZE_KSTACK, stack, (size_t)stacksz, proc_current()->sigmask, arg);
+	err = proc_threadCreate(proc, start, id, (priority_t)priority, (size_t)SIZE_KSTACK, stack, (size_t)stacksz, proc_current()->sigmask, arg);
 
 	if (err < 0) {
 		(void)proc_put(proc);
@@ -369,13 +370,18 @@ int syscalls_nsleep(u8 *ustack)
 }
 
 
-int syscalls_priority(u8 *ustack)
+int syscalls_sys_priority(u8 *ustack)
 {
-	int priority;
+	int val, *res;
 
-	GETFROMSTACK(ustack, int, priority, 0U);
+	GETFROMSTACK(ustack, int, val, 0U);
+	GETFROMSTACK(ustack, int *, res, 1U);
 
-	return proc_threadPriority(proc_current(), priority);
+	if ((res != NULL) && (vm_mapBelongs(proc_current()->process, res, sizeof(*res)) < 0)) {
+		return -EFAULT;
+	}
+
+	return proc_threadPriority(proc_current(), val, res);
 }
 
 
@@ -762,12 +768,17 @@ int syscalls_mutexConsistent(u8 *ustack)
 int syscalls_mutexPrioCeiling(u8 *ustack)
 {
 	handle_t h;
-	int prioceiling;
+	int prioceiling, *res;
 
 	GETFROMSTACK(ustack, handle_t, h, 0U);
 	GETFROMSTACK(ustack, int, prioceiling, 1U);
+	GETFROMSTACK(ustack, int *, res, 2U);
 
-	return proc_mutexPrioCeiling(h, prioceiling);
+	if ((res != NULL) && (vm_mapBelongs(proc_current()->process, res, sizeof(*res)) < 0)) {
+		return -EFAULT;
+	}
+
+	return proc_mutexPrioCeiling(h, prioceiling, res);
 }
 
 

--- a/test/proc.c
+++ b/test/proc.c
@@ -20,7 +20,7 @@
 
 
 struct {
-	volatile unsigned int rotations[8];
+	volatile unsigned int rotations[NPRIOS];
 	volatile time_t tm;
 	spinlock_t spinlock;
 	thread_t *queue;
@@ -35,28 +35,37 @@ struct {
 
 static void test_proc_indthr(void *arg)
 {
-	char *indicator = "o|/-\\|/-\\";
+	const char *indicator = "o|/-\\|/-\\";
+	const int k = 8;
+	int i;
 
 	lib_printf("test: [proc.threads] Starting indicating thread\n");
 	hal_consolePrint(ATTR_USER, "\033[?25l");
 
 	for (;;) {
-		lib_printf("\rtest: [proc.threads] %c %c %c %c %c %c %c  %02d %02d %02d %02d %02d %02d %02d",
-				indicator[test_proc_common.rotations[1] % 8U],
-				indicator[test_proc_common.rotations[2] % 8U],
-				indicator[test_proc_common.rotations[3] % 8U],
-				indicator[test_proc_common.rotations[4] % 8U],
-				indicator[test_proc_common.rotations[5] % 8U],
-				indicator[test_proc_common.rotations[6] % 8U],
-				indicator[test_proc_common.rotations[7] % 8U],
+		for (i = 0; i < k; i++) {
+			lib_printf("test: [proc.threads] %02d %c %c %c %c %c %c %c %c  %02d %02d %02d %02d %02d %02d %02d %02d\n",
+					i * k,
+					indicator[test_proc_common.rotations[i * k + 0] % 8U],
+					indicator[test_proc_common.rotations[i * k + 1] % 8U],
+					indicator[test_proc_common.rotations[i * k + 2] % 8U],
+					indicator[test_proc_common.rotations[i * k + 3] % 8U],
+					indicator[test_proc_common.rotations[i * k + 4] % 8U],
+					indicator[test_proc_common.rotations[i * k + 5] % 8U],
+					indicator[test_proc_common.rotations[i * k + 6] % 8U],
+					indicator[test_proc_common.rotations[i * k + 7] % 8U],
 
-				test_proc_common.rotations[1] % 100U,
-				test_proc_common.rotations[2] % 100U,
-				test_proc_common.rotations[3] % 100U,
-				test_proc_common.rotations[4] % 100U,
-				test_proc_common.rotations[5] % 100U,
-				test_proc_common.rotations[6] % 100U,
-				test_proc_common.rotations[7] % 100U);
+					test_proc_common.rotations[i * k + 0] % 100U,
+					test_proc_common.rotations[i * k + 1] % 100U,
+					test_proc_common.rotations[i * k + 2] % 100U,
+					test_proc_common.rotations[i * k + 3] % 100U,
+					test_proc_common.rotations[i * k + 4] % 100U,
+					test_proc_common.rotations[i * k + 5] % 100U,
+					test_proc_common.rotations[i * k + 6] % 100U,
+					test_proc_common.rotations[i * k + 7] % 100U);
+		}
+
+		lib_printf("\033[8A\r");
 
 		proc_threadSleep(5000);
 	}
@@ -110,20 +119,17 @@ static void test_proc_rotthr1(void *arg)
 void test_proc_threads1(void)
 {
 	unsigned int i, stacksz = 1384;
-	for (i = 0; i < 8U; i++) {
+	for (i = 0; i < NPRIOS; i++) {
 		test_proc_common.rotations[i] = 0;
 	}
 
-	proc_threadCreate(NULL, test_proc_indthr, NULL, 0, stacksz, NULL, 0, 0, NULL);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 1, stacksz, NULL, 0, 0, (void *)(int *)1);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 2, stacksz, NULL, 0, 0, (void *)(int *)2);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 3, stacksz, NULL, 0, 0, (void *)(int *)3);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 4, stacksz, NULL, 0, 0, (void *)(int *)4);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 5, stacksz, NULL, 0, 0, (void *)(int *)5);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 6, stacksz, NULL, 0, 0, (void *)(int *)6);
-	proc_threadCreate(NULL, test_proc_rotthr1, NULL, 7, stacksz, NULL, 0, 0, (void *)(int *)7);
+	proc_threadCreate(NULL, test_proc_indthr, NULL, MIN_PRIO, stacksz, NULL, 0, 0, NULL);
 
-	proc_threadCreate(NULL, test_proc_busythr, NULL, 4, 1024, NULL, 0, 0, NULL);
+	for (i = 1; i < NPRIOS; i++) {
+		proc_threadCreate(NULL, test_proc_rotthr1, NULL, MIN_PRIO + i, stacksz, NULL, 0, 0, (void *)(ptr_t)i);
+	}
+
+	proc_threadCreate(NULL, test_proc_busythr, NULL, 0, 1024, NULL, 0, 0, NULL);
 }
 
 
@@ -158,7 +164,7 @@ static void test_proc_rotthr2(void *arg)
 void test_proc_threads2(void)
 {
 	unsigned int i;
-	for (i = 0; i < 8U; i++) {
+	for (i = 0; i < NPRIOS; i++) {
 		test_proc_common.rotations[i] = 0;
 	}
 
@@ -166,13 +172,12 @@ void test_proc_threads2(void)
 	test_proc_common.queue = NULL;
 	hal_spinlockCreate(&test_proc_common.spinlock, "test_proc_common.spinlock");
 
-	proc_threadCreate(NULL, test_proc_indthr, NULL, 0, 1024, NULL, 0, 0, NULL);
-	proc_threadCreate(NULL, test_proc_timethr, NULL, 0, 1024, NULL, 0, 0, NULL);
+	proc_threadCreate(NULL, test_proc_indthr, NULL, MIN_PRIO, 1024, NULL, 0, 0, NULL);
+	proc_threadCreate(NULL, test_proc_timethr, NULL, MIN_PRIO, 1024, NULL, 0, 0, NULL);
 
-	proc_threadCreate(NULL, test_proc_rotthr2, NULL, 1, 1024, NULL, 0, 0, (void *)(int *)1);
-	proc_threadCreate(NULL, test_proc_rotthr2, NULL, 2, 1024, NULL, 0, 0, (void *)(int *)2);
-	proc_threadCreate(NULL, test_proc_rotthr2, NULL, 3, 1024, NULL, 0, 0, (void *)(int *)3);
-	proc_threadCreate(NULL, test_proc_rotthr2, NULL, 4, 1024, NULL, 0, 0, (void *)(int *)4);
+	for (i = 8; i < NPRIOS; i += 8) {
+		proc_threadCreate(NULL, test_proc_rotthr2, NULL, MIN_PRIO + i, 1024, NULL, 0, 0, (void *)(ptr_t)i);
+	}
 }
 
 

--- a/usrv.c
+++ b/usrv.c
@@ -64,7 +64,7 @@ void _usrv_start(void)
 		return;
 	}
 
-	(void)proc_threadCreate(NULL, usrv_msgthr, NULL, 1, (size_t)SIZE_KSTACK, NULL, 0, 0, NULL);
+	(void)proc_threadCreate(NULL, usrv_msgthr, NULL, MIN_PRIO + 1, (size_t)SIZE_KSTACK, NULL, 0, 0, NULL);
 }
 
 


### PR DESCRIPTION
This change moves the priority range from [0,7] to [-32,31].

This change is breaking:
1. The priority had to be made signed.
2. The priority syscall has been renamed to sys_priority.
3. As a consequence of 1., the API of sys_priority and mutexPrioCeiling syscalls was modified to return current priority and previous priority ceiling, respectively, through an extra argument instead of the retval. Otherwise legal negative priority values would conflict with errors.

[-32,31] range instead of [0,63] was chosen, as the existing userspace code is concentrated in the high prio range (<4) with 4 usually being the default thread priority. Expanding the range to negative values is a way to relax that contention without the need to reconfigure/rescale the priorities in the userspace code.

If needed, the readyBitmask can be extended with an L2 bitmask to support more priorities.

If needed, NPRIOS can be set to lower even values if memory is a concern.

TASK: RTOS-1434

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [X] New test added: kernel self-tests updated
- [x] Tested by hand on: ia32

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/815
- [x] I will merge this PR by myself when appropriate.
