### PR TITLE
    armv7m/pmap: Clarify PRIVDEFENA bit comment in MPU_CTRL

### DIFF
--- a/hal/armv7m/pmap.c
+++ b/hal/armv7m/pmap.c
@@ -199,7 +199,7 @@ void _pmap_init(pmap_t *pmap, void **vstart, void **vend)
 	*(pmap_common.mpu + mpu_ctrl) &= ~1U;
 	hal_cpuDataMemoryBarrier();
 
-	/* Allow unlimited kernel access */
+	/* Allow kernel access to memory areas outside of defined maps */
 	*(pmap_common.mpu + mpu_ctrl) |= (1U << 2);
 	hal_cpuDataMemoryBarrier();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Change in misleading comment, and fix syspage stuct mpu size.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1st commit  – improve comment when enabling PRIVDEFENA bit in MPU_CTRL (I was literally mislead by it!)
NOTE: I see that armv8m differs by the comment, but I don't like the comment in there – I feel it's too descriptive and not fitting in the code standard. If kernel maintainer wish to align comments there (or change mine to the same as there), I am open to do it :)
~~2nd commit – stm32l4 has 8 regions of MPU. PLO cmd mpu was unable to work due to that syspage struct have more space than processor have regions.
https://github.com/phoenix-rtos/plo/blob/611f2b00b57e5826155267ab07ad05746a4082f7/cmds/mpu.c#L112
It's discussable if this check is valid, but in fact syspage struct can be changed anyways.
I have a strong opinion, that syspage should be serialized/deserialized instead of having fixed-sized arrays. But this is not a scope of task. I just want to have working mpu command.~~

~~I know, that other STMs can potentially have more regions but I think then syspage definition should be done per cpu, not per cpu family.~~

EDIT: decided to drop 2nd commit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

ABI break but nothing have to be done in projects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo(like)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
