### PR TITLE
Add STM32U3 ADC support

### DIFF
--- a/hal/armv8m/stm32/u3/stm32u3.c
+++ b/hal/armv8m/stm32/u3/stm32u3.c
@@ -256,6 +256,7 @@ static const struct {
 	[pctl_ipclk_spi4sel] = { (u16)rcc_ccipr2, 0x1U, 7U },
 	[pctl_ipclk_i2c4sel] = { (u16)rcc_ccipr2, 0x1U, 9U },
 	[pctl_ipclk_rngsel] = { (u16)rcc_ccipr2, 0x1U, 11U },
+	[pctl_ipclk_adcdacpre] = { (u16)rcc_ccipr2, 0xfU, 12U },
 	[pctl_ipclk_adcdacsel] = { (u16)rcc_ccipr2, 0x3U, 16U },
 	[pctl_ipclk_dac1shsel] = { (u16)rcc_ccipr2, 0x1U, 19U },
 	[pctl_ipclk_octospisel] = { (u16)rcc_ccipr2, 0x1U, 20U },

--- a/include/arch/armv8m/stm32/u3/stm32u3.h
+++ b/include/arch/armv8m/stm32/u3/stm32u3.h
@@ -122,6 +122,7 @@ enum ipclks {
 	pctl_ipclk_spi4sel,
 	pctl_ipclk_i2c4sel,
 	pctl_ipclk_rngsel,
+	pctl_ipclk_adcdacpre,
 	pctl_ipclk_adcdacsel,
 	pctl_ipclk_dac1shsel,
 	pctl_ipclk_octospisel,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add facilities required for enablement of the analog-digital converter of the STM32U3 (ARMv8-M) family of microcontrollers:
- ~~OTP area reading, byte-addressed due to unaligned location of VREFINT_CAL~~ removed as unnecessary on U3
- ADC/DAC prescaler control with pctl_ipclk API

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Access to ~~VREFINT_CAL and~~ RCC_CCIPR2_ADCDACPRE is required for ADC enablement in stm32l4-multi for STM32U3.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).
  - STMicroelectronics Nucleo-U385RG-Q kit

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

Tagging @jmaksymowicz 