### PR TITLE
hal/stm32u3: add support for low-power mode

### DIFF
--- a/hal/armv8m/cpu.c
+++ b/hal/armv8m/cpu.c
@@ -20,6 +20,10 @@
 
 #include "config.h"
 
+#ifndef STM32_ENABLE_LOW_POWER
+#define STM32_ENABLE_LOW_POWER 0
+#endif
+
 static struct {
 	int busy;
 	spinlock_t busySp;
@@ -31,14 +35,33 @@ static struct {
 
 void hal_cpuLowPower(time_t us, spinlock_t *spinlock, spinlock_ctx_t *sc)
 {
+#if STM32_ENABLE_LOW_POWER
+	spinlock_ctx_t scp;
+
+	hal_spinlockSet(&cpu_common.busySp, &scp);
+	if (cpu_common.busy == 0) {
+		_stm32_pwrEnterLPStop(us);
+		hal_spinlockClear(&cpu_common.busySp, &scp);
+	}
+	else {
+		hal_spinlockClear(&cpu_common.busySp, &scp);
+		hal_cpuHalt();
+	}
+	hal_spinlockClear(spinlock, sc);
+#else
 	hal_spinlockClear(spinlock, sc);
 	hal_cpuHalt();
+#endif
 }
 
 
 int hal_cpuLowPowerAvail(void)
 {
+#if STM32_ENABLE_LOW_POWER
+	return 1;
+#else
 	return 0;
+#endif
 }
 
 

--- a/hal/armv8m/stm32/Makefile
+++ b/hal/armv8m/stm32/Makefile
@@ -12,4 +12,4 @@ else ifneq (, $(findstring u3, $(TARGET_SUBFAMILY)))
     include hal/armv8m/stm32/u3/Makefile
 endif
 
-OBJS += $(addprefix $(PREFIX_O)hal/armv8m/stm32/, console.o)
+OBJS += $(addprefix $(PREFIX_O)hal/armv8m/stm32/, console.o gpio.o)

--- a/hal/armv8m/stm32/gpio.c
+++ b/hal/armv8m/stm32/gpio.c
@@ -1,0 +1,340 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system kernel
+ *
+ * HAL STM32 GPIO and EXTI driver
+ *
+ * Copyright 2020, 2025, 2026 Phoenix Systems
+ * Author: Aleksander Kaminski, Pawel Pisarczyk, Jacek Maksymowicz
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "hal/armv8m/stm32/stm32.h"
+
+#include "hal/cpu.h"
+#include "hal/hal.h"
+#include "include/errno.h"
+
+/*
+ * Note: the lookups depend on all pctl_gpio* enum values being aligned with alphabet letters in sequence,
+ * i.e. pctl_gpiob == (pctl_gpioa + 1), pctl_gpioz == (pctl_gpioa + 25).
+ */
+
+#if defined(__CPU_STM32N6)
+#include "hal/armv8m/stm32/n6/stm32n6_regs.h"
+
+#define MAX_GPIO pctl_gpioq
+
+static volatile u32 *const stm32_gpioBase[MAX_GPIO - pctl_gpioa + 1] = {
+	(volatile u32 *)0x56020000U, /* GPIOA */
+	(volatile u32 *)0x56020400U, /* GPIOB */
+	(volatile u32 *)0x56020800U, /* GPIOC */
+	(volatile u32 *)0x56020c00U, /* GPIOD */
+	(volatile u32 *)0x56021000U, /* GPIOE */
+	(volatile u32 *)0x56021400U, /* GPIOF */
+	(volatile u32 *)0x56021800U, /* GPIOG */
+	(volatile u32 *)0x56021c00U, /* GPIOH */
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	(volatile u32 *)0x56023400U, /* GPION */
+	(volatile u32 *)0x56023800U, /* GPIOO */
+	(volatile u32 *)0x56023c00U, /* GPIOP */
+	(volatile u32 *)0x56024000U, /* GPIOQ */
+};
+
+#define EXTI_BASE  ((void *)0x56025000U)
+#define EXTI_LINES 78U
+#elif defined(__CPU_STM32U3)
+#include "hal/armv8m/stm32/u3/stm32u3_regs.h"
+
+#define MAX_GPIO pctl_gpioh
+
+static volatile u32 *const stm32_gpioBase[MAX_GPIO - pctl_gpioa + 1] = {
+	(volatile u32 *)0x52020000U, /* GPIOA */
+	(volatile u32 *)0x52020400U, /* GPIOB */
+	(volatile u32 *)0x52020800U, /* GPIOC */
+	(volatile u32 *)0x52020c00U, /* GPIOD */
+	(volatile u32 *)0x52021000U, /* GPIOE */
+	(volatile u32 *)0x52021400U, /* GPIOF */
+	(volatile u32 *)0x52021800U, /* GPIOG */
+	(volatile u32 *)0x52021c00U, /* GPIOH */
+};
+
+#define EXTI_BASE  ((void *)0x50032000U)
+#define EXTI_LINES 23U
+#else
+#error "Unsupported platform"
+#endif
+
+static volatile u32 *const stm32_extiBase = EXTI_BASE;
+
+
+/* GPIO */
+
+
+static volatile u32 *_stm32_gpioGetBase(int d)
+{
+	if ((d < pctl_gpioa) || (d > MAX_GPIO)) {
+		return NULL;
+	}
+
+	return stm32_gpioBase[d - pctl_gpioa];
+}
+
+
+int _stm32_gpioConfig(int d, u8 pin, u8 mode, u8 af, u8 otype, u8 ospeed, u8 pupd)
+{
+	volatile u32 *base;
+	u32 t;
+
+	base = _stm32_gpioGetBase(d);
+	if ((base == NULL) || (pin > 15U)) {
+		return -EINVAL;
+	}
+
+	t = *(base + gpio_moder) & ~(0x3UL << (pin << 1));
+	*(base + gpio_moder) = t | ((u32)mode & 0x3U) << (pin << 1);
+
+	t = *(base + gpio_otyper) & ~(1UL << pin);
+	*(base + gpio_otyper) = t | ((u32)otype & 1U) << pin;
+
+	t = *(base + gpio_ospeedr) & ~(0x3UL << (pin << 1));
+	*(base + gpio_ospeedr) = t | ((u32)ospeed & 0x3U) << (pin << 1);
+
+	t = *(base + gpio_pupdr) & ~(0x03UL << (pin << 1));
+	*(base + gpio_pupdr) = t | ((u32)pupd & 0x3U) << (pin << 1);
+
+	if (pin < 8U) {
+		t = *(base + gpio_afrl) & ~(0xfUL << (pin << 2));
+		*(base + gpio_afrl) = t | ((u32)af & 0xfU) << (pin << 2);
+	}
+	else {
+		t = *(base + gpio_afrh) & ~(0xfUL << ((pin - 8U) << 2));
+		*(base + gpio_afrh) = t | ((u32)af & 0xfU) << ((pin - 8U) << 2);
+	}
+
+	return EOK;
+}
+
+
+int _stm32_gpioSet(int d, u8 pin, u8 val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if ((base == NULL) || (pin > 15U)) {
+		return -EINVAL;
+	}
+
+	*(base + gpio_bsrr) = 1UL << ((val == 0U) ? ((u32)pin + 16U) : (u32)pin);
+	return EOK;
+}
+
+
+int _stm32_gpioSetPort(int d, u16 val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if (base == NULL) {
+		return -EINVAL;
+	}
+
+	*(base + gpio_odr) = (u32)val;
+
+	return EOK;
+}
+
+
+int _stm32_gpioGet(int d, u8 pin, u8 *val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if ((base == NULL) || (pin > 15U)) {
+		return -EINVAL;
+	}
+
+	*val = (u8)(*(base + gpio_idr) >> pin) & 1U;
+
+	return EOK;
+}
+
+
+int _stm32_gpioGetPort(int d, u32 *val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if (base == NULL) {
+		return -EINVAL;
+	}
+
+	*val = *(base + gpio_idr);
+
+	return EOK;
+}
+
+
+#if STM32_GPIO_PRIVILEGE
+int _stm32_gpioSetPrivilege(int d, u32 val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if (base == NULL) {
+		return -EINVAL;
+	}
+
+	*(base + gpio_privcfgr) = val;
+
+	return EOK;
+}
+
+
+int _stm32_gpioGetPrivilege(int d, u32 *val)
+{
+	volatile u32 *base;
+
+	base = _stm32_gpioGetBase(d);
+	if (base == NULL) {
+		return -EINVAL;
+	}
+
+	*val = *(base + gpio_privcfgr);
+
+	return EOK;
+}
+#endif
+
+
+/* EXTI */
+
+
+static int _stm32_extiLineToRegBit(u32 line, u32 *reg_offs, u32 *bit)
+{
+	if (line >= EXTI_LINES) {
+		return -1;
+	}
+
+	*reg_offs = (line / 32U) * 8U;
+	*bit = (1UL << (line % 32U));
+	return 0;
+}
+
+
+int _stm32_extiMaskInterrupt(u32 line, u8 state)
+{
+	u32 offs, bit;
+	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
+		return -EINVAL;
+	}
+
+	offs += (u32)exti_imr1;
+	if (state != 0U) {
+		*(stm32_extiBase + offs) |= bit;
+	}
+	else {
+		*(stm32_extiBase + offs) &= ~bit;
+	}
+
+	return EOK;
+}
+
+
+int _stm32_extiMaskEvent(u32 line, u8 state)
+{
+	u32 offs, bit;
+	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
+		return -EINVAL;
+	}
+
+	offs += (u32)exti_emr1;
+	if (state != 0U) {
+		*(stm32_extiBase + offs) |= bit;
+	}
+	else {
+		*(stm32_extiBase + offs) &= ~bit;
+	}
+
+	return EOK;
+}
+
+
+int _stm32_extiSetTrigger(u32 line, u8 state, u8 edge)
+{
+	u32 offs, bit;
+	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
+		return -EINVAL;
+	}
+
+	offs += (u32)((edge != 0U) ? exti_rtsr1 : exti_ftsr1);
+	if (state != 0U) {
+		*(stm32_extiBase + offs) |= bit;
+	}
+	else {
+		*(stm32_extiBase + offs) &= ~bit;
+	}
+
+	return EOK;
+}
+
+
+int _stm32_extiSoftInterrupt(u32 line)
+{
+	u32 offs, bit;
+	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
+		return -EINVAL;
+	}
+
+	*(stm32_extiBase + exti_swier1 + offs) |= bit;
+	return EOK;
+}
+
+
+static u32 _stm32_extiGetMuxValue(int gpioDev)
+{
+	int num;
+	num = gpioDev - pctl_gpioa;
+#if defined(__CPU_STM32N6)
+	/* This is one of very few cases on STM32N6 where port numbering is continuous, without a hole for missing ports */
+	if (gpioDev >= pctl_gpion) {
+		num -= (pctl_gpion - pctl_gpioh) - 1;
+	}
+#endif
+
+	return ((u32)num) & 0xffUL;
+}
+
+
+int _stm32_extiSetGpioMux(int gpioDev, u8 pin)
+{
+	u32 val, mux;
+	u8 shift, offset;
+	if ((pin > 15U) || (_stm32_gpioGetBase(gpioDev) == NULL)) {
+		return -EINVAL;
+	}
+
+	shift = (pin % 4U) * 8U;
+	offset = pin / 4U;
+	mux = _stm32_extiGetMuxValue(gpioDev);
+	val = *(stm32_extiBase + exti_exticr1 + offset) & ~(0xffUL << shift);
+	*(stm32_extiBase + exti_exticr1 + offset) = val | (mux << shift);
+	return EOK;
+}
+
+
+void _stm32_gpioInit(void)
+{
+	int i;
+	for (i = pctl_gpioa; i <= MAX_GPIO; i++) {
+		if (stm32_gpioBase[i - pctl_gpioa] != NULL) {
+			(void)_stm32_rccSetDevClock(i, 1, 1);
+		}
+	}
+}

--- a/hal/armv8m/stm32/n6/stm32n6.c
+++ b/hal/armv8m/stm32/n6/stm32n6.c
@@ -42,41 +42,24 @@
 #endif
 
 
-#define GPIOA_BASE ((void *)0x56020000U)
-#define GPIOB_BASE ((void *)0x56020400U)
-#define GPIOC_BASE ((void *)0x56020800U)
-#define GPIOD_BASE ((void *)0x56020c00U)
-#define GPIOE_BASE ((void *)0x56021000U)
-#define GPIOF_BASE ((void *)0x56021400U)
-#define GPIOG_BASE ((void *)0x56021800U)
-#define GPIOH_BASE ((void *)0x56021c00U)
-#define GPION_BASE ((void *)0x56023400U)
-#define GPIOO_BASE ((void *)0x56023800U)
-#define GPIOP_BASE ((void *)0x56023c00U)
-#define GPIOQ_BASE ((void *)0x56024000U)
-
 #define IWDG_BASE     ((void *)0x56004800U)
 #define PWR_BASE      ((void *)0x56024800U)
 #define RCC_BASE      ((void *)0x56028000U)
 #define RTC_BASE      ((void *)0x56004000U)
 #define SYSCFG_BASE   ((void *)0x56008000U)
-#define EXTI_BASE     ((void *)0x56025000U)
 #define RIFSC_BASE    ((void *)0x54024000U)
 #define GPDMA1_BASE   ((void *)0x50021000U)
 #define HPDMA1_BASE   ((void *)0x58020000U)
 #define DBGMCU_BASE   ((void *)0x54001000U)
 #define CACHEAXI_BASE ((void *)0x580dfc00U)
 
-#define EXTI_LINES   78U
 #define DMA_CHANNELS 16U
 
 
 static struct {
 	volatile u32 *rcc;
-	volatile u32 *gpio[17];
 	volatile u32 *pwr;
 	volatile u32 *rtc;
-	volatile u32 *exti;
 	volatile u32 *syscfg;
 	volatile u32 *iwdg;
 	volatile u32 *rifsc;
@@ -783,227 +766,6 @@ void _stm32_rtcLockRegs(void)
 }
 
 
-/* EXTI */
-
-
-static int _stm32_extiLineToRegBit(u32 line, u32 *reg_offs, u32 *bit)
-{
-	if (line >= EXTI_LINES) {
-		return -1;
-	}
-
-	*reg_offs = (line / 32U) * 8U;
-	*bit = (1UL << (line % 32U));
-	return 0;
-}
-
-
-int _stm32_extiMaskInterrupt(u32 line, u8 state)
-{
-	u32 offs, bit;
-	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
-		return -EINVAL;
-	}
-
-	offs += (u32)exti_imr1;
-	if (state != 0U) {
-		*(stm32_common.exti + offs) |= bit;
-	}
-	else {
-		*(stm32_common.exti + offs) &= ~bit;
-	}
-
-	return EOK;
-}
-
-
-int _stm32_extiMaskEvent(u32 line, u8 state)
-{
-	u32 offs, bit;
-	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
-		return -EINVAL;
-	}
-
-	offs += (u32)exti_emr1;
-	if (state != 0U) {
-		*(stm32_common.exti + offs) |= bit;
-	}
-	else {
-		*(stm32_common.exti + offs) &= ~bit;
-	}
-
-	return EOK;
-}
-
-
-int _stm32_extiSetTrigger(u32 line, u8 state, u8 edge)
-{
-	u32 offs, bit;
-	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
-		return -EINVAL;
-	}
-
-	offs += (u32)((edge != 0U) ? exti_rtsr1 : exti_ftsr1);
-	if (state != 0U) {
-		*(stm32_common.exti + offs) |= bit;
-	}
-	else {
-		*(stm32_common.exti + offs) &= ~bit;
-	}
-
-	return EOK;
-}
-
-
-int _stm32_extiSoftInterrupt(u32 line)
-{
-	u32 offs, bit;
-	if (_stm32_extiLineToRegBit(line, &offs, &bit) < 0) {
-		return -EINVAL;
-	}
-
-	*(stm32_common.exti + exti_swier1 + offs) |= bit;
-	return EOK;
-}
-
-
-/* GPIO */
-
-
-static volatile u32 *_stm32_gpioGetBase(int d)
-{
-	if ((d < pctl_gpioa) || (d > pctl_gpioq)) {
-		return NULL;
-	}
-
-	return stm32_common.gpio[d - pctl_gpioa];
-}
-
-
-int _stm32_gpioConfig(int d, u8 pin, u8 mode, u8 af, u8 otype, u8 ospeed, u8 pupd)
-{
-	volatile u32 *base;
-	u32 t;
-
-	base = _stm32_gpioGetBase(d);
-	if ((base == NULL) || (pin > 15U)) {
-		return -EINVAL;
-	}
-
-	t = *(base + gpio_moder) & ~(0x3UL << (pin << 1));
-	*(base + gpio_moder) = t | ((u32)mode & 0x3U) << (pin << 1);
-
-	t = *(base + gpio_otyper) & ~(1UL << pin);
-	*(base + gpio_otyper) = t | ((u32)otype & 1U) << pin;
-
-	t = *(base + gpio_ospeedr) & ~(0x3UL << (pin << 1));
-	*(base + gpio_ospeedr) = t | ((u32)ospeed & 0x3U) << (pin << 1);
-
-	t = *(base + gpio_pupdr) & ~(0x03UL << (pin << 1));
-	*(base + gpio_pupdr) = t | ((u32)pupd & 0x3U) << (pin << 1);
-
-	if (pin < 8U) {
-		t = *(base + gpio_afrl) & ~(0xfUL << (pin << 2));
-		*(base + gpio_afrl) = t | ((u32)af & 0xfU) << (pin << 2);
-	}
-	else {
-		t = *(base + gpio_afrh) & ~(0xfUL << ((pin - 8U) << 2));
-		*(base + gpio_afrh) = t | ((u32)af & 0xfU) << ((pin - 8U) << 2);
-	}
-
-	return EOK;
-}
-
-
-int _stm32_gpioSet(int d, u8 pin, u8 val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if ((base == NULL) || (pin > 15U)) {
-		return -EINVAL;
-	}
-
-	*(base + gpio_bsrr) = 1UL << ((val == 0U) ? ((u32)pin + 16U) : (u32)pin);
-	return EOK;
-}
-
-
-int _stm32_gpioSetPort(int d, u16 val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if (base == NULL) {
-		return -EINVAL;
-	}
-
-	*(base + gpio_odr) = (u32)val;
-
-	return EOK;
-}
-
-
-int _stm32_gpioGet(int d, u8 pin, u8 *val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if ((base == NULL) || (pin > 15U)) {
-		return -EINVAL;
-	}
-
-	*val = (u8)(*(base + gpio_idr) >> pin) & 1U;
-
-	return EOK;
-}
-
-
-int _stm32_gpioGetPort(int d, u32 *val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if (base == NULL) {
-		return -EINVAL;
-	}
-
-	*val = *(base + gpio_idr);
-
-	return EOK;
-}
-
-
-int _stm32_gpioSetPrivilege(int d, u32 val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if (base == NULL) {
-		return -EINVAL;
-	}
-
-	*(base + gpio_privcfgr) = val;
-
-	return EOK;
-}
-
-
-int _stm32_gpioGetPrivilege(int d, u32 *val)
-{
-	volatile u32 *base;
-
-	base = _stm32_gpioGetBase(d);
-	if (base == NULL) {
-		return -EINVAL;
-	}
-
-	*val = *(base + gpio_privcfgr);
-
-	return EOK;
-}
-
-
 /* Watchdog */
 
 
@@ -1017,41 +779,18 @@ void _stm32_wdgReload(void)
 
 void _stm32_init(void)
 {
-	u32 i;
-	static const int gpioDevs[] = {
-		pctl_gpioa, pctl_gpiob, pctl_gpioc, pctl_gpiod,
-		pctl_gpioe, pctl_gpiof, pctl_gpiog, pctl_gpioh,
-		pctl_gpion, pctl_gpioo, pctl_gpiop, pctl_gpioq
-	};
-
 	/* Base addresses init */
 	stm32_common.iwdg = IWDG_BASE;
 	stm32_common.pwr = PWR_BASE;
 	stm32_common.rcc = RCC_BASE;
 	stm32_common.rtc = RTC_BASE;
-	stm32_common.exti = EXTI_BASE;
 	stm32_common.syscfg = SYSCFG_BASE;
 	stm32_common.rifsc = RIFSC_BASE;
 	stm32_common.cacheaxiconf = CACHEAXI_BASE;
-	stm32_common.gpio[0] = GPIOA_BASE;
-	stm32_common.gpio[1] = GPIOB_BASE;
-	stm32_common.gpio[2] = GPIOC_BASE;
-	stm32_common.gpio[3] = GPIOD_BASE;
-	stm32_common.gpio[4] = GPIOE_BASE;
-	stm32_common.gpio[5] = GPIOF_BASE;
-	stm32_common.gpio[6] = GPIOG_BASE;
-	stm32_common.gpio[7] = GPIOH_BASE;
-	stm32_common.gpio[8] = NULL;
-	stm32_common.gpio[9] = NULL;
-	stm32_common.gpio[10] = NULL;
-	stm32_common.gpio[11] = NULL;
-	stm32_common.gpio[12] = NULL;
-	stm32_common.gpio[13] = GPION_BASE;
-	stm32_common.gpio[14] = GPIOO_BASE;
-	stm32_common.gpio[15] = GPIOP_BASE;
-	stm32_common.gpio[16] = GPIOQ_BASE;
 
 	_hal_scsInit();
+
+	_stm32_gpioInit();
 
 	/* Enable System configuration controller */
 	(void)_stm32_rccSetDevClock(pctl_syscfg, 1U, 1U);
@@ -1074,11 +813,6 @@ void _stm32_init(void)
 	*(stm32_common.rcc + rcc_cier) = 0;
 
 	hal_cpuDataMemoryBarrier();
-
-	/* GPIO init */
-	for (i = 0; i < sizeof(gpioDevs) / sizeof(gpioDevs[0]); ++i) {
-		(void)_stm32_rccSetDevClock(gpioDevs[i], 1U, 1U);
-	}
 
 #if NPU
 	/* Enable NPU clock */

--- a/hal/armv8m/stm32/stm32.h
+++ b/hal/armv8m/stm32/stm32.h
@@ -192,4 +192,9 @@ int _stm32_systickInit(u32 interval);
 void _stm32_init(void);
 
 
+#if defined(__CPU_STM32U3)
+void _stm32_pwrEnterLPStop(time_t us);
+#endif
+
+
 #endif

--- a/hal/armv8m/stm32/stm32.h
+++ b/hal/armv8m/stm32/stm32.h
@@ -23,6 +23,12 @@
 #include "include/arch/armv8m/stm32/u3/stm32u3.h"
 #endif
 
+#if defined(__CPU_STM32N6)
+#define STM32_GPIO_PRIVILEGE 1 /* Set to 1 to compile support for setting GPIO privileges */
+#else
+#define STM32_GPIO_PRIVILEGE 0
+#endif
+
 
 enum gpio_modes {
 	gpio_mode_gpi = 0,
@@ -84,10 +90,12 @@ void _stm32_rccClearResetFlags(void);
 int _stm32_dbgmcuStopTimerInDebug(int dev, u32 stop);
 
 
+void _stm32_gpioInit(void);
+
+
 int _stm32_gpioConfig(int d, u8 pin, u8 mode, u8 af, u8 otype, u8 ospeed, u8 pupd);
 
 
-#if defined(__CPU_STM32N6)
 int _stm32_gpioSet(int d, u8 pin, u8 val);
 
 
@@ -100,16 +108,20 @@ int _stm32_gpioGet(int d, u8 pin, u8 *val);
 int _stm32_gpioGetPort(int d, u32 *val);
 
 
+#if STM32_GPIO_PRIVILEGE
 int _stm32_gpioSetPrivilege(int d, u32 val);
 
 
 int _stm32_gpioGetPrivilege(int d, u32 *val);
+#endif
 
 
+#if defined(__CPU_STM32N6)
 void _stm32_rtcUnlockRegs(void);
 
 
 void _stm32_rtcLockRegs(void);
+#endif
 
 
 int _stm32_extiMaskInterrupt(u32 line, u8 state);
@@ -125,7 +137,9 @@ int _stm32_extiSetTrigger(u32 line, u8 state, u8 edge);
 
 
 int _stm32_extiSoftInterrupt(u32 line);
-#endif
+
+
+int _stm32_extiSetGpioMux(int gpioDev, u8 pin);
 
 
 void _stm32_wdgReload(void);

--- a/hal/armv8m/stm32/u3/config.h
+++ b/hal/armv8m/stm32/u3/config.h
@@ -33,10 +33,10 @@
 #include "hal/armv8m/stm32/stm32-timer.h"
 
 /* Constants for configuring which LPTIM peripheral is used as system timer */
-#define LPTIM_SYSTEM_BASE      ((void *)0x50009400UL) /* LPTIM2 base address */
-#define LPTIM_SYSTEM_IRQ       lptim2_irq
-#define LPTIM_SYSTEM_PCTL      pctl_lptim2
-#define LPTIM_SYSTEM_IPCLK_SEL pctl_ipclk_lptim2sel
+#define LPTIM_SYSTEM_BASE      ((void *)0x50044c00UL) /* LPTIM4 base address */
+#define LPTIM_SYSTEM_IRQ       lptim4_irq
+#define LPTIM_SYSTEM_PCTL      pctl_lptim4
+#define LPTIM_SYSTEM_IPCLK_SEL pctl_ipclk_lptim34sel
 #define LPTIM_SYSTEM_IPCLK_VAL 1       /* LSI */
 #define LPTIM_SYSTEM_INPUT     32000UL /* LSI input frequency in Hz */
 #define LPTIM_SYSTEM_CYCLE_MS  16000UL /* 16 s */

--- a/hal/armv8m/stm32/u3/config.h
+++ b/hal/armv8m/stm32/u3/config.h
@@ -43,6 +43,8 @@
 
 #define HAL_NAME_PLATFORM "STM32U3 "
 
+#define STM32_ENABLE_LOW_POWER 1
+
 #endif
 
 #endif

--- a/hal/armv8m/stm32/u3/stm32u3.c
+++ b/hal/armv8m/stm32/u3/stm32u3.c
@@ -47,6 +47,7 @@ static struct {
 	volatile u32 *rtc;
 	volatile u32 *syscfg;
 	volatile u32 *iwdg;
+	volatile u32 *dbgmcu;
 
 	u32 cpuclk;
 
@@ -331,6 +332,7 @@ int _stm32_rccSetDevClock(int dev, u32 status, u32 lpStatus)
 	return EOK;
 }
 
+
 int _stm32_rccGetDevClock(int dev, u32 *status, u32 *lpStatus)
 {
 	u32 shift;
@@ -377,7 +379,6 @@ void _stm32_rccClearResetFlags(void)
 int _stm32_dbgmcuStopTimerInDebug(int dev, u32 stop)
 {
 	u32 reg;
-	volatile u32 *base = DBGMCU_BASE;
 	if ((pctl_tim2 <= dev) && (dev <= pctl_rtcapb)) {
 		reg = (u32)dbgmcu_apb1lfzr;
 	}
@@ -395,10 +396,10 @@ int _stm32_dbgmcuStopTimerInDebug(int dev, u32 stop)
 	}
 
 	if (stop != 0U) {
-		*(base + reg) |= 1UL << ((u32)dev % 32U);
+		*(stm32_common.dbgmcu + reg) |= 1UL << ((u32)dev % 32U);
 	}
 	else {
-		*(base + reg) &= ~(1UL << ((u32)dev % 32U));
+		*(stm32_common.dbgmcu + reg) &= ~(1UL << ((u32)dev % 32U));
 	}
 
 	hal_cpuDataSyncBarrier();
@@ -527,6 +528,23 @@ void _stm32_wdgReload(void)
 }
 
 
+void _stm32_pwrEnterLPStop(time_t us)
+{
+	unsigned int t;
+
+	/* Select Stop 2 as deep sleep mode */
+	t = *(stm32_common.pwr + pwr_cr1) & ~(0x7U);
+	*(stm32_common.pwr + pwr_cr1) = t | 2U;
+	hal_cpuDataMemoryBarrier();
+
+	timer_setAlarm(us);
+
+	_hal_scsDeepSleepSet(1); /* Switch to deep sleep mode */
+	hal_cpuHalt();           /* WFI enters Stop mode */
+	_hal_scsDeepSleepSet(0); /* Switch to shallow sleep mode */
+}
+
+
 void _stm32_init(void)
 {
 	/* Base addresses init */
@@ -535,6 +553,7 @@ void _stm32_init(void)
 	stm32_common.rcc = RCC_BASE;
 	stm32_common.rtc = RTC_BASE;
 	stm32_common.syscfg = SYSCFG_BASE;
+	stm32_common.dbgmcu = DBGMCU_BASE;
 
 	_hal_scsInit();
 
@@ -557,4 +576,7 @@ void _stm32_init(void)
 
 	_stm32_rtcInit();
 	_stm32_wdgInit();
+#ifdef NDEBUG
+	*(stm32_common.dbgmcu + dbgmcu_cr) &= ~(1UL << 1); /* Turn off DBG_STOP to ensure clocks will be turned off in Stop mode */
+#endif
 }

--- a/hal/armv8m/stm32/u3/stm32u3.c
+++ b/hal/armv8m/stm32/u3/stm32u3.c
@@ -30,15 +30,6 @@
 #endif
 
 
-#define GPIOA_BASE ((void *)0x52020000U)
-#define GPIOB_BASE ((void *)0x52020400U)
-#define GPIOC_BASE ((void *)0x52020800U)
-#define GPIOD_BASE ((void *)0x52020c00U)
-#define GPIOE_BASE ((void *)0x52021000U)
-#define GPIOF_BASE ((void *)0x52021400U)
-#define GPIOG_BASE ((void *)0x52021800U)
-#define GPIOH_BASE ((void *)0x52021c00U)
-
 #define IWDG_BASE   ((void *)0x50003000U)
 #define PWR_BASE    ((void *)0x50030800U)
 #define RCC_BASE    ((void *)0x50030c00U)
@@ -52,7 +43,6 @@
 
 static struct {
 	volatile u32 *rcc;
-	volatile u32 *gpio[8];
 	volatile u32 *pwr;
 	volatile u32 *rtc;
 	volatile u32 *syscfg;
@@ -432,54 +422,6 @@ int _stm32_systickInit(u32 interval)
 }
 
 
-/* GPIO */
-
-
-static volatile u32 *_stm32_gpioGetBase(int d, u8 pin)
-{
-	if ((d < pctl_gpioa) || (d > pctl_gpioh) || (pin > 15U)) {
-		return NULL;
-	}
-
-	return stm32_common.gpio[d - pctl_gpioa];
-}
-
-
-int _stm32_gpioConfig(int d, u8 pin, u8 mode, u8 af, u8 otype, u8 ospeed, u8 pupd)
-{
-	volatile u32 *base;
-	u32 t;
-
-	base = _stm32_gpioGetBase(d, pin);
-	if (base == NULL) {
-		return -EINVAL;
-	}
-
-	t = *(base + gpio_moder) & ~(0x3UL << (pin << 1));
-	*(base + gpio_moder) = t | ((u32)mode & 0x3U) << (pin << 1);
-
-	t = *(base + gpio_otyper) & ~(1UL << pin);
-	*(base + gpio_otyper) = t | ((u32)otype & 1U) << pin;
-
-	t = *(base + gpio_ospeedr) & ~(0x3UL << (pin << 1));
-	*(base + gpio_ospeedr) = t | ((u32)ospeed & 0x3U) << (pin << 1);
-
-	t = *(base + gpio_pupdr) & ~(0x03UL << (pin << 1));
-	*(base + gpio_pupdr) = t | ((u32)pupd & 0x3U) << (pin << 1);
-
-	if (pin < 8U) {
-		t = *(base + gpio_afrl) & ~(0xfUL << (pin << 2));
-		*(base + gpio_afrl) = t | ((u32)af & 0xfU) << (pin << 2);
-	}
-	else {
-		t = *(base + gpio_afrh) & ~(0xfUL << ((pin - 8U) << 2));
-		*(base + gpio_afrh) = t | ((u32)af & 0xfU) << ((pin - 8U) << 2);
-	}
-
-	return EOK;
-}
-
-
 /* Real time clock */
 
 
@@ -587,24 +529,16 @@ void _stm32_wdgReload(void)
 
 void _stm32_init(void)
 {
-	u32 i;
-
 	/* Base addresses init */
 	stm32_common.iwdg = IWDG_BASE;
 	stm32_common.pwr = PWR_BASE;
 	stm32_common.rcc = RCC_BASE;
 	stm32_common.rtc = RTC_BASE;
 	stm32_common.syscfg = SYSCFG_BASE;
-	stm32_common.gpio[0] = GPIOA_BASE;
-	stm32_common.gpio[1] = GPIOB_BASE;
-	stm32_common.gpio[2] = GPIOC_BASE;
-	stm32_common.gpio[3] = GPIOD_BASE;
-	stm32_common.gpio[4] = GPIOE_BASE;
-	stm32_common.gpio[5] = GPIOF_BASE;
-	stm32_common.gpio[6] = GPIOG_BASE;
-	stm32_common.gpio[7] = GPIOH_BASE;
 
 	_hal_scsInit();
+
+	_stm32_gpioInit();
 
 	/* Enable System configuration controller */
 	(void)_stm32_rccSetDevClock(pctl_syscfg, 1U, 1U);
@@ -620,11 +554,6 @@ void _stm32_init(void)
 	*(stm32_common.rcc + rcc_cier) = 0;
 
 	hal_cpuDataMemoryBarrier();
-
-	/* GPIO init */
-	for (i = pctl_gpioa; i <= pctl_gpioh; i++) {
-		(void)_stm32_rccSetDevClock(i, 1U, 1U);
-	}
 
 	_stm32_rtcInit();
 	_stm32_wdgInit();

--- a/hal/armv8m/stm32/u3/stm32u3_regs.h
+++ b/hal/armv8m/stm32/u3/stm32u3_regs.h
@@ -235,4 +235,22 @@ enum {
 	dbgmcu_cidr3,
 };
 
+enum exti_regs {
+	exti_rtsr1 = 0x0,
+	exti_ftsr1,
+	exti_swier1,
+	exti_rpr1,
+	exti_fpr1,
+	exti_seccfgr1,
+	exti_privcfgr1,
+	exti_exticr1 = 0x18,
+	exti_exticr2,
+	exti_exticr3,
+	exti_exticr4,
+	exti_lockr,
+	exti_imr1 = 0x20,
+	exti_emr1,
+};
+
+
 #endif /* _PH_STM32U3_REGS_H_ */

--- a/hal/armv8m/stm32/u3/timer.c
+++ b/hal/armv8m/stm32/u3/timer.c
@@ -22,6 +22,7 @@
 
 #define PRESC_SHIFT 3UL
 #define RELOAD_VAL  (((LPTIM_SYSTEM_INPUT >> PRESC_SHIFT) * LPTIM_SYSTEM_CYCLE_MS / 1000UL) - 1UL)
+#define TICKS_PER_CYCLE ((time_t)(RELOAD_VAL + 1UL))
 
 #if RELOAD_VAL > 0xffffUL
 #error Impossible cycle duration!
@@ -39,9 +40,19 @@ enum lptim_regs {
 	lptim_cnt,
 	lptim_cfgr2 = 0x9,
 	lptim_rcr,
-	lptim_ccmr1,
-	lptim_ccr2 = 0xd,
 };
+
+/* Interrupt status/enable/clear bits */
+#define LPTIM_CC1IF   (1UL << 0)
+#define LPTIM_ARRM    (1UL << 1)
+#define LPTIM_EXTTRIG (1UL << 2)
+#define LPTIM_CMP1OK  (1UL << 3)
+#define LPTIM_ARROK   (1UL << 4)
+#define LPTIM_UP      (1UL << 5)
+#define LPTIM_DOWN    (1UL << 6)
+#define LPTIM_UE      (1UL << 7)
+#define LPTIM_REPOK   (1UL << 8)
+#define LPTIM_IEROK   (1UL << 24) /* Note: this bit is not valid for lptim_ier register */
 
 
 static struct {
@@ -79,23 +90,19 @@ static int timer_irqHandler(unsigned int n, cpu_context_t *ctx, void *arg)
 	(void)n;
 	(void)ctx;
 	(void)arg;
-	u32 isr = *(timer_common.lptim + lptim_isr), clr = 0;
+	u32 isr, clr;
 
-	/* Clear CMPOK. Has to be done before active IRQs (errata) */
-	if ((isr & (1U << 3)) != 0U) {
-		*(timer_common.lptim + lptim_icr) = (1U << 3);
-		hal_cpuDataMemoryBarrier();
+	isr = *(timer_common.lptim + lptim_isr);
+	clr = 0;
+
+	/* Timer overflow */
+	if ((isr & LPTIM_ARRM) != 0U) {
+		timer_common.upper += TICKS_PER_CYCLE;
+		clr |= LPTIM_ARRM;
 	}
 
-	/* Clear ARRM */
-	if ((isr & (1U << 1)) != 0U) {
-		++timer_common.upper;
-		clr |= (1U << 1);
-	}
-
-	/* Clear CMPM */
-	if ((isr & (1U << 0)) != 0U) {
-		clr |= (1U << 0);
+	if ((isr & LPTIM_CC1IF) != 0U) {
+		clr |= LPTIM_CC1IF;
 	}
 
 	*(timer_common.lptim + lptim_icr) = clr;
@@ -123,16 +130,16 @@ static time_t hal_timerGetCyc(void)
 	lower = timer_getCnt();
 
 	/* Check if we have unhandled overflow event */
-	if ((*(timer_common.lptim + lptim_isr) & (1U << 1)) != 0U) {
+	if ((*(timer_common.lptim + lptim_isr) & LPTIM_ARRM) != 0U) {
 		lower = timer_getCnt();
 		if (lower != RELOAD_VAL) {
-			++upper;
+			upper += TICKS_PER_CYCLE;
 		}
 	}
 
 	hal_spinlockClear(&timer_common.sp, &sc);
 
-	return (upper * (time_t)(RELOAD_VAL + 1U)) + (time_t)lower;
+	return upper + (time_t)lower;
 }
 
 /* Additional functions */
@@ -178,7 +185,7 @@ int hal_timerRegister(intrFn_t f, void *data, intr_handler_t *h)
 char *hal_timerFeatures(char *features, size_t len)
 {
 	char cycle[40];
-	long cycle_len = hal_i2s(", cycle [us] ", cycle, (unsigned long)hal_timerCyc2us((time_t)RELOAD_VAL + 1), 10U, 0);
+	long cycle_len = hal_i2s(", cycle [us] ", cycle, (unsigned long)hal_timerCyc2us(TICKS_PER_CYCLE), 10U, 0);
 
 	(void)hal_strncpy(features, "Using Low-Power Timer", len);
 	if (len > (21 + cycle_len)) {
@@ -205,16 +212,17 @@ void _hal_timerInit(u32 interval)
 	*(timer_common.lptim + lptim_cr) = 0;
 	hal_cpuDataMemoryBarrier();
 	*(timer_common.lptim + lptim_cfgr) = (PRESC_SHIFT << 9);
-	/* Enable CMPM and ARRM IRQs */
-	*(timer_common.lptim + lptim_ier) = (1U << 1) | (1U << 0);
+	*(timer_common.lptim + lptim_ier) = LPTIM_CC1IF | LPTIM_ARRM;
 	hal_cpuDataMemoryBarrier();
 	/* Timer enable */
 	*(timer_common.lptim + lptim_cr) = 1;
 	hal_cpuDataMemoryBarrier();
 	*(timer_common.lptim + lptim_arr) = RELOAD_VAL;
-	/* Wait for ARROK. Don't need to clear this ISR, we do it once */
-	while ((*(timer_common.lptim + lptim_isr) & (1U << 4)) == 0U) {
+	while ((*(timer_common.lptim + lptim_isr) & LPTIM_ARROK) == 0U) {
+		/* Wait for ARROK status bit */
 	}
+
+	*(timer_common.lptim + lptim_icr) = LPTIM_ARROK; /* Not strictly necessary because we don't update ARR again */
 	hal_cpuDataMemoryBarrier();
 
 	timer_common.overflowh.f = timer_irqHandler;
@@ -223,9 +231,54 @@ void _hal_timerInit(u32 interval)
 	timer_common.overflowh.data = NULL;
 	(void)hal_interruptsSetHandler(&timer_common.overflowh);
 
-	/* Trigger timer start */
-	*(timer_common.lptim + lptim_cr) |= 4U;
+	/* Start timer in continuous mode */
+	*(timer_common.lptim + lptim_cr) |= (1UL << 2);
 	hal_cpuDataMemoryBarrier();
 
 	(void)_stm32_systickInit(interval);
+}
+
+
+static time_t hal_timerUs2Cyc(time_t us)
+{
+	return (((time_t)LPTIM_SYSTEM_INPUT / (1LL << PRESC_SHIFT)) * us + (500 * 1000)) / (1000 * 1000);
+}
+
+
+void timer_setAlarm(time_t us)
+{
+	u32 setval, timerval, oldval;
+	spinlock_ctx_t sc;
+	time_t ticks = hal_timerUs2Cyc(us);
+
+	hal_spinlockSet(&timer_common.sp, &sc);
+
+	timerval = timer_getCnt();
+
+	oldval = *(timer_common.lptim + lptim_ccr1);
+	setval = timerval + (u32)ticks; /* We will check ticks value for potential overflow later */
+	/*
+	 * Value of CCR1 must be < ARR. If we are asked to sleep longer than that we will be woken up by ARRM anyway.
+	 * In those cases we set the CCR1 register to either (CNT - 1) or 0 to save ourselves one needless wakeup.
+	 */
+	if ((ticks >= (time_t)RELOAD_VAL) || (setval >= RELOAD_VAL)) {
+		setval = (timerval > 1U) ? (timerval - 1U) : 0U;
+	}
+
+	/*
+	 * Only change CCR1 if the value is actually different - this is an optimization,
+	 * but also trying to write CCR1 to the same value may never trigger CMP1OK.
+	 */
+	if (setval != oldval) {
+		*(timer_common.lptim + lptim_ccr1) = setval;
+		hal_cpuDataSyncBarrier();
+
+		while ((*(timer_common.lptim + lptim_isr) & LPTIM_CMP1OK) == 0U) {
+			/* Wait for CMP1OK */
+		}
+
+		*(timer_common.lptim + lptim_icr) = LPTIM_CMP1OK;
+	}
+
+	hal_spinlockClear(&timer_common.sp, &sc);
 }


### PR DESCRIPTION
Implement entering Stop 2 low-power mode and timer wakeup.

## Description
During testing I needed to use GPIO and EXTI functionality in kernel, so I decided to extract the implementation from STM32N6 so that it could be easily adapted to other STM32 targets. Now these functions are available to use if the are needed in the future.

For our use case Stop 2 mode was determined to be the optimal trade-off between functionality and power consumption. In this mode the microcontroller can be woken up by LPTIM, LPUART, I2C3 and EXTI peripherals (the latter encompassing GPIO interrupts, on-chip comparator interrupts and tamper detection).

System timer was switched from LPTIM2 to LPTIM4, as LPTIM2 on U3 cannot wake the system up from Stop 2 mode. Out of the remaining timers, LPTIM4 is optimal for use with the kernel - it has limited functionality (lacks PWM output mode), but its limitations are irrelevant for kernel use. This frees up other, more capable timers for user applications.

Some small optimizations were made to timer code. `timer_common.upper` now counts timer ticks instead of timer overflow events. This avoids the necessity to perform 64-bit multiplication in `hal_timerGetCyc` (which gets called frequently). Also, small refactors were made to the code to make it more readable (replacing literal values for interrupt bits with macros).

`timer_setAlarm` was implemented based on the STM32L4 implementation. The implementation was cleaned up, removing old workarounds for errors that don't seem to happen anymore (and don't appear in errata sheet ES0659 rev 1) and making the code easier to read.

Finally, a function to enter low-power mode was implemented. The function will eventually need to be expanded if we implement CPU frequency switching and high-performance voltage ranges, but it is sufficient for now.

Entering and exiting low-power mode was tested to work. It was confirmed that LPTIM and GPIO interrupts can wake the system up from sleep mode. LPUART and I2C3 wake-ups were not tested yet. Other peripherals like UART1 have been confirmed to be disabled in low-power mode (as they should be).

## Motivation and Context
YT: RTOS-1415

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m33-stm32u3-nucleo_u3c5

A board running this patch, together with a modified version of `psh` (removed calls to `keepidle()` to allow board to enter low-power mode) was left running `top` for over 16 days. After the test period the program was still running, printing new data and responding to input.

<img width="800" height="565" alt="Screenshot from 2026-09-07 10-41-42" src="https://github.com/user-attachments/assets/0022b721-3ad6-423b-a688-7c651f591ab6" />

For this reason I believe that the timeouts checking for `LPTIM_CMP1OK` bit are no longer necessary - if they were, the code would likely have entered an infinite loop and become unresponsive during the test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
